### PR TITLE
Revise migration checklist for Capacitor v8

### DIFF
--- a/src/content/docs/docs/upgrade/from-v7-to-v8.md
+++ b/src/content/docs/docs/upgrade/from-v7-to-v8.md
@@ -53,12 +53,9 @@ The configuration remains the same as v7. Your existing `capacitor.config` setti
 
 ## Migration Checklist
 
-- [ ] Update @capacitor/core to ^8.0.0
-- [ ] Update @capacitor/android to ^8.0.0
-- [ ] Update @capacitor/ios to ^8.0.0
-- [ ] Follow Capacitor's v8 migration guide
-- [ ] Update @capgo/capacitor-updater to ^8.0.0
-- [ ] Run `npx cap sync`
+- [ ] Follow Capacitor's v8 [migration guide](https://capacitorjs.com/docs/updating/8-0), check for breaking changes.
+- [ ] [Update](#install) @capgo/capacitor-updater to ^8.0.0
+- [ ] [Run](#install) `npx cap sync`
 - [ ] Test your app thoroughly on both iOS and Android
 
 ## Need Help?


### PR DESCRIPTION
Added a few more links to help guide people as I just upgraded. I also removed the first bullet points of needing to manually upgrade dependencies as when upgrading capactior, their migration guides states to use `npx cap migrate` which updates all dependencies anyway. So this streamlines the process for people.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Consolidated and streamlined the v7-to-v8 upgrade guide by replacing individual package version specifications with direct links to comprehensive Capacitor migration resources and detailed guidance documentation.
  * Enhanced accessibility of updater and sync instructions by introducing direct reference links for improved navigation and easier implementation throughout the migration process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->