### PR TITLE
Fix url in self host cli docs

### DIFF
--- a/src/content/docs/docs/self-hosted/local-dev/cli.mdx
+++ b/src/content/docs/docs/self-hosted/local-dev/cli.mdx
@@ -29,4 +29,4 @@ const config: CapacitorConfig = {
 };
 ```
 
-Note: To get `localSupaAnon` please follow [this tutorial](http://localhost:3000/docs/self-hosted/local-dev/getting-started/) and copy the `anon key` into `localSupaAnon`
+Note: To get `localSupaAnon` please follow [this tutorial](/docs/self-hosted/local-dev/getting-started/) and copy the `anon key` into `localSupaAnon`


### PR DESCRIPTION
I have accidentally left localhost in one of the URL when working on [this PR](https://github.com/Cap-go/website/pull/111)

Thanks @ayewo for pointing this out