### PR TITLE
fix(docs): broken link for Manual Mode in getting-started.mdx

### DIFF
--- a/src/content/docs/docs/getting-started.mdx
+++ b/src/content/docs/docs/getting-started.mdx
@@ -73,7 +73,7 @@ Please note that using **Self Hosted Manual Mode** mode can lead to complex issu
 
 <LinkCard
 	title="Manual Mode"
-	href="/docs/plugin/self-hosted/manual-mode/"
+	href="/docs/plugin/self-hosted/manual-update/"
 />
 
 ## Store Guideline Compliance


### PR DESCRIPTION
The "Manual Mode" link on the "Getting Started" page pointed to a possibly older link that no longer exists.