### PR TITLE
docs: auto-update.md

### DIFF
--- a/src/content/docs/docs/plugin/cloud-mode/auto-update.md
+++ b/src/content/docs/docs/plugin/cloud-mode/auto-update.md
@@ -44,7 +44,9 @@ The server allows you to manage channels and versions and much more.
 
 `autoUpdate` will use data from `capacitor.config` to identify the Capgo server
 
-> ℹ️ You can still use Capgo Cloud without sending your code to our server. If that is not allowed by your company.
+:::note
+You can still use Capgo Cloud without sending your code to our server. If that is not allowed by your company.
+:::
 
 #### Validate version
 


### PR DESCRIPTION
I think "You can still use Capgo Cloud without... " should be a Note.

cf screenshot: 
<img width="613" alt="Screenshot 2024-07-23 at 11 48 51" src="https://github.com/user-attachments/assets/c7a67419-0adf-4fbd-8ca6-6173444c6ce8">
