### PR TITLE
typo fix macOS

### DIFF
--- a/src/content/docs/docs/plugins/social-login/apple/general.mdx
+++ b/src/content/docs/docs/plugins/social-login/apple/general.mdx
@@ -10,6 +10,6 @@ sidebar:
 In this guide, you are going to learn how to configure Apple Login with Capacitor. In order to do this, you will need the following:
 
 - an Apple Developer Account
-- A computer running maacOS (IOS only)
+- A computer running macOS (IOS only)
 - Xcode installed (IOS only)
 - A custom backend (Android only)


### PR DESCRIPTION
"macOS"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typographical error in the Apple Login setup guide, changing "maacOS" to "macOS" in the requirements list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->