### PR TITLE
Fix broken demo booking links in solution pages

### DIFF
--- a/src/pages/solutions/agencies.astro
+++ b/src/pages/solutions/agencies.astro
@@ -51,7 +51,7 @@ const content = { title, description }
               {m.solutions_start_free_trial({}, { locale })}
             </a>
             <a
-              href={getRelativeLocaleUrl(locale, 'book_demo')}
+              href="https://cal.com/team/capgo/demo"
               class="px-8 py-4 text-base font-semibold text-gray-300 transition-all duration-200 border border-gray-600 rounded-xl hover:bg-gray-800 hover:text-white"
             >
               {m.solutions_agencies_partner({}, { locale })}
@@ -335,7 +335,7 @@ const content = { title, description }
                 {m.solutions_start_free_trial({}, { locale })}
               </a>
               <a
-                href={getRelativeLocaleUrl(locale, 'book_demo')}
+                href="https://cal.com/team/capgo/demo"
                 class="px-8 py-4 text-base font-semibold text-white transition-all duration-200 border rounded-xl border-white/30 hover:bg-white/10"
               >
                 {m.solutions_agencies_partner({}, { locale })}

--- a/src/pages/solutions/direct-updates.astro
+++ b/src/pages/solutions/direct-updates.astro
@@ -48,7 +48,7 @@ const content = { title, description }
               {m.solutions_start_free_trial({}, { locale })}
             </a>
             <a
-              href={getRelativeLocaleUrl(locale, 'book_demo')}
+              href="https://cal.com/team/capgo/demo"
               class="px-8 py-4 text-base font-semibold text-gray-300 transition-all duration-200 border border-gray-600 rounded-xl hover:bg-gray-800 hover:text-white"
             >
               {m.solutions_talk_to_team({}, { locale })}

--- a/src/pages/solutions/ecommerce.astro
+++ b/src/pages/solutions/ecommerce.astro
@@ -52,7 +52,7 @@ const content = { title, description }
               {m.solutions_start_free_trial({}, { locale })}
             </a>
             <a
-              href={getRelativeLocaleUrl(locale, 'book_demo')}
+              href="https://cal.com/team/capgo/demo"
               class="px-8 py-4 text-base font-semibold text-gray-300 transition-all duration-200 border border-gray-600 rounded-xl hover:bg-gray-800 hover:text-white"
             >
               {m.solutions_talk_to_team({}, { locale })}
@@ -286,7 +286,7 @@ const content = { title, description }
                 {m.solutions_start_free_trial({}, { locale })}
               </a>
               <a
-                href={getRelativeLocaleUrl(locale, 'book_demo')}
+                href="https://cal.com/team/capgo/demo"
                 class="px-8 py-4 text-base font-semibold text-white transition-all duration-200 border rounded-xl border-white/30 hover:bg-white/10"
               >
                 {m.solutions_schedule_demo({}, { locale })}

--- a/src/pages/solutions/fintech.astro
+++ b/src/pages/solutions/fintech.astro
@@ -51,7 +51,7 @@ const content = { title, description }
               {m.solutions_start_free_trial({}, { locale })}
             </a>
             <a
-              href={getRelativeLocaleUrl(locale, 'book_demo')}
+              href="https://cal.com/team/capgo/demo"
               class="px-8 py-4 text-base font-semibold text-gray-300 transition-all duration-200 border border-gray-600 rounded-xl hover:bg-gray-800 hover:text-white"
             >
               {m.solutions_talk_to_team({}, { locale })}
@@ -343,7 +343,7 @@ const content = { title, description }
                 {m.solutions_start_free_trial({}, { locale })}
               </a>
               <a
-                href={getRelativeLocaleUrl(locale, 'book_demo')}
+                href="https://cal.com/team/capgo/demo"
                 class="px-8 py-4 text-base font-semibold text-white transition-all duration-200 border rounded-xl border-white/30 hover:bg-white/10"
               >
                 {m.solutions_schedule_demo({}, { locale })}

--- a/src/pages/solutions/healthcare.astro
+++ b/src/pages/solutions/healthcare.astro
@@ -48,7 +48,7 @@ const content = { title, description }
               {m.solutions_start_free_trial({}, { locale })}
             </a>
             <a
