### PR TITLE
fix: Blog articles with published false should not visible with URL 

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -4,11 +4,11 @@ import { useRuntimeConfig } from '../../config/app'
 import VueBlogSlug from '../../vue-pages/blog/[slug].vue'
 
 export async function getStaticPaths() {
-  const posts = await Astro.glob('../../content/blog/**/*.md')
+const allBlogPosts = await Astro.glob('../../content/blog/**/*.md');
+const posts = allBlogPosts.filter((j) => j.frontmatter.published);
   return posts.map((post) => {
     let related = posts
       .filter((i) => i.frontmatter.slug !== post.frontmatter.slug)
-      .filter((i) => i.frontmatter.published)
       .sort((a, b) => (new Date(a.frontmatter.created_at) > new Date(b.frontmatter.created_at) ? -1 : 1))
       .slice(0, 3)
     if (post.frontmatter.next_blog) {


### PR DESCRIPTION
fixes #160

![Screenshot 2023-12-22 002859](https://github.com/Cap-go/website/assets/81948346/b611278d-c400-4385-be73-7548d038a0b2)

![Screenshot 2023-12-22 002831](https://github.com/Cap-go/website/assets/81948346/a94accc8-585f-406b-964d-891e8a2748b8)
