### PR TITLE
Fixed syntax error when users copy and paste for `capacitor.config.ts`

### DIFF
--- a/src/content/docs/docs/plugin/api.md
+++ b/src/content/docs/docs/plugin/api.md
@@ -78,8 +78,8 @@ import { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   plugins: {
     CapacitorUpdater: {
-      appReadyTimeout: 1000 // (1 second),
-      responseTimeout: 10 // (10 second),
+      appReadyTimeout: 1000, // (1 second)
+      responseTimeout: 10, // (10 second)
       autoDeleteFailed: false,
       autoDeletePrevious: false,
       autoUpdate: false,

--- a/src/content/docs/docs/self-hosted/Auto Update/update-endpoint.md
+++ b/src/content/docs/docs/self-hosted/Auto Update/update-endpoint.md
@@ -53,7 +53,7 @@ export const handler: Handler = async (event) => {
   }
   else {
     return {
-      message: 'Error version not found'
+      message: 'Error version not found',
       version: '',
       url: '',
     }


### PR DESCRIPTION
Update api.md | Fixed syntax error when users copy and paste for `capacitor.config.ts` example as well, related with #183 