-              href={getRelativeLocaleUrl(locale, 'book_demo')}
+              href="https://cal.com/team/capgo/demo"
               class="px-8 py-4 text-base font-semibold text-gray-300 transition-all duration-200 border border-gray-600 rounded-xl hover:bg-gray-800 hover:text-white"
             >
               {m.solutions_talk_to_team({}, { locale })}
@@ -396,7 +396,7 @@ console.log(info.bundle.url)      <span class="text-gray-500">// Link to commit<
                 {m.solutions_start_free_trial({}, { locale })}
               </a>
               <a
-                href={getRelativeLocaleUrl(locale, 'book_demo')}
+                href="https://cal.com/team/capgo/demo"
                 class="px-8 py-4 text-base font-semibold text-white transition-all duration-200 border rounded-xl border-white/30 hover:bg-white/10"
               >
                 {m.solutions_schedule_demo({}, { locale })}

--- a/src/pages/solutions/pr-preview.astro
+++ b/src/pages/solutions/pr-preview.astro
@@ -48,7 +48,7 @@ const content = { title, description }
               {m.solutions_start_free_trial({}, { locale })}
             </a>
             <a
-              href={getRelativeLocaleUrl(locale, 'book_demo')}
+              href="https://cal.com/team/capgo/demo"
               class="px-8 py-4 text-base font-semibold text-gray-300 transition-all duration-200 border border-gray-600 rounded-xl hover:bg-gray-800 hover:text-white"
             >
               {m.solutions_talk_to_team({}, { locale })}

--- a/src/pages/solutions/production-updates.astro
+++ b/src/pages/solutions/production-updates.astro
@@ -48,7 +48,7 @@ const content = { title, description }
               {m.solutions_start_free_trial({}, { locale })}
             </a>
             <a
-              href={getRelativeLocaleUrl(locale, 'book_demo')}
+              href="https://cal.com/team/capgo/demo"
               class="px-8 py-4 text-base font-semibold text-gray-300 transition-all duration-200 border border-gray-600 rounded-xl hover:bg-gray-800 hover:text-white"
             >
               {m.solutions_talk_to_team({}, { locale })}
@@ -725,7 +725,7 @@ npx @capgo/cli bundle upload
                 {m.solutions_start_free_trial({}, { locale })}
               </a>
               <a
-                href={getRelativeLocaleUrl(locale, 'book_demo')}
+                href="https://cal.com/team/capgo/demo"
                 class="px-8 py-4 text-base font-semibold text-white transition-all duration-200 border rounded-xl border-white/30 hover:bg-white/10"
               >
                 {m.solutions_schedule_demo({}, { locale })}

--- a/src/pages/solutions/qsr.astro
+++ b/src/pages/solutions/qsr.astro
@@ -48,7 +48,7 @@ const content = { title, description }
               {m.solutions_start_free_trial({}, { locale })}
             </a>
             <a
-              href={getRelativeLocaleUrl(locale, 'book_demo')}
+              href="https://cal.com/team/capgo/demo"
               class="px-8 py-4 text-base font-semibold text-gray-300 transition-all duration-200 border border-gray-600 rounded-xl hover:bg-gray-800 hover:text-white"
             >
               {m.solutions_talk_to_team({}, { locale })}
@@ -488,7 +488,7 @@ jobs:
                 {m.solutions_start_free_trial({}, { locale })}
               </a>
               <a
-                href={getRelativeLocaleUrl(locale, 'book_demo')}
+                href="https://cal.com/team/capgo/demo"
                 class="px-8 py-4 text-base font-semibold text-white transition-all duration-200 border rounded-xl border-white/30 hover:bg-white/10"
               >
                 {m.solutions_talk_to_team({}, { locale })}


### PR DESCRIPTION
## Summary
- Fixed non-existent `book_demo` routing in all solution pages
- Replaced with direct Calendly link: https://cal.com/team/capgo/demo
- Fixes booking buttons on agencies, healthcare, e-commerce, QSR, fintech, production updates, direct updates, and PR preview pages
- 14 button fixes across 8 files

## Test plan
- Click "Schedule Demo" / "Partner with us" / "Talk to Team" buttons on each solution page
- Verify they navigate to Calendly booking page
- Confirm all CTA sections at bottom of pages also link correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated demo booking links across eight solution pages (Agencies, Direct Updates, E-commerce, Fintech, Healthcare, PR Preview, Production Updates, and QSR) to point to an external booking service instead of internal routes. Users will now be directed to an external booking platform when clicking demo CTAs on these pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->