### PR TITLE
docs: Upgrade Next.js & Nuxt guides to Capacitor 8 + add from-scratch tutorials

### DIFF
--- a/src/content/blog/en/building-a-native-mobile-app-with-nextjs-and-capacitor.md
+++ b/src/content/blog/en/building-a-native-mobile-app-with-nextjs-and-capacitor.md
@@ -1,18 +1,18 @@
 ---
 slug: building-a-native-mobile-app-with-nextjs-and-capacitor
-title: Build Native Apps with Next.js 15 + Capacitor (2025)
+title: Convert Your Next.js App to iOS & Android with Capacitor 8
 description: >-
-  Learn how to create native mobile apps using Next.js 15, Capacitor, Tailwind CSS 4, and Konsta UI 5 in this
-  guide. Discover the latest best practices for
-  building high-performance, feature-rich mobile applications with modern UI frameworks.
+  Transform your existing Next.js 15 web application into native iOS and Android
+  mobile apps using Capacitor 8. A complete guide to configuring static export,
+  adding native plugins, and deploying to app stores.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2023-02-21T00:00:00.000Z
-updated_at: 2026-01-01T17:10:20.000Z
+updated_at: 2026-01-15T00:00:00.000Z
 head_image: /next_capgo.webp
 head_image_alt: Next.js 15 and Capacitor illustration
-keywords: Next.js 15, Capacitor, Tailwind CSS 4, Konsta UI 5, mobile app development, live updates, OTA updates, continuous integration, mobile app updates
+keywords: Next.js 15, Capacitor 8, convert web app to mobile, iOS, Android, mobile app development, static export, native plugins
 tag: Tutorial
 published: true
 locale: en
@@ -21,9 +21,18 @@ next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
 
 ## Introduction
 
