### PR TITLE
fix: remove SPM workaround and update iOS minimum to 15

### DIFF
--- a/src/content/docs/de/docs/upgrade/from-v7-to-v8.md
+++ b/src/content/docs/de/docs/upgrade/from-v7-to-v8.md
@@ -16,28 +16,7 @@ Folgen Sie zuerst dem Migrations-Leitfaden von Capacitor:
 
 ## iOS-Mindestversionsanforderung
 
-Das iOS-Mindest-Deployment-Ziel wurde auf **15.5** erhöht, um sicherzustellen, dass iOS-Geräte mit [CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943) ausgeschlossen werden. Dies ist die Mindestversion der iOS-Zip-Bibliothek, die den Sicherheits-Fix implementiert hat.
-
-### Swift Package Manager (SPM) Workaround
-
-Capacitor hat derzeit einen Bug ([ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556)), der es nicht ermöglicht, das iOS-Deployment-Ziel auf 15.5 zu setzen, wenn SPM verwendet wird.
-
-Wenn Sie SPM-Unterstützung benötigen, können Sie vorübergehend unseren Fork verwenden:
-
-**GitHub:** [https://github.com/Cap-go/capacitor-plus](https://github.com/Cap-go/capacitor-plus)
-
-Um ihn zu verwenden, ersetzen Sie das CLI-Paket `@capacitor/cli` durch `@capacitor-plus/cli`:
-
-```bash
-npm uninstall @capacitor/cli
-npm install @capacitor-plus/cli
-```
-
-Verwenden Sie dann das CLI wie gewohnt:
-
-```bash
-npx capacitor sync
-```
+Das iOS-Mindest-Deployment-Ziel wurde auf **15** erhöht, um sicherzustellen, dass iOS-Geräte mit [CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943) ausgeschlossen werden. Dies ist die Mindestversion der iOS-Zip-Bibliothek, die den Sicherheits-Fix implementiert hat.
 
 ## Installation
 
@@ -80,8 +59,7 @@ Die Konfiguration bleibt dieselbe wie bei v7. Ihre bestehenden `capacitor.config
 ## Migrations-Checkliste
 
 - [ ] Dem v8-[Migrations-Leitfaden](https://capacitorjs.com/docs/updating/8-0) von Capacitor folgen, auf Breaking Changes prüfen
-- [ ] iOS-Mindest-Deployment-Ziel auf 15.5 erhöhen (erforderlich für CVE-2022-36943-Fix)
-- [ ] Bei SPM-Nutzung vorübergehend auf [@capacitor-plus/cli](https://github.com/Cap-go/capacitor-plus) wechseln, bis [ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556) behoben ist
+- [ ] iOS-Mindest-Deployment-Ziel auf 15 erhöhen (erforderlich für CVE-2022-36943-Fix)
 - [ ] @capgo/capacitor-updater auf ^8.0.0 aktualisieren
 - [ ] `npx cap sync` ausführen
 - [ ] Ihre App gründlich auf iOS und Android testen

--- a/src/content/docs/docs/upgrade/from-v7-to-v8.md
+++ b/src/content/docs/docs/upgrade/from-v7-to-v8.md
@@ -15,28 +15,7 @@ First follow the migration guide of Capacitor:
 
 ## iOS Minimum Version Requirement
 
-The iOS minimum deployment target has been bumped to **15.5** to ensure that iOS devices with [CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943) are excluded. This is the minimum version of the iOS zip library that has the security fix implemented.
-
-### Swift Package Manager (SPM) Workaround
-
-Capacitor currently has a bug ([ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556)) that does not allow setting the iOS deployment target to 15.5 when using SPM.
-
-If you need SPM support, you can temporarily use our fork:
-
-**GitHub:** [https://github.com/Cap-go/capacitor-plus](https://github.com/Cap-go/capacitor-plus)
-
-To use it, replace the CLI package `@capacitor/cli` with `@capacitor-plus/cli`:
-
-```bash
-npm uninstall @capacitor/cli
-npm install @capacitor-plus/cli
-```
-
-Then use the CLI as usual:
-
-```bash
-npx capacitor sync
-```
+The iOS minimum deployment target has been bumped to **15** to ensure that iOS devices with [CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943) are excluded. This is the minimum version of the iOS zip library that has the security fix implemented.
 
 ## Install
 
@@ -79,8 +58,7 @@ The configuration remains the same as v7. Your existing `capacitor.config` setti
 ## Migration Checklist
 
 - [ ] Follow Capacitor's v8 [migration guide](https://capacitorjs.com/docs/updating/8-0), check for breaking changes.
-- [ ] Bump iOS minimum deployment target to 15.5 (required for CVE-2022-36943 fix)
-- [ ] If using SPM, temporarily switch to [@capacitor-plus/cli](https://github.com/Cap-go/capacitor-plus) until [ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556) is fixed
+- [ ] Bump iOS minimum deployment target to 15 (required for CVE-2022-36943 fix)
 - [ ] [Update](#install) @capgo/capacitor-updater to ^8.0.0
 - [ ] [Run](#install) `npx cap sync`
 - [ ] Test your app thoroughly on both iOS and Android

--- a/src/content/docs/es/docs/upgrade/from-v7-to-v8.md
+++ b/src/content/docs/es/docs/upgrade/from-v7-to-v8.md
@@ -16,28 +16,7 @@ Primero sigue la guía de migración de Capacitor:
 
 ## Requisito de versión mínima de iOS
 
-El objetivo de implementación mínimo de iOS se ha aumentado a **15.5** para garantizar que los dispositivos iOS con [CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943) sean excluidos. Esta es la versión mínima de la biblioteca zip de iOS que tiene implementada la corrección de seguridad.
-
-### Solución alternativa para Swift Package Manager (SPM)
-
-Capacitor actualmente tiene un bug ([ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556)) que no permite establecer el objetivo de implementación de iOS en 15.5 cuando se usa SPM.
-
-Si necesitas soporte de SPM, puedes usar temporalmente nuestro fork:
-
-**GitHub:** [https://github.com/Cap-go/capacitor-plus](https://github.com/Cap-go/capacitor-plus)
-
-Para usarlo, reemplaza el paquete CLI `@capacitor/cli` por `@capacitor-plus/cli`:
-
-```bash
-npm uninstall @capacitor/cli
-npm install @capacitor-plus/cli
-```
-
-Luego usa el CLI como de costumbre:
-
-```bash
-npx capacitor sync
-```
+El objetivo de implementación mínimo de iOS se ha aumentado a **15** para garantizar que los dispositivos iOS con [CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943) sean excluidos. Esta es la versión mínima de la biblioteca zip de iOS que tiene implementada la corrección de seguridad.
 
 ## Instalación
 
@@ -80,8 +59,7 @@ La configuración sigue siendo la misma que en v7. Tu configuración existente d
 ## Lista de verificación de migración
 
 - [ ] Seguir la [guía de migración](https://capacitorjs.com/docs/updating/8-0) v8 de Capacitor, verificar cambios incompatibles
-- [ ] Aumentar el objetivo de implementación mínimo de iOS a 15.5 (requerido para la corrección de CVE-2022-36943)
-- [ ] Si usas SPM, cambiar temporalmente a [@capacitor-plus/cli](https://github.com/Cap-go/capacitor-plus) hasta que [ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556) sea corregido
+- [ ] Aumentar el objetivo de implementación mínimo de iOS a 15 (requerido para la corrección de CVE-2022-36943)
 - [ ] Actualizar @capgo/capacitor-updater a ^8.0.0
 - [ ] Ejecutar `npx cap sync`
 - [ ] Probar tu aplicación exhaustivamente en iOS y Android

--- a/src/content/docs/fr/upgrade/from-v7-to-v8.md
+++ b/src/content/docs/fr/upgrade/from-v7-to-v8.md
@@ -16,28 +16,7 @@ Suivez d'abord le guide de migration de Capacitor :
 
 ## Exigence de version iOS minimale
 
-La cible de déploiement iOS minimale a été augmentée à **15.5** pour garantir que les appareils iOS avec [CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943) sont exclus. C'est la version minimale de la bibliothèque zip iOS qui a le correctif de sécurité implémenté.
-
-### Solution de contournement Swift Package Manager (SPM)
-
-Capacitor a actuellement un bug ([ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556)) qui ne permet pas de définir la cible de déploiement iOS à 15.5 lors de l'utilisation de SPM.
-
-Si vous avez besoin du support SPM, vous pouvez temporairement utiliser notre fork :
-
-**GitHub:** [https://github.com/Cap-go/capacitor-plus](https://github.com/Cap-go/capacitor-plus)
-
-Pour l'utiliser, remplacez le package CLI `@capacitor/cli` par `@capacitor-plus/cli` :
-
-```bash
-npm uninstall @capacitor/cli
-npm install @capacitor-plus/cli
-```
-
-Ensuite, utilisez le CLI comme d'habitude :
-
-```bash
-npx capacitor sync
-```
+La cible de déploiement iOS minimale a été augmentée à **15** pour garantir que les appareils iOS avec [CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943) sont exclus. C'est la version minimale de la bibliothèque zip iOS qui a le correctif de sécurité implémenté.
 
 ## Installation
 
@@ -80,8 +59,7 @@ La configuration reste la même que pour v7. Vos paramètres `capacitor.config` 
 ## Liste de vérification de migration
 
 - [ ] Suivre le [guide de migration](https://capacitorjs.com/docs/updating/8-0) v8 de Capacitor, vérifier les changements incompatibles
-- [ ] Augmenter la cible de déploiement iOS minimale à 15.5 (requis pour le correctif CVE-2022-36943)
-- [ ] Si vous utilisez SPM, passer temporairement à [@capacitor-plus/cli](https://github.com/Cap-go/capacitor-plus) jusqu'à ce que [ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556) soit corrigé
+- [ ] Augmenter la cible de déploiement iOS minimale à 15 (requis pour le correctif CVE-2022-36943)
 - [ ] Mettre à jour @capgo/capacitor-updater vers ^8.0.0
 - [ ] Exécuter `npx cap sync`
 - [ ] Tester votre application en profondeur sur iOS et Android

--- a/src/content/docs/id/docs/upgrade/from-v7-to-v8.md
+++ b/src/content/docs/id/docs/upgrade/from-v7-to-v8.md
@@ -16,28 +16,7 @@ Pertama ikuti panduan migrasi Capacitor:
 
 ## Persyaratan Versi Minimum iOS
 
-Target deployment minimum iOS telah ditingkatkan ke **15.5** untuk memastikan perangkat iOS dengan [CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943) dikecualikan. Ini adalah versi minimum dari pustaka zip iOS yang memiliki perbaikan keamanan yang diimplementasikan.
-
-### Solusi Swift Package Manager (SPM)
-
-Capacitor saat ini memiliki bug ([ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556)) yang tidak memungkinkan pengaturan target deployment iOS ke 15.5 saat menggunakan SPM.
-
-Jika Anda membutuhkan dukungan SPM, Anda dapat sementara menggunakan fork kami:
-
-**GitHub:** [https://github.com/Cap-go/capacitor-plus](https://github.com/Cap-go/capacitor-plus)
-
-Untuk menggunakannya, ganti paket CLI `@capacitor/cli` dengan `@capacitor-plus/cli`:
-
-```bash
-npm uninstall @capacitor/cli
-npm install @capacitor-plus/cli
-```
-
-Kemudian gunakan CLI seperti biasa:
-
-```bash
-npx capacitor sync
-```
+Target deployment minimum iOS telah ditingkatkan ke **15** untuk memastikan perangkat iOS dengan [CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943) dikecualikan. Ini adalah versi minimum dari pustaka zip iOS yang memiliki perbaikan keamanan yang diimplementasikan.
 
 ## Instalasi
 
@@ -80,8 +59,7 @@ Konfigurasi tetap sama seperti v7. Pengaturan `capacitor.config` yang ada akan t
 ## Daftar Periksa Migrasi
 
 - [ ] Ikuti [panduan migrasi](https://capacitorjs.com/docs/updating/8-0) v8 Capacitor, periksa perubahan yang tidak kompatibel
-- [ ] Tingkatkan target deployment minimum iOS ke 15.5 (diperlukan untuk perbaikan CVE-2022-36943)
-- [ ] Jika menggunakan SPM, sementara beralih ke [@capacitor-plus/cli](https://github.com/Cap-go/capacitor-plus) sampai [ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556) diperbaiki
+- [ ] Tingkatkan target deployment minimum iOS ke 15 (diperlukan untuk perbaikan CVE-2022-36943)
 - [ ] Perbarui @capgo/capacitor-updater ke ^8.0.0
 - [ ] Jalankan `npx cap sync`
 - [ ] Uji aplikasi Anda secara menyeluruh di iOS dan Android

--- a/src/content/docs/it/docs/upgrade/from-v7-to-v8.md
+++ b/src/content/docs/it/docs/upgrade/from-v7-to-v8.md
@@ -16,28 +16,7 @@ Prima segui la guida alla migrazione di Capacitor:
 
 ## Requisito versione minima iOS
 
-L'obiettivo di distribuzione minimo per iOS è stato aumentato a **15.5** per garantire che i dispositivi iOS con [CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943) siano esclusi. Questa è la versione minima della libreria zip iOS che ha implementato la correzione di sicurezza.
-
-### Soluzione alternativa Swift Package Manager (SPM)
-
-Capacitor attualmente ha un bug ([ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556)) che non permette di impostare l'obiettivo di distribuzione iOS a 15.5 quando si usa SPM.
-
-Se hai bisogno del supporto SPM, puoi usare temporaneamente il nostro fork:
-
-**GitHub:** [https://github.com/Cap-go/capacitor-plus](https://github.com/Cap-go/capacitor-plus)
-
-Per usarlo, sostituisci il pacchetto CLI `@capacitor/cli` con `@capacitor-plus/cli`:
-
-```bash
-npm uninstall @capacitor/cli
-npm install @capacitor-plus/cli
-```
-
-Poi usa il CLI come al solito:
-
-```bash
-npx capacitor sync
-```
+L'obiettivo di distribuzione minimo per iOS è stato aumentato a **15** per garantire che i dispositivi iOS con [CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943) siano esclusi. Questa è la versione minima della libreria zip iOS che ha implementato la correzione di sicurezza.
 
 ## Installazione
 
@@ -80,8 +59,7 @@ La configurazione rimane la stessa di v7. Le tue impostazioni `capacitor.config`
 ## Lista di controllo della migrazione
 
 - [ ] Seguire la [guida alla migrazione](https://capacitorjs.com/docs/updating/8-0) v8 di Capacitor, verificare le modifiche incompatibili
-- [ ] Aumentare l'obiettivo di distribuzione minimo iOS a 15.5 (richiesto per la correzione CVE-2022-36943)
-- [ ] Se usi SPM, passare temporaneamente a [@capacitor-plus/cli](https://github.com/Cap-go/capacitor-plus) fino a quando [ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556) non sarà risolto
+- [ ] Aumentare l'obiettivo di distribuzione minimo iOS a 15 (richiesto per la correzione CVE-2022-36943)
 - [ ] Aggiornare @capgo/capacitor-updater a ^8.0.0
 - [ ] Eseguire `npx cap sync`
 - [ ] Testare accuratamente la tua app su iOS e Android

--- a/src/content/docs/ja/docs/upgrade/from-v7-to-v8.md
+++ b/src/content/docs/ja/docs/upgrade/from-v7-to-v8.md
@@ -16,28 +16,7 @@ sidebar:
 
 ## iOS最小バージョン要件
 
-iOSの最小デプロイメントターゲットが**15.5**に引き上げられ、[CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943)の脆弱性を持つiOSデバイスが除外されるようになりました。これは、セキュリティ修正が実装されたiOS zipライブラリの最小バージョンです。
-
-### Swift Package Manager（SPM）の回避策
-
-Capacitorには現在、SPMを使用する際にiOSデプロイメントターゲットを15.5に設定できないバグ（[ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556)）があります。
-
-SPMサポートが必要な場合は、一時的に私たちのフォークを使用できます：
-
-**GitHub:** [https://github.com/Cap-go/capacitor-plus](https://github.com/Cap-go/capacitor-plus)
-
-使用するには、CLIパッケージ `@capacitor/cli` を `@capacitor-plus/cli` に置き換えます：
-
-```bash
-npm uninstall @capacitor/cli
-npm install @capacitor-plus/cli
-```
-
-その後、通常通りCLIを使用します：
-
-```bash
-npx capacitor sync
-```
+iOSの最小デプロイメントターゲットが**15**に引き上げられ、[CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943)の脆弱性を持つiOSデバイスが除外されるようになりました。これは、セキュリティ修正が実装されたiOS zipライブラリの最小バージョンです。
 
 ## インストール
 
@@ -80,8 +59,7 @@ capacitor-updaterのバージョン8は、Capacitor 8との完全な互換性を
 ## 移行チェックリスト
 
 - [ ] Capacitorのv8[移行ガイド](https://capacitorjs.com/docs/updating/8-0)に従い、破壊的変更を確認
-- [ ] iOS最小デプロイメントターゲットを15.5に引き上げ（CVE-2022-36943修正に必要）
-- [ ] SPMを使用している場合、[ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556)が修正されるまで一時的に[@capacitor-plus/cli](https://github.com/Cap-go/capacitor-plus)に切り替え
+- [ ] iOS最小デプロイメントターゲットを15に引き上げ（CVE-2022-36943修正に必要）
 - [ ] @capgo/capacitor-updaterを^8.0.0に更新
 - [ ] `npx cap sync`を実行
 - [ ] iOSとAndroidでアプリを徹底的にテスト

--- a/src/content/docs/ko/docs/upgrade/from-v7-to-v8.md
+++ b/src/content/docs/ko/docs/upgrade/from-v7-to-v8.md
@@ -16,28 +16,7 @@ sidebar:
 
 ## iOS 최소 버전 요구사항
 
-iOS 최소 배포 대상이 **15.5**로 상향되어 [CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943) 취약점이 있는 iOS 기기가 제외됩니다. 이는 보안 수정이 구현된 iOS zip 라이브러리의 최소 버전입니다.
-
-### Swift Package Manager (SPM) 해결 방법
-
-Capacitor에는 현재 SPM 사용 시 iOS 배포 대상을 15.5로 설정할 수 없는 버그([ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556))가 있습니다.
-
-SPM 지원이 필요한 경우 일시적으로 우리의 포크를 사용할 수 있습니다:
-
-**GitHub:** [https://github.com/Cap-go/capacitor-plus](https://github.com/Cap-go/capacitor-plus)
-
-사용하려면 CLI 패키지 `@capacitor/cli`를 `@capacitor-plus/cli`로 교체하세요:
-
-```bash
-npm uninstall @capacitor/cli
-npm install @capacitor-plus/cli
-```
-
-그런 다음 평소처럼 CLI를 사용합니다:
-
-```bash
-npx capacitor sync
-```
+iOS 최소 배포 대상이 **15**로 상향되어 [CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943) 취약점이 있는 iOS 기기가 제외됩니다. 이는 보안 수정이 구현된 iOS zip 라이브러리의 최소 버전입니다.
 
 ## 설치
 
@@ -80,8 +59,7 @@ capacitor-updater 버전 8은 Capacitor 8과의 완전한 호환성을 제공하
 ## 마이그레이션 체크리스트
 
 - [ ] Capacitor의 v8 [마이그레이션 가이드](https://capacitorjs.com/docs/updating/8-0) 따르기, 주요 변경 사항 확인
-- [ ] iOS 최소 배포 대상을 15.5로 상향 (CVE-2022-36943 수정에 필요)
-- [ ] SPM 사용 시 [ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556)이 수정될 때까지 일시적으로 [@capacitor-plus/cli](https://github.com/Cap-go/capacitor-plus)로 전환
+- [ ] iOS 최소 배포 대상을 15로 상향 (CVE-2022-36943 수정에 필요)
 - [ ] @capgo/capacitor-updater를 ^8.0.0으로 업데이트
 - [ ] `npx cap sync` 실행
 - [ ] iOS 및 Android에서 앱을 철저히 테스트

--- a/src/content/docs/zh/docs/upgrade/from-v7-to-v8.md
+++ b/src/content/docs/zh/docs/upgrade/from-v7-to-v8.md
@@ -16,28 +16,7 @@ sidebar:
 
 ## iOS最低版本要求
 
-iOS最低部署目标已提升至**15.5**，以确保排除存在[CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943)漏洞的iOS设备。这是实施了安全修复的iOS zip库的最低版本。
-
-### Swift Package Manager (SPM) 解决方案
-
-Capacitor目前存在一个bug（[ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556)），在使用SPM时无法将iOS部署目标设置为15.5。
-
-如果您需要SPM支持，可以临时使用我们的分支：
-
-**GitHub:** [https://github.com/Cap-go/capacitor-plus](https://github.com/Cap-go/capacitor-plus)
-
-使用方法是将CLI包 `@capacitor/cli` 替换为 `@capacitor-plus/cli`：
-
-```bash
-npm uninstall @capacitor/cli
-npm install @capacitor-plus/cli
-```
-
-然后像往常一样使用CLI：
-
-```bash
-npx capacitor sync
-```
+iOS最低部署目标已提升至**15**，以确保排除存在[CVE-2022-36943](https://nvd.nist.gov/vuln/detail/CVE-2022-36943)漏洞的iOS设备。这是实施了安全修复的iOS zip库的最低版本。
 
 ## 安装
 
@@ -80,8 +59,7 @@ capacitor-updater版本8带来了与Capacitor 8的完全兼容性，确保您的
 ## 迁移检查清单
 
 - [ ] 遵循Capacitor的v8[迁移指南](https://capacitorjs.com/docs/updating/8-0)，检查破坏性更改
-- [ ] 将iOS最低部署目标提升至15.5（CVE-2022-36943修复所需）
-- [ ] 如果使用SPM，在[ionic-team/capacitor#7556](https://github.com/ionic-team/capacitor/issues/7556)修复之前临时切换到[@capacitor-plus/cli](https://github.com/Cap-go/capacitor-plus)
+- [ ] 将iOS最低部署目标提升至15（CVE-2022-36943修复所需）
 - [ ] 将@capgo/capacitor-updater更新至^8.0.0
 - [ ] 运行`npx cap sync`
 - [ ] 在iOS和Android上全面测试您的应用


### PR DESCRIPTION
## Summary
- Removed Swift Package Manager (SPM) workaround section from v7 to v8 upgrade docs as it's no longer required
- Updated iOS minimum deployment target from 15.5 to 15 across all 9 language versions (English, German, Spanish, French, Indonesian, Italian, Japanese, Korean, Chinese)

## Test plan
- Verify documentation displays correctly for all language versions
- Confirm iOS minimum version is now 15 instead of 15.5
- Ensure SPM workaround section has been removed from all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)