### PR TITLE
Filter blog articles by category and language

### DIFF
--- a/src/pages/blog/category/[slug].astro
+++ b/src/pages/blog/category/[slug].astro
@@ -18,6 +18,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
 }
 
 const allPosts = Astro.props.posts as CollectionEntry<'blog'>[]
+// Filter posts by current locale
+const localePosts = allPosts.filter(post => post.data.locale === Astro.locals.locale)
 ---
 
-<BlogListing {allPosts} />
+<BlogListing allPosts={localePosts} />


### PR DESCRIPTION
Filter blog posts by current locale on category pages to display only articles in the active language.

Previously, category pages displayed articles from all locales when filtered by category. This change aligns category filtering with the main blog index, ensuring only posts matching `Astro.locals.locale` are shown, providing a consistent i18n experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-86df34f1-5963-411d-8c78-560d2804b571">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86df34f1-5963-411d-8c78-560d2804b571">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>