-In this tutorial, we'll explore how to create native mobile apps using the powerful combination of [Next.js](https://nextjs.org/) 15 and [Capacitor](https://capacitorjs.com/) in 2025. By leveraging the latest versions of these technologies, you can build high-performance, feature-rich mobile applications with ease. We'll also demonstrate how to enhance the mobile UI using [Konsta UI](https://konstaui.com/) v5 and Tailwind CSS 4, although this step is optional.
+Have an existing Next.js web application? In this guide, you'll learn how to transform it into native iOS and Android mobile apps using [Capacitor](https://capacitorjs.com/) 8 — the latest version with improved performance and new features.
 
-Next.js, a popular React framework, provides a solid foundation for building web applications, while Capacitor allows you to transform your Next.js app into a native mobile app without significant modifications or the need to learn new skills like React Native. This tutorial will guide you through the process, starting with setting up a new Next.js app and integrating Capacitor to create a native mobile experience.
+Capacitor wraps your web app in a native container, giving you access to device APIs like camera, filesystem, and push notifications while keeping your existing React codebase. Unlike React Native, you don't need to rewrite anything — your Next.js code runs as-is.
+
+**What you'll learn:**
+- Configure your existing Next.js app for static export
+- Add Capacitor 8 with essential native plugins
+- Build and test on iOS and Android simulators
+- Enable live reload for faster development
+- Optionally add Konsta UI for native-looking components
+
+> Looking to start a new project from scratch? Check out our guide on [Building a Next.js Mobile App from Scratch](/blog/nextjs-mobile-app-capacitor-from-scratch/).
 
 ### Benefits of Using Next.js and Capacitor
 
@@ -32,44 +41,25 @@ Next.js, a popular React framework, provides a solid foundation for building web
 - **Native Capabilities**: Capacitor provides access to native device features like the camera, geolocation, and more, allowing you to build feature-rich mobile apps.
 - **Simplified Development**: With Capacitor, you can develop and test your mobile app using familiar web technologies, reducing the learning curve and streamlining the development process.
 
-## Preparing Your Next.js App
+## Prerequisites
 
-To get started, let's create a new Next.js application using the `create-next-app` command:
+Before you begin, make sure you have:
 
-```shell
-npx create-next-app@latest my-app
-```
+- **Node.js 18+** installed
+- An existing **Next.js 15+** application
+- **Xcode** (for iOS development, macOS only)
+- **Android Studio** (for Android development)
 
-This command will set up a blank Next.js project with the recommended configuration for the latest version.
+## Configuring Your Next.js App for Mobile
 
-Next, navigate to the project directory:
+The first step is to configure your Next.js app for static export. Capacitor needs static HTML/JS/CSS files to bundle into the native app.
 
-```shell
-cd my-app
-```
-
-To create a native mobile app, we need to generate a static export of our Next.js project. Update the `package.json` file to include a script for building and exporting the project:
-
-```json
-{
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
-    "static": "NEXT_PUBLIC_IS_MOBILE=true next build"
-  }
-}
-```
-
-Running the `npm run static` command may result in errors due to image optimization incompatibility. To resolve this, open the `next.config.js` file and modify it as follows:
+Open your `next.config.js` (or `next.config.ts`) file and add the export configuration:
 
 ```javascript
 /** @type {import('next').NextConfig} */
-const isMobile = process.env.NEXT_PUBLIC_IS_MOBILE === 'true';
 const nextConfig = {
-    ...(isMobile ? {output: 'export'} : {}),
-  reactStrictMode: true,
+  output: 'export',
   images: {
     unoptimized: true,
   },
@@ -78,64 +68,113 @@ const nextConfig = {
 module.exports = nextConfig;
 ```
 
-Now, running `npm run static` should work without any issues, and you will find a new `out` folder at the root of your project. This folder will be used by Capacitor in the next steps.
+The `output: 'export'` setting tells Next.js to generate static HTML files, and `images: { unoptimized: true }` bypasses Next.js image optimization which requires a server.
 
-## Adding Capacitor to Your Next.js 15 App
+**Important:** If you're using features that require a server (API routes, server components with data fetching, etc.), you'll need to refactor those to use client-side alternatives or external APIs.
 
-To package your Next.js app into a native mobile container, follow these steps:
-
-1. Install the [Capacitor CLI](https://capacitorjs.com/docs/cli/) as a development dependency:
-
-```shell
-npm install -D @capacitor/cli
-```
-
-2. Initialize Capacitor in your Next.js project:
-
-```shell
-npx cap init
-```
-
-During the initialization process, you can press "Enter" to accept the default values for the app name and bundle ID.
-
-3. Install the required Capacitor packages:
-
-```shell
-npm install @capacitor/core @capacitor/ios @capacitor/android
-```
-
-4. Add the native platforms:
-
-```shell
-npx cap add ios
-npx cap add android
-```
-
-Capacitor will create folders for each platform (`ios` and `android`) at the root of your project. These folders contain the native projects for iOS and Android, respectively.
-
-To access and build the Android project, you need to have [Android Studio](https://developer.android.com/studio) installed. For iOS development, you need a Mac with [Xcode](https://developer.apple.com/xcode/) installed.
-
-5. Configure Capacitor:
-
-Open the `capacitor.config.ts` file and update the `webDir` property to point to the output directory of your Next.js build:
+Add mobile-specific scripts to your `package.json`:
 
 ```json
 {
-  "appId": "com.example.app",
-  "appName": "my-app",
-  "webDir": "out",
-  "bundledWebRuntime": false
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "mobile": "bun run build && bunx cap sync",
+    "mobile:ios": "bun run mobile && bunx cap open ios",
+    "mobile:android": "bun run mobile && bunx cap open android"
+  }
 }
 ```
 
-6. Build and sync your project:
+Test the static export by running:
 
 ```shell
-npm run static
-npx cap sync
+bun run build
 ```
 
-The `npm run static` command builds your Next.js project and exports the static files, while `npx cap sync` synchronizes the web code with the native platforms.
+You should see an `out` folder at the root of your project. This contains all the static files that Capacitor will bundle into your native app.
+
+## Adding Capacitor 8 to Your Project
+
+To package your Next.js app into a native mobile container, follow these steps:
+
+1. Install Capacitor core and CLI:
+
+```shell
+bun add @capacitor/core
+bun add -D @capacitor/cli
+```
+
+2. Install common Capacitor plugins you'll likely need:
+
+```shell
+bun add @capacitor/app @capacitor/keyboard @capacitor/splash-screen @capacitor/preferences
+```
+
+These plugins provide essential features:
+- **@capacitor/app**: Handle app lifecycle events (foreground/background, URLs)
+- **@capacitor/keyboard**: Control keyboard behavior on mobile
+- **@capacitor/splash-screen**: Manage the native splash screen
+- **@capacitor/preferences**: Store key-value data persistently
+
+3. Initialize Capacitor with your project details:
+
+```shell
+bunx cap init my-app com.example.myapp --web-dir out
+```
+
+Replace `my-app` with your app name and `com.example.myapp` with your app ID (reverse domain notation).
+
+4. Create or update the `capacitor.config.ts` file with the proper configuration:
+
+```typescript
+import type { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.example.myapp',
+  appName: 'my-app',
+  webDir: 'out',
+  plugins: {
+    SplashScreen: {
+      launchShowDuration: 2000,
+      launchAutoHide: true,
+      androidScaleType: 'CENTER_CROP',
+      showSpinner: false,
+      splashFullScreen: true,
+      splashImmersive: true,
+    },
+  },
+};
+
+export default config;
+```
+
+5. Install native platforms:
+
+```shell
+bun add @capacitor/ios @capacitor/android
+```
+
+6. Add the native platform folders:
+
+```shell
+bunx cap add ios
+bunx cap add android
+```
+
+Capacitor will create `ios` and `android` folders at the root of your project containing the native projects.
+
+To build the Android project, you need [Android Studio](https://developer.android.com/studio). For iOS, you need a Mac with [Xcode](https://developer.apple.com/xcode/).
+
+7. Build and sync your project:
+
+```shell
+bun run mobile
+```
+
+This runs your custom script that builds the Next.js project and syncs the static files with the native platforms.
 
 ## Building and Deploying Native Apps
 
@@ -146,12 +185,18 @@ To develop iOS apps, you need to have **Xcode** installed, and for Android apps,
 
 For iOS:
 ```shell
-npx cap open ios
+bun run mobile:ios
 ```
 
 For Android:
 ```shell
-npx cap open android
+bun run mobile:android
+```
+
+Or directly with Capacitor CLI:
+```shell
+bunx cap open ios
+bunx cap open android
 ```
 
 2. Build and run the app:
@@ -187,16 +232,15 @@ During development, you can take advantage of live reloading to see changes inst
   ```
   Look for the IPv4 address in the output.
 
-2. Update the `capacitor.config.ts` file to include the server configuration:
+2. Update your `capacitor.config.ts` to point to your development server:
 
-```javascript
-import { CapacitorConfig } from '@capacitor/cli';
+```typescript
+import type { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
   appId: 'com.example.app',
   appName: 'my-app',
   webDir: 'out',
-  bundledWebRuntime: false,
   server: {
     url: 'http://YOUR_IP_ADDRESS:3000',
     cleartext: true,
@@ -206,12 +250,12 @@ const config: CapacitorConfig = {
 export default config;
 ```
 
-Replace `YOUR_IP_ADDRESS` with your local IP address.
+Replace `YOUR_IP_ADDRESS` with your local IP address (e.g., `192.168.1.100`).
 
 3. Apply the changes to your native project:
 
 ```shell
-npx cap copy
+bunx cap copy
 ```
 
 The `copy` command copies the web folder and configuration changes to the native project without updating the entire project.
@@ -229,7 +273,7 @@ Capacitor plugins allow you to access native device features from your Next.js a
 1. Install the Share plugin:
 
 ```shell
-npm i @capacitor/share
+bun add @capacitor/share
 ```
 
 2. Update the `pages/index.js` file to use the Share plugin:
@@ -277,7 +321,12 @@ export default function Home() {
 As mentioned earlier, when installing new plugins, we need to perform a sync operation and then redeploy the app to our device. To do this, run the following command:
 
 ```shell
-npx cap sync
+bun run mobile
+```
+
+Or just sync without rebuilding:
+```shell
+bunx cap sync
 ```
 
 4. Rebuild and run the app on your device.
@@ -304,7 +353,7 @@ To enhance the mobile UI of your Next.js app, you can use [Konsta UI v5](https:/
 1. Install the required packages (Konsta UI v5):
 
 ```shell
-npm i konsta
+bun add konsta
 ```
 
 2. Import Konsta UI theme in your main CSS file (e.g., `styles/globals.css`):
@@ -416,21 +465,28 @@ To ensure optimal performance of your Next.js and Capacitor app, consider the fo
 
 ## Conclusion
 
-In this tutorial, we explored how to build native mobile apps using Next.js and Capacitor. By leveraging the power of these technologies, you can create high-performance, feature-rich mobile applications with ease.
+You've successfully converted your existing Next.js web application into native iOS and Android apps using Capacitor 8. Your web codebase now runs natively on mobile devices with access to device APIs.
 
-We covered the steps to set up a Next.js app, integrate Capacitor, and build and deploy the app to mobile devices. Additionally, we discussed using Capacitor plugins, adding Konsta UI for an enhanced mobile UI, and performance optimization techniques.
+**What you accomplished:**
+- Configured Next.js for static export
+- Added Capacitor 8 with essential plugins
+- Built and deployed to iOS and Android simulators
+- Enabled live reload for development
+- Optionally added Konsta UI for native-looking components
 
-To take your Next.js and Capacitor app to the next level, consider exploring [Capgo](https://capgo.app/) for seamless live updates, ensuring your users always have access to the latest features and bug fixes.
+**Next steps:**
+- Set up [Capgo](https://capgo.app/) for over-the-air updates without app store resubmission
+- Add more native plugins like Camera, Geolocation, or Push Notifications
+- Configure app icons and splash screens for production
+- Prepare your app for App Store and Google Play submission
 
-By following the best practices and techniques outlined in this guide, you'll be well-equipped to build stunning native mobile apps using Next.js and Capacitor.
+> Starting a brand new project? Check out [Building a Next.js Mobile App from Scratch](/blog/nextjs-mobile-app-capacitor-from-scratch/) for a guided walkthrough.
 
 ## Resources
 
 - [Next.js Documentation](https://nextjs.org/docs)
-- [Capacitor Documentation](https://capacitorjs.com/docs)
+- [Capacitor 8 Documentation](https://capacitorjs.com/docs)
 - [Konsta UI v5 Documentation](https://konstaui.com/docs)
 - [Capgo - Live Updates for Capacitor Apps](https://capgo.app/)
-
-Happy app building!
 
 Learn how Capgo can help you build better apps faster, [sign up for a free account](/register/) today.

--- a/src/content/blog/en/nextjs-mobile-app-capacitor-from-scratch.md
+++ b/src/content/blog/en/nextjs-mobile-app-capacitor-from-scratch.md
@@ -1,0 +1,468 @@
+---
+slug: nextjs-mobile-app-capacitor-from-scratch
+title: Build a Next.js Mobile App from Scratch with Capacitor 8
+description: >-
+  Step-by-step guide to creating a new Next.js 15 project and turning it into native
+  iOS and Android mobile apps using Capacitor 8. Perfect for starting fresh with
+  mobile-first development.
+author: Martin Donadieu
+author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
+author_url: 'https://x.com/martindonadieu'
+created_at: 2026-01-15T00:00:00.000Z
+updated_at: 2026-01-15T00:00:00.000Z
+head_image: /next_capgo.webp
+head_image_alt: Next.js and Capacitor mobile app development
+keywords: Next.js 15, Capacitor 8, mobile app from scratch, iOS development, Android development, React mobile app, native plugins, Tailwind CSS
+tag: Tutorial
+published: true
+locale: en
+next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
+---
+
+## Introduction
+
+Want to build a mobile app with Next.js from the ground up? This guide walks you through creating a brand new Next.js 15 project configured for mobile from day one, then packaging it as native iOS and Android apps using [Capacitor](https://capacitorjs.com/) 8.
+
+By the end of this tutorial, you'll have a working mobile app running on simulators that you can continue developing and eventually publish to the App Store and Google Play.
+
+**Time required:** ~30 minutes
+
+**What you'll build:**
+- A new Next.js 15 project with App Router
+- Static export configuration for mobile
+- Capacitor 8 with essential plugins
+- Native iOS and Android apps
+- Live reload development setup
+
+> Already have a Next.js app? Check out [Convert Your Next.js App to Mobile](/blog/building-a-native-mobile-app-with-nextjs-and-capacitor/) instead.
+
+## Prerequisites
+
+Make sure you have these installed:
+
+- **Node.js 18+** (check with `node --version`)
+- **Bun** package manager (`curl -fsSL https://bun.sh/install | bash`)
+- **Xcode** (macOS only, for iOS development)
+- **Android Studio** (for Android development)
+
+## Step 1: Create a New Next.js Project
+
+Start by creating a fresh Next.js 15 project:
+
+```shell
+bunx create-next-app@latest my-mobile-app
+```
+
+When prompted, select these options:
+- **TypeScript:** Yes (recommended)
+- **ESLint:** Yes
+- **Tailwind CSS:** Yes (recommended for mobile styling)
+- **`src/` directory:** Yes
+- **App Router:** Yes (recommended)
+- **Import alias:** Default (`@/*`)
+
+Navigate to your project:
+
+```shell
+cd my-mobile-app
+```
+
+## Step 2: Configure Next.js for Static Export
+
+Capacitor requires static HTML/JS/CSS files. Configure Next.js for static export by updating `next.config.ts`:
+
+```typescript
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  output: 'export',
+  images: {
+    unoptimized: true,
+  },
+  // Ensure trailing slashes for proper routing in Capacitor
+  trailingSlash: true,
+};
+
+export default nextConfig;
+```
+
+**Why these settings?**
+- `output: 'export'` — Generates static HTML instead of requiring a Node.js server
+- `images: { unoptimized: true }` — Disables Next.js Image Optimization (requires a server)
+- `trailingSlash: true` — Ensures proper routing in the native WebView
+
+## Step 3: Add Mobile Scripts
+
+Update your `package.json` with mobile development scripts:
+
+```json
+{
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "mobile": "bun run build && bunx cap sync",
+    "mobile:ios": "bun run mobile && bunx cap open ios",
+    "mobile:android": "bun run mobile && bunx cap open android"
+  }
+}
+```
+
+Test the build:
+
+```shell
+bun run build
+```
+
+You should see an `out` directory with your static files.
+
+## Step 4: Install Capacitor 8
+
+Install the Capacitor core packages:
+
+```shell
+bun add @capacitor/core
+bun add -D @capacitor/cli
+```
+
+Install essential plugins that most mobile apps need:
+
+```shell
+bun add @capacitor/app @capacitor/keyboard @capacitor/splash-screen @capacitor/status-bar @capacitor/preferences
+```
+
+**What these plugins do:**
+- **@capacitor/app** — App lifecycle events (foreground/background, deep links)
+- **@capacitor/keyboard** — Control keyboard behavior
+- **@capacitor/splash-screen** — Native splash screen control
+- **@capacitor/status-bar** — Style the device status bar
+- **@capacitor/preferences** — Key-value storage (like localStorage but native)
+
+## Step 5: Initialize Capacitor
+
+Initialize Capacitor with your project details:
+
+```shell
+bunx cap init "My Mobile App" com.example.mymobileapp --web-dir out
+```
+
+Replace:
+- `"My Mobile App"` with your app's display name
+- `com.example.mymobileapp` with your app ID (reverse domain notation)
+
+This creates `capacitor.config.ts`. Update it with plugin configuration:
+
+```typescript
+import type { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.example.mymobileapp',
+  appName: 'My Mobile App',
+  webDir: 'out',
+  plugins: {
+    SplashScreen: {
+      launchShowDuration: 2000,
+      launchAutoHide: true,
+      androidScaleType: 'CENTER_CROP',
+      splashFullScreen: true,
+      splashImmersive: true,
+    },
+    Keyboard: {
+      resize: 'body',
+      resizeOnFullScreen: true,
+    },
+    StatusBar: {
+      style: 'light',
+    },
+  },
+};
+
+export default config;
+```
+
+## Step 6: Add Native Platforms
+
+Install the platform packages:
+
+```shell
+bun add @capacitor/ios @capacitor/android
+```
+
+Generate the native projects:
+
+```shell
+bunx cap add ios
+bunx cap add android
+```
+
+This creates `ios` and `android` directories containing the native projects.
+
+## Step 7: Build and Run
+
+Build your project and sync with native platforms:
+
+```shell
+bun run mobile
+```
+
+Open in iOS Simulator:
+
+```shell
+bun run mobile:ios
+```
+
+Or Android Emulator:
+
+```shell
+bun run mobile:android
+```
+
+**In Xcode (iOS):**
+1. Select a simulator from the device dropdown
+2. Click the Play button or press `Cmd + R`
+
+**In Android Studio:**
+1. Wait for Gradle to finish syncing
+2. Select an emulator from the device dropdown
+3. Click the Run button or press `Shift + F10`
+
+## Step 8: Set Up Live Reload
+
+For faster development, enable live reload so changes appear instantly on your device.
+
+1. Find your local IP address:
+
+```shell
+# macOS
+ipconfig getifaddr en0
+
+# Windows
+ipconfig
+```
+
+2. Create a development Capacitor config. Add to `capacitor.config.ts`:
+
+```typescript
+import type { CapacitorConfig } from '@capacitor/cli';
+
+const devConfig: CapacitorConfig = {
+  appId: 'com.example.mymobileapp',
+  appName: 'My Mobile App',
+  webDir: 'out',
+  server: {
+    url: 'http://YOUR_IP_ADDRESS:3000',
+    cleartext: true,
+  },
+  plugins: {
+    // ... same plugin config
+  },
+};
+
+const prodConfig: CapacitorConfig = {
+  appId: 'com.example.mymobileapp',
+  appName: 'My Mobile App',
+  webDir: 'out',
+  plugins: {
+    // ... same plugin config
+  },
+};
+
+const config = process.env.NODE_ENV === 'development' ? devConfig : prodConfig;
+
+export default config;
+```
+
+3. Start the dev server and copy config to native:
+
+```shell
+bun run dev &
+NODE_ENV=development bunx cap copy
+```
+
+4. Rebuild in Xcode/Android Studio
+
+Now edits to your Next.js code will hot-reload on the device.
+
+## Step 9: Create Your First Mobile Screen
+
+Let's create a simple mobile-friendly home screen. Update `src/app/page.tsx`:
+
+```tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { App } from '@capacitor/app';
+import { Keyboard } from '@capacitor/keyboard';
+
+export default function Home() {
+  const [appInfo, setAppInfo] = useState<{ name: string; version: string } | null>(null);
+
+  useEffect(() => {
+    // Get app info on mount
+    App.getInfo().then(setAppInfo).catch(console.error);
+
+    // Handle back button on Android
+    const backHandler = App.addListener('backButton', ({ canGoBack }) => {
+      if (!canGoBack) {
+        App.exitApp();
+      } else {
+        window.history.back();
+      }
+    });
+
+    // Hide keyboard when tapping outside inputs
+    const keyboardHandler = Keyboard.addListener('keyboardWillShow', () => {
+      document.body.classList.add('keyboard-open');
+    });
+
+    return () => {
+      backHandler.then(h => h.remove());
+      keyboardHandler.then(h => h.remove());
+    };
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-blue-500 to-blue-700 flex flex-col items-center justify-center p-6 text-white">
+      <h1 className="text-4xl font-bold mb-4">My Mobile App</h1>
+      <p className="text-xl mb-8 text-center opacity-90">
+        Built with Next.js 15 + Capacitor 8
+      </p>
+
+      {appInfo && (
+        <div className="bg-white/20 rounded-lg p-4 backdrop-blur-sm">
+          <p className="text-sm">
+            {appInfo.name} v{appInfo.version}
+          </p>
+        </div>
+      )}
+
+      <div className="mt-12 space-y-4 w-full max-w-sm">
+        <button className="w-full py-4 px-6 bg-white text-blue-600 rounded-xl font-semibold text-lg shadow-lg active:scale-95 transition-transform">
+          Get Started
+        </button>
+        <button className="w-full py-4 px-6 bg-white/20 text-white rounded-xl font-semibold text-lg backdrop-blur-sm active:scale-95 transition-transform">
+          Learn More
+        </button>
+      </div>
+    </main>
+  );
+}
+```
+
+## Step 10: Add Safe Area Handling
+
+Mobile devices have notches, home indicators, and status bars. Add safe area handling with Tailwind.
+
+Update `src/app/globals.css`:
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --sat: env(safe-area-inset-top);
+  --sar: env(safe-area-inset-right);
+  --sab: env(safe-area-inset-bottom);
+  --sal: env(safe-area-inset-left);
+}
+
+body {
+  padding-top: var(--sat);
+  padding-right: var(--sar);
+  padding-bottom: var(--sab);
+  padding-left: var(--sal);
+}
+
+/* Prevent text selection on mobile */
+* {
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Allow text selection in inputs */
+input, textarea {
+  -webkit-user-select: auto;
+  user-select: auto;
+}
+
+/* Keyboard handling */
+.keyboard-open {
+  --sab: 0px;
+}
+```
+
+## Project Structure
+
+Your project should now look like this:
+
+```
+my-mobile-app/
+├── android/              # Android native project
+├── ios/                  # iOS native project
+├── out/                  # Static build output
+├── src/
+│   ├── app/
+│   │   ├── globals.css
+│   │   ├── layout.tsx
+│   │   └── page.tsx
+│   └── ...
+├── capacitor.config.ts   # Capacitor configuration
+├── next.config.ts        # Next.js configuration
+├── package.json
+└── ...
+```
+
+## Next Steps
+
+You now have a working Next.js mobile app. Here's what to do next:
+
+### Essential Setup
+- **App Icons:** Replace default icons in `ios/App/App/Assets.xcassets` and `android/app/src/main/res`
+- **Splash Screen:** Customize in native projects or use `@capacitor/splash-screen` config
+- **Deep Links:** Configure URL schemes for your app
+
+### Add More Features
+- **Camera:** `bun add @capacitor/camera`
+- **Geolocation:** `bun add @capacitor/geolocation`
+- **Push Notifications:** `bun add @capacitor/push-notifications`
+- **File System:** `bun add @capacitor/filesystem`
+
+### UI Enhancement
+Consider adding [Konsta UI](https://konstaui.com/) for native-looking iOS/Android components:
+
+```shell
+bun add konsta
+```
+
+### Over-the-Air Updates
+Set up [Capgo](https://capgo.app/) to push updates without app store resubmission:
+
+```shell
+bunx @capgo/cli init
+```
+
+## Troubleshooting
+
+**Build fails with "Cannot find module"**
+Run `bun install` and try again.
+
+**iOS: "No signing identity found"**
+Open Xcode, go to Signing & Capabilities, and select your development team.
+
+**Android: "SDK location not found"**
+Create `android/local.properties` with `sdk.dir=/path/to/android/sdk`
+
+**Changes not appearing on device**
+Make sure you ran `bun run mobile` after making changes. For live reload, verify the IP address is correct and the dev server is running.
+
+## Resources
+
+- [Capacitor 8 Documentation](https://capacitorjs.com/docs)
+- [Next.js 15 Documentation](https://nextjs.org/docs)
+- [Capgo - Live Updates](https://capgo.app/)
+- [Konsta UI - Mobile UI Components](https://konstaui.com/)
+
+Ready to ship your app? Learn how Capgo can help you deliver updates faster — [sign up for a free account](/register/) today.

--- a/src/content/blog/en/nuxt-mobile-app-capacitor-from-scratch.md
+++ b/src/content/blog/en/nuxt-mobile-app-capacitor-from-scratch.md
@@ -1,0 +1,566 @@
+---
+slug: nuxt-mobile-app-capacitor-from-scratch
+title: Build a Nuxt Mobile App from Scratch with Capacitor 8
+description: >-
+  Step-by-step guide to creating a new Nuxt 4 project and turning it into native
+  iOS and Android mobile apps using Capacitor 8. Perfect for starting fresh with
+  mobile-first Vue development.
+author: Martin Donadieu
+author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
+author_url: 'https://x.com/martindonadieu'
+created_at: 2026-01-15T00:00:00.000Z
+updated_at: 2026-01-15T00:00:00.000Z
+head_image: /nuxt_capgo.webp
+head_image_alt: Nuxt and Capacitor mobile app development
+keywords: Nuxt 4, Capacitor 8, mobile app from scratch, iOS development, Android development, Vue mobile app, native plugins, Tailwind CSS
+tag: Tutorial
+published: true
+locale: en
+next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
+---
+
+## Introduction
+
+Want to build a mobile app with Nuxt from the ground up? This guide walks you through creating a brand new Nuxt 4 project configured for mobile from day one, then packaging it as native iOS and Android apps using [Capacitor](https://capacitorjs.com/) 8.
+
+By the end of this tutorial, you'll have a working mobile app running on simulators that you can continue developing and eventually publish to the App Store and Google Play.
+
+**Time required:** ~30 minutes
+
+**What you'll build:**
+- A new Nuxt 4 project with the latest directory structure
+- Static generation configuration for mobile
+- Capacitor 8 with essential plugins
+- Native iOS and Android apps
+- Live reload development setup
+
+> Already have a Nuxt app? Check out [Convert Your Nuxt App to Mobile](/blog/building-a-native-mobile-app-with-nuxt-and-capacitor/) instead.
+
+## Prerequisites
+
+Make sure you have these installed:
+
+- **Node.js 18+** (check with `node --version`)
+- **Bun** package manager (`curl -fsSL https://bun.sh/install | bash`)
+- **Xcode** (macOS only, for iOS development)
+- **Android Studio** (for Android development)
+
+## Step 1: Create a New Nuxt 4 Project
+
+Start by creating a fresh Nuxt 4 project:
+
+```shell
+bunx nuxi@latest init my-mobile-app
+cd my-mobile-app
+bun install
+```
+
+### Nuxt 4 Directory Structure
+
+Nuxt 4 uses a new directory structure with app code in the `app/` directory:
+
+```
+my-mobile-app/
+  app/
+    assets/
+    components/
+    composables/
+    layouts/
+    middleware/
+    pages/
+    plugins/
+    utils/
+    app.vue
+  public/
+  server/
+  nuxt.config.ts
+  package.json
+```
+
+This structure provides better separation between app and server code.
+
+## Step 2: Configure Nuxt for Static Generation
+
+Capacitor requires static HTML/JS/CSS files. Configure Nuxt for static generation in `nuxt.config.ts`:
+
+```typescript
+export default defineNuxtConfig({
+  compatibilityDate: '2025-01-15',
+  devtools: { enabled: true },
+
+  // Enable static generation
+  ssr: true,
+  nitro: {
+    preset: 'static',
+  },
+});
+```
+
+## Step 3: Add Mobile Scripts
+
+Update your `package.json` with mobile development scripts:
+
+```json
+{
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview",
+    "mobile": "bun run generate && bunx cap sync",
+    "mobile:ios": "bun run mobile && bunx cap open ios",
+    "mobile:android": "bun run mobile && bunx cap open android"
+  }
+}
+```
+
+Test the static generation:
+
+```shell
+bun run generate
+```
+
+You should see a `.output/public` directory with your static files.
+
+## Step 4: Install Capacitor 8
+
+Install the Capacitor core packages:
+
+```shell
+bun add @capacitor/core
+bun add -D @capacitor/cli
+```
+
+Install essential plugins that most mobile apps need:
+
+```shell
+bun add @capacitor/app @capacitor/keyboard @capacitor/splash-screen @capacitor/status-bar @capacitor/preferences
+```
+
+**What these plugins do:**
+- **@capacitor/app** — App lifecycle events (foreground/background, deep links)
+- **@capacitor/keyboard** — Control keyboard behavior
+- **@capacitor/splash-screen** — Native splash screen control
+- **@capacitor/status-bar** — Style the device status bar
+- **@capacitor/preferences** — Key-value storage (like localStorage but native)
+
+## Step 5: Initialize Capacitor
+
+Initialize Capacitor with your project details:
+
+```shell
+bunx cap init "My Mobile App" com.example.mymobileapp --web-dir .output/public
+```
+
+Replace:
+- `"My Mobile App"` with your app's display name
+- `com.example.mymobileapp` with your app ID (reverse domain notation)
+
+This creates `capacitor.config.ts`. Update it with plugin configuration:
+
+```typescript
+import type { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.example.mymobileapp',
+  appName: 'My Mobile App',
+  webDir: '.output/public',
+  plugins: {
+    SplashScreen: {
+      launchShowDuration: 2000,
+      launchAutoHide: true,
+      androidScaleType: 'CENTER_CROP',
+      splashFullScreen: true,
+      splashImmersive: true,
+    },
+    Keyboard: {
+      resize: 'body',
+      resizeOnFullScreen: true,
+    },
+    StatusBar: {
+      style: 'dark',
+    },
+  },
+};
+
+export default config;
+```
+
+## Step 6: Add Native Platforms
+
+Install the platform packages:
+
+```shell
+bun add @capacitor/ios @capacitor/android
+```
+
+Generate the native projects:
+
+```shell
+bunx cap add ios
+bunx cap add android
+```
+
+This creates `ios` and `android` directories containing the native projects.
+
+## Step 7: Build and Run
+
+Build your project and sync with native platforms:
+
+```shell
+bun run mobile
+```
+
+Open in iOS Simulator:
+
+```shell
+bun run mobile:ios
+```
+
+Or Android Emulator:
+
+```shell
+bun run mobile:android
+```
+
+**In Xcode (iOS):**
+1. Select a simulator from the device dropdown
+2. Click the Play button or press `Cmd + R`
+
+**In Android Studio:**
+1. Wait for Gradle to finish syncing
+2. Select an emulator from the device dropdown
+3. Click the Run button or press `Shift + F10`
+
+## Step 8: Set Up Live Reload
+
+For faster development, enable live reload so changes appear instantly on your device.
+
+1. Find your local IP address:
+
+```shell
+# macOS
+ipconfig getifaddr en0
+
+# Windows
+ipconfig
+```
+
+2. Create a development Capacitor config. Update `capacitor.config.ts`:
+
+```typescript
+import type { CapacitorConfig } from '@capacitor/cli';
+
+const devConfig: CapacitorConfig = {
+  appId: 'com.example.mymobileapp',
+  appName: 'My Mobile App',
+  webDir: '.output/public',
+  server: {
+    url: 'http://YOUR_IP_ADDRESS:3000',
+    cleartext: true,
+  },
+  plugins: {
+    // ... same plugin config
+  },
+};
+
+const prodConfig: CapacitorConfig = {
+  appId: 'com.example.mymobileapp',
+  appName: 'My Mobile App',
+  webDir: '.output/public',
+  plugins: {
+    // ... same plugin config
+  },
+};
+
+const config = process.env.NODE_ENV === 'development' ? devConfig : prodConfig;
+
+export default config;
+```
+
+3. Start the dev server and copy config to native:
+
+```shell
+bun run dev &
+NODE_ENV=development bunx cap copy
+```
+
+4. Rebuild in Xcode/Android Studio
+
+Now edits to your Nuxt code will hot-reload on the device.
+
+## Step 9: Create Your First Mobile Screen
+
+Let's create a mobile-friendly home screen. Update `app/app.vue`:
+
+```vue
+<template>
+  <NuxtPage />
+</template>
+```
+
+Create `app/pages/index.vue`:
+
+```vue
+<template>
+  <main
+    class="min-h-screen bg-gradient-to-b from-green-500 to-green-700 flex flex-col items-center justify-center p-6 text-white"
+  >
+    <h1 class="text-4xl font-bold mb-4">My Mobile App</h1>
+    <p class="text-xl mb-8 text-center opacity-90">
+      Built with Nuxt 4 + Capacitor 8
+    </p>
+
+    <div v-if="appInfo" class="bg-white/20 rounded-lg p-4 backdrop-blur-sm mb-8">
+      <p class="text-sm">
+        {{ appInfo.name }} v{{ appInfo.version }}
+      </p>
+    </div>
+
+    <div class="space-y-4 w-full max-w-sm">
+      <button
+        class="w-full py-4 px-6 bg-white text-green-600 rounded-xl font-semibold text-lg shadow-lg active:scale-95 transition-transform"
+        @click="handleGetStarted"
+      >
+        Get Started
+      </button>
+      <button
+        class="w-full py-4 px-6 bg-white/20 text-white rounded-xl font-semibold text-lg backdrop-blur-sm active:scale-95 transition-transform"
+        @click="handleShare"
+      >
+        Share App
+      </button>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue';
+import { App } from '@capacitor/app';
+
+const appInfo = ref<{ name: string; version: string } | null>(null);
+
+let backButtonListener: { remove: () => void } | null = null;
+
+onMounted(async () => {
+  // Get app info
+  try {
+    appInfo.value = await App.getInfo();
+  } catch (e) {
+    // Web fallback
+    appInfo.value = { name: 'My Mobile App', version: '1.0.0' };
+  }
+
+  // Handle Android back button
+  backButtonListener = await App.addListener('backButton', ({ canGoBack }) => {
+    if (!canGoBack) {
+      App.exitApp();
+    } else {
+      window.history.back();
+    }
+  });
+});
+
+onUnmounted(() => {
+  backButtonListener?.remove();
+});
+
+function handleGetStarted() {
+  // Navigate to onboarding or main app
+  console.log('Get started clicked');
+}
+
+async function handleShare() {
+  // We'll implement this with the Share plugin later
+  console.log('Share clicked');
+}
+</script>
+```
+
+## Step 10: Add Tailwind CSS
+
+For the styling to work, add Tailwind CSS to your project:
+
+```shell
+bun add tailwindcss @tailwindcss/vite
+```
+
+Update `nuxt.config.ts`:
+
+```typescript
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineNuxtConfig({
+  compatibilityDate: '2025-01-15',
+  devtools: { enabled: true },
+
+  ssr: true,
+  nitro: {
+    preset: 'static',
+  },
+
+  css: ['~/assets/css/main.css'],
+
+  vite: {
+    plugins: [tailwindcss()],
+  },
+});
+```
+
+Create `app/assets/css/main.css`:
+
+```css
+@import 'tailwindcss';
+
+:root {
+  --sat: env(safe-area-inset-top);
+  --sar: env(safe-area-inset-right);
+  --sab: env(safe-area-inset-bottom);
+  --sal: env(safe-area-inset-left);
+}
+
+body {
+  padding-top: var(--sat);
+  padding-right: var(--sar);
+  padding-bottom: var(--sab);
+  padding-left: var(--sal);
+}
+
+/* Prevent text selection on mobile */
+* {
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Allow text selection in inputs */
+input,
+textarea {
+  -webkit-user-select: auto;
+  user-select: auto;
+}
+```
+
+## Step 11: Add the Share Plugin
+
+Let's implement the share button functionality:
+
+```shell
+bun add @capacitor/share
+```
+
+Update `app/pages/index.vue` to use the Share plugin:
+
+```vue
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue';
+import { App } from '@capacitor/app';
+import { Share } from '@capacitor/share';
+
+// ... existing code ...
+
+async function handleShare() {
+  try {
+    await Share.share({
+      title: 'Check out this app!',
+      text: 'Built with Nuxt 4 and Capacitor 8',
+      url: 'https://capacitorjs.com',
+      dialogTitle: 'Share with friends',
+    });
+  } catch (e) {
+    console.log('Share cancelled or failed:', e);
+  }
+}
+</script>
+```
+
+Sync and rebuild:
+
+```shell
+bun run mobile
+```
+
+## Project Structure
+
+Your project should now look like this:
+
+```
+my-mobile-app/
+├── android/                  # Android native project
+├── ios/                      # iOS native project
+├── .output/
+│   └── public/              # Static build output
+├── app/
+│   ├── assets/
+│   │   └── css/
+│   │       └── main.css
+│   ├── pages/
+│   │   └── index.vue
+│   └── app.vue
+├── capacitor.config.ts       # Capacitor configuration
+├── nuxt.config.ts            # Nuxt configuration
+├── package.json
+└── ...
+```
+
+## Next Steps
+
+You now have a working Nuxt mobile app. Here's what to do next:
+
+### Essential Setup
+- **App Icons:** Replace default icons in `ios/App/App/Assets.xcassets` and `android/app/src/main/res`
+- **Splash Screen:** Customize in native projects or use `@capacitor/splash-screen` config
+- **Deep Links:** Configure URL schemes for your app
+
+### Add More Features
+- **Camera:** `bun add @capacitor/camera`
+- **Geolocation:** `bun add @capacitor/geolocation`
+- **Push Notifications:** `bun add @capacitor/push-notifications`
+- **File System:** `bun add @capacitor/filesystem`
+
+### UI Enhancement
+Consider adding [Konsta UI](https://konstaui.com/) for native-looking iOS/Android components:
+
+```shell
+bun add konsta
+```
+
+Then update your CSS to import the theme:
+
+```css
+@import 'tailwindcss';
+@import 'konsta/theme.css';
+```
+
+### Over-the-Air Updates
+Set up [Capgo](https://capgo.app/) to push updates without app store resubmission:
+
+```shell
+bunx @capgo/cli init
+```
+
+## Troubleshooting
+
+**Build fails with "Cannot find module"**
+Run `bun install` and try again.
+
+**iOS: "No signing identity found"**
+Open Xcode, go to Signing & Capabilities, and select your development team.
+
+**Android: "SDK location not found"**
+Create `android/local.properties` with `sdk.dir=/path/to/android/sdk`
+
+**Changes not appearing on device**
+Make sure you ran `bun run mobile` after making changes. For live reload, verify the IP address is correct and the dev server is running.
+
+**.output/public is empty or missing**
+Make sure you configured `nitro: { preset: 'static' }` in `nuxt.config.ts` and run `bun run generate`.
+
+## Resources
+
+- [Capacitor 8 Documentation](https://capacitorjs.com/docs)
+- [Nuxt 4 Documentation](https://nuxt.com/docs)
+- [Capgo - Live Updates](https://capgo.app/)
+- [Konsta UI - Mobile UI Components](https://konstaui.com/)
+
+Ready to ship your app? Learn how Capgo can help you deliver updates faster — [sign up for a free account](/register/) today.


### PR DESCRIPTION
## Summary

- Upgraded existing Next.js and Nuxt guides to Capacitor 8 with improved best practices
- Refocused existing guides on converting existing apps (instead of creating from zero)
- Created dedicated from-scratch tutorials for developers starting new projects
- Modernized all commands to use bun/bunx and removed deprecated Capacitor options
- Cross-linked guides so users can find the right tutorial for their situation

## Changes

- **Next.js guides:** Convert existing app (updated) + Build from scratch (new)
- **Nuxt guides:** Convert existing app (updated) + Build from scratch (new)
- Updated Capacitor 7 → 8, npm → bun commands throughout
- Added live reload, Tailwind CSS, Konsta UI, plugin examples in both frameworks

## Test Plan

- [ ] Verify Next.js conversion guide works with existing projects
- [ ] Verify Next.js from-scratch guide creates functional mobile app
- [ ] Verify Nuxt conversion guide works with existing projects
- [ ] Verify Nuxt from-scratch guide creates functional mobile app
- [ ] Check cross-links between guides work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated mobile development guides to Capacitor 8 with new code examples and configuration steps
  * Added two comprehensive tutorials for building mobile apps from scratch with Next.js and Nuxt
  * Refreshed deployment and tooling recommendations for iOS and Android development

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->