### PR TITLE
feat: add premium support offering with dedicated page

### DIFF
--- a/project.inlang/.gitignore
+++ b/project.inlang/.gitignore
@@ -1,1 +1,19 @@
-cache
+# IF GIT SHOWED THAT THIS FILE CHANGED
+#
+# 1. RUN THE FOLLOWING COMMAND
+#
+# ---
+# git rm --cached '**/*.inlang/.gitignore'
+# ---
+#
+# 2. COMMIT THE CHANGE
+#
+# ---
+# git commit -m "fix: remove tracked .gitignore from inlang project"
+# ---
+#
+# Inlang handles the gitignore itself starting with version ^2.5.
+#
+# everything is ignored except settings.json
+*
+!settings.json

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -71,6 +71,10 @@ const navigation: Record<string, NavigationItem[]> = {
       href: getRelativeLocaleUrl(Astro.locals.locale, 'pricing'),
     },
     {
+      name: 'Premium Support',
+      href: getRelativeLocaleUrl(Astro.locals.locale, 'premium-support'),
+    },
+    {
       name: 'App store publishing costs',
       href: getRelativeLocaleUrl(Astro.locals.locale, 'cost/cost-to-publish-app-on-app-store'),
     },

--- a/src/pages/premium-support.astro
+++ b/src/pages/premium-support.astro
@@ -1,0 +1,429 @@
+---
+import Layout from '@/layouts/Layout.astro'
+import { getRelativeLocaleUrl } from 'astro:i18n'
+import * as m from '@/paraglide/messages'
+import { createServiceLdJson, createLdJsonGraph, createFAQPageLdJson } from '@/lib/ldJson'
+
+const locale = Astro.locals.locale
+const brand = Astro.locals.runtimeConfig.public.brand
+
+const title = `${brand} | Premium Support for Capacitor Apps`
+const description = 'Get expert emergency support for your Capacitor app. 4 hours of prepaid support for €1000/month. We help with deployment issues, crashes, and native-side problems.'
+
+const baseUrl = Astro.locals.runtimeConfig.public.baseUrl
+const pageUrl = `${baseUrl}${getRelativeLocaleUrl(locale, 'premium-support/')}`
+const homeUrl = `${baseUrl}${getRelativeLocaleUrl(locale, '/')}`
+
+const serviceLdJson = createServiceLdJson(Astro.locals.runtimeConfig.public, {
+  name: 'Capgo Premium Support - Expert Capacitor Support',
+  description: 'Premium support retainer for Capacitor applications. 4 hours of prepaid expert support monthly for deployment issues, crashes, and native-side problems.',
+  url: pageUrl,
+  serviceType: 'Technical Support Service',
+  areaServed: ['Worldwide'],
+})
+
+const faqSchema = createFAQPageLdJson(Astro.locals.runtimeConfig.public, {
+  url: pageUrl,
+  questions: [
+    { question: 'What is included in the Premium Support retainer?', answer: '4 hours of prepaid expert support per month for deployment issues, app crashes, native code problems, and Capacitor-related questions.' },
+    { question: 'How quickly will you respond?', answer: 'We prioritize premium support requests and typically respond within hours during business days.' },
+    { question: 'What happens if I don\'t use all 4 hours?', answer: 'Unused hours do not roll over to the next month. The retainer ensures we\'re available when you need us.' },
+    { question: 'Can I get more hours if needed?', answer: 'Yes, additional hours can be purchased at €250/hour beyond your monthly retainer.' },
+    { question: 'What kind of issues can you help with?', answer: 'We help with deployment problems, app crashes, native iOS/Android issues, plugin problems, performance optimization, and any Capacitor-related technical challenges.' },
+  ],
+})
+
+const ldJSON = createLdJsonGraph(Astro.locals.runtimeConfig.public, serviceLdJson, {
+  includeOrganization: true,
+  includeBreadcrumbs: true,
+  breadcrumbs: [
+    { name: 'Home', url: homeUrl },
+    { name: 'Premium Support', url: pageUrl },
+  ],
+  additionalEntities: [faqSchema],
+})
+
+const content = { title, description, ldJSON }
+
+const supportFeatures = [
+  {
+    icon: 'M13 10V3L4 14h7v7l9-11h-7z',
+    title: 'Emergency Response',
+    description: 'When your app crashes in production or deployment fails, we drop everything to help you fix it fast.',
+  },
+  {
+    icon: 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z',
+    title: 'Native Expertise',
+    description: 'Deep knowledge of iOS, Android, and Capacitor internals. We solve the problems your team can\'t.',
+  },
+  {
+    icon: 'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z',
+    title: 'Save Valuable Time',
+    description: 'Stop spending days debugging native issues. Get expert help and ship your features faster.',
+  },
+  {
+    icon: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z',
+    title: 'Direct Access',
+    description: 'Talk directly to our engineers. No ticket queues, no waiting for triage. Real experts, real fast.',
+  },
+]
+
+const helpAreas = [
+  { title: 'Deployment Issues', desc: 'App store rejections, build failures, signing problems' },
+  { title: 'App Crashes', desc: 'Production crashes, memory issues, ANRs on Android' },
+  { title: 'Native Side Problems', desc: 'iOS/Android native code bugs, plugin conflicts' },
+  { title: 'Plugin Issues', desc: 'Capacitor plugin configuration, custom plugin debugging' },
+  { title: 'Performance', desc: 'App optimization, startup time, memory usage' },
+  { title: 'Live Updates', desc: 'Capgo integration, update failures, rollback issues' },
+]
+---
+
+<Layout content={content}>
+  <!-- Hero Section -->
+  <section class="relative py-20 sm:py-28 lg:py-36 overflow-hidden">
+    <div class="absolute inset-0 overflow-hidden pointer-events-none">
+      <div class="absolute top-0 left-1/2 -translate-x-1/2 w-full max-w-6xl h-full">
+        <div class="absolute top-1/4 left-1/4 w-96 h-96 bg-orange-500/10 rounded-full blur-3xl"></div>
+        <div class="absolute bottom-1/4 right-1/4 w-96 h-96 bg-red-500/10 rounded-full blur-3xl"></div>
+      </div>
+    </div>
+
+    <div class="relative px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
+      <div class="max-w-4xl mx-auto text-center">
+        <div class="inline-flex items-center px-4 py-2 text-sm font-medium text-orange-200 border rounded-full border-orange-400/40 bg-orange-500/10 mb-8">
+          <svg class="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 5.636l-3.536 3.536m0 5.656l3.536 3.536M9.172 9.172L5.636 5.636m3.536 9.192l-3.536 3.536M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-5 0a4 4 0 11-8 0 4 4 0 018 0z" />
+          </svg>
+          Premium Support Retainer
+        </div>
+
+        <h1 class="text-4xl font-bold leading-tight text-white sm:text-5xl lg:text-6xl">
+          Expert Help When
+          <br />
+          <span class="text-orange-400">You Need It Most</span>
+        </h1>
+
+        <p class="max-w-3xl mx-auto mt-8 text-xl leading-relaxed text-gray-300">
+          Your app crashed in production? Deployment stuck? Native side acting weird?
+          <br class="hidden sm:block" />
+          <strong class="text-white">We come in and save the day.</strong>
+        </p>
+
+        <div class="mt-10 p-8 bg-gray-800/50 rounded-2xl border border-gray-700 max-w-2xl mx-auto">
+          <div class="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-8">
+            <div class="text-center">
+              <div class="text-5xl font-bold text-white">€1,000</div>
+              <div class="text-gray-400 mt-1">per month</div>
+            </div>
+            <div class="hidden sm:block w-px h-16 bg-gray-600"></div>
+            <div class="text-center">
+              <div class="text-5xl font-bold text-orange-400">4 hours</div>
+              <div class="text-gray-400 mt-1">of expert support</div>
+            </div>
+          </div>
+          <p class="mt-4 text-gray-400 text-sm">€250/hour effective rate &bull; Additional hours available at the same rate</p>
+        </div>
+
+        <div class="flex flex-col items-center justify-center gap-4 mt-10 sm:flex-row">
+          <a
+            href="https://pay.capgo.app/b/8wM8wNaKHbTMbsIfZg"
+            target="_blank"
+            class="px-8 py-4 text-base font-semibold text-white transition-all duration-200 bg-orange-600 rounded-xl hover:bg-orange-700 focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 shadow-lg shadow-orange-500/25"
+          >
+            Subscribe Now
+            <svg class="inline-block w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
+            </svg>
+          </a>
+          <a
+            href="https://cal.com/team/capgo/premium-support"
+            target="_blank"
+            class="px-8 py-4 text-base font-semibold text-gray-300 transition-all duration-200 border border-gray-600 rounded-xl hover:bg-gray-800 hover:text-white"
+          >
+            Talk to Us First
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- The Problem Section -->
+  <section class="py-20 bg-gray-800">
+    <div class="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
+      <div class="max-w-3xl mx-auto text-center mb-16">
+        <h2 class="text-sm font-semibold tracking-wide text-red-400 uppercase mb-4">The Reality</h2>
+        <h3 class="text-3xl font-bold text-white sm:text-4xl">When Things Go Wrong With Mobile Apps</h3>
+        <p class="mt-4 text-xl text-gray-400">You know the feeling...</p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-5xl mx-auto">
+        <div class="bg-gray-900 rounded-2xl p-8 border border-red-500/20">
+          <div class="w-12 h-12 bg-red-500/20 rounded-lg flex items-center justify-center mb-6">
+            <svg class="w-6 h-6 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+          </div>
+          <h4 class="text-xl font-bold text-white mb-3">Production Crash</h4>
+          <p class="text-gray-400">Your app starts crashing for thousands of users. The stack trace points to native code you don't understand.</p>
+        </div>
+
+        <div class="bg-gray-900 rounded-2xl p-8 border border-red-500/20">
+          <div class="w-12 h-12 bg-red-500/20 rounded-lg flex items-center justify-center mb-6">
+            <svg class="w-6 h-6 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+            </svg>
+          </div>
+          <h4 class="text-xl font-bold text-white mb-3">Deployment Blocked</h4>
+          <p class="text-gray-400">Apple or Google rejected your update. The error message is cryptic. Your deadline is tomorrow.</p>
+        </div>
+
+        <div class="bg-gray-900 rounded-2xl p-8 border border-red-500/20">
+          <div class="w-12 h-12 bg-red-500/20 rounded-lg flex items-center justify-center mb-6">
+            <svg class="w-6 h-6 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          <h4 class="text-xl font-bold text-white mb-3">No Clue What's Wrong</h4>
+          <p class="text-gray-400">Something broke after the last update. Your web team doesn't know native. Days of debugging ahead.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Features Section -->
+  <section class="py-20 bg-gray-900">
+    <div class="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
+      <div class="max-w-3xl mx-auto text-center mb-16">
+        <h2 class="text-sm font-semibold tracking-wide text-green-400 uppercase mb-4">The Solution</h2>
+        <h3 class="text-3xl font-bold text-white sm:text-4xl">Expert Backup On Standby</h3>
+        <p class="mt-4 text-xl text-gray-400">With Premium Support, you have Capacitor experts ready to jump in when you need help.</p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-5xl mx-auto">
+        {supportFeatures.map((feature) => (
+          <div class="bg-gray-800 rounded-2xl p-8 border border-gray-700 hover:border-orange-500/50 transition-colors">
+            <div class="w-12 h-12 bg-orange-500/20 rounded-lg flex items-center justify-center mb-6">
+              <svg class="w-6 h-6 text-orange-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={feature.icon} />
+              </svg>
+            </div>
+            <h4 class="text-xl font-bold text-white mb-3">{feature.title}</h4>
+            <p class="text-gray-400">{feature.description}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- What We Help With Section -->
+  <section class="py-20 bg-gray-800">
+    <div class="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
+      <div class="max-w-3xl mx-auto text-center mb-16">
+        <h2 class="text-3xl font-bold text-white sm:text-4xl">What We Help With</h2>
+        <p class="mt-4 text-xl text-gray-400">Any Capacitor or mobile app problem your team is struggling with.</p>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto">
+        {helpAreas.map((area) => (
+          <div class="bg-gray-900 rounded-xl p-6 border border-gray-700">
+            <div class="flex items-start gap-3">
+              <svg class="w-5 h-5 text-green-400 mt-1 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+              </svg>
+              <div>
+                <h4 class="font-bold text-white">{area.title}</h4>
+                <p class="text-sm text-gray-400 mt-1">{area.desc}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- How It Works Section -->
+  <section class="py-20 bg-gray-900">
+    <div class="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
+      <div class="max-w-3xl mx-auto text-center mb-16">
+        <h2 class="text-3xl font-bold text-white sm:text-4xl">How It Works</h2>
+      </div>
+
+      <div class="max-w-4xl mx-auto">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+          <div class="text-center">
+            <div class="flex justify-center items-center mx-auto mb-6 w-16 h-16 text-2xl font-bold text-white bg-orange-600 rounded-full">1</div>
+            <h4 class="text-xl font-bold text-white mb-2">Subscribe</h4>
+            <p class="text-gray-400">Sign up for €1,000/month. You get 4 hours of expert support ready to use.</p>
+          </div>
+          <div class="text-center">
+            <div class="flex justify-center items-center mx-auto mb-6 w-16 h-16 text-2xl font-bold text-white bg-orange-600 rounded-full">2</div>
+            <h4 class="text-xl font-bold text-white mb-2">Reach Out</h4>
+            <p class="text-gray-400">When you hit a problem, contact us via email or Discord. Describe the issue.</p>
+          </div>
+          <div class="text-center">
+            <div class="flex justify-center items-center mx-auto mb-6 w-16 h-16 text-2xl font-bold text-white bg-orange-600 rounded-full">3</div>
+            <h4 class="text-xl font-bold text-white mb-2">We Fix It</h4>
+            <p class="text-gray-400">Our experts jump in, diagnose the problem, and help you solve it fast.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Pricing Details Section -->
+  <section class="py-20 bg-gray-800">
+    <div class="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
+      <div class="max-w-3xl mx-auto">
+        <div class="bg-gray-900 rounded-2xl p-8 lg:p-12 border border-orange-500/30">
+          <div class="text-center mb-8">
+            <h2 class="text-3xl font-bold text-white mb-2">Premium Support Retainer</h2>
+            <p class="text-gray-400">Peace of mind for your Capacitor app</p>
+          </div>
+
+          <div class="flex flex-col md:flex-row items-center justify-center gap-8 mb-8">
+            <div class="text-center">
+              <div class="text-6xl font-bold text-white">€1,000</div>
+              <div class="text-gray-400">/month</div>
+            </div>
+            <div class="hidden md:block w-px h-24 bg-gray-700"></div>
+            <div class="space-y-3 text-left">
+              <div class="flex items-center gap-2 text-gray-300">
+                <svg class="w-5 h-5 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+                  <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+                </svg>
+                4 hours of expert support included
+              </div>
+              <div class="flex items-center gap-2 text-gray-300">
+                <svg class="w-5 h-5 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+                  <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+                </svg>
+                Priority response time
+              </div>
+              <div class="flex items-center gap-2 text-gray-300">
+                <svg class="w-5 h-5 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+                  <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+                </svg>
+                Direct access to engineers
+              </div>
+              <div class="flex items-center gap-2 text-gray-300">
+                <svg class="w-5 h-5 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+                  <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+                </svg>
+                Additional hours at €250/hr
+              </div>
+              <div class="flex items-center gap-2 text-gray-300">
+                <svg class="w-5 h-5 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+                  <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+                </svg>
+                Cancel anytime
+              </div>
+            </div>
+          </div>
+
+          <div class="text-center">
+            <a
+              href="https://pay.capgo.app/b/8wM8wNaKHbTMbsIfZg"
+              target="_blank"
+              class="inline-flex items-center px-8 py-4 text-lg font-semibold text-white bg-orange-600 rounded-xl hover:bg-orange-700 transition-colors shadow-lg shadow-orange-500/25"
+            >
+              Subscribe Now
+              <svg class="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
+              </svg>
+            </a>
+            <p class="mt-4 text-sm text-gray-500">Secure payment via Stripe</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- FAQ Section -->
+  <section class="py-20 bg-gray-900">
+    <div class="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
+      <div class="max-w-3xl mx-auto">
+        <h2 class="text-3xl font-bold text-white text-center mb-12">Frequently Asked Questions</h2>
+
+        <div class="space-y-6">
+          <div class="bg-gray-800 rounded-xl p-6 border border-gray-700">
+            <h3 class="text-lg font-semibold text-white mb-2">What if I need more than 4 hours?</h3>
+            <p class="text-gray-400">Additional hours are billed at €250/hour. Most companies find 4 hours sufficient for a typical month, but some months you might need more help, and that's totally fine.</p>
+          </div>
+
+          <div class="bg-gray-800 rounded-xl p-6 border border-gray-700">
+            <h3 class="text-lg font-semibold text-white mb-2">Do unused hours roll over?</h3>
+            <p class="text-gray-400">No, hours don't roll over to the next month. The retainer ensures we're available and prioritize your requests when you need help. Think of it as insurance for your app.</p>
+          </div>
+
+          <div class="bg-gray-800 rounded-xl p-6 border border-gray-700">
+            <h3 class="text-lg font-semibold text-white mb-2">How quickly do you respond?</h3>
+            <p class="text-gray-400">We aim to respond within hours during business days. For critical production issues, we prioritize getting you help as fast as possible.</p>
+          </div>
+
+          <div class="bg-gray-800 rounded-xl p-6 border border-gray-700">
+            <h3 class="text-lg font-semibold text-white mb-2">What's the difference from regular support?</h3>
+            <p class="text-gray-400">Regular support is for Capgo product questions. Premium Support is for any Capacitor app problem - deployment issues, crashes, native bugs, performance - anything your team needs expert help with.</p>
+          </div>
+
+          <div class="bg-gray-800 rounded-xl p-6 border border-gray-700">
+            <h3 class="text-lg font-semibold text-white mb-2">Do I need to be a Capgo customer?</h3>
+            <p class="text-gray-400">No! Premium Support is available to any company with a Capacitor app, whether you use Capgo or not.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Testimonial / Trust Section -->
+  <section class="py-20 bg-gray-800">
+    <div class="px-4 mx-auto max-w-4xl text-center">
+      <h2 class="text-3xl font-bold text-white mb-8">Companies Trust Our Expertise</h2>
+      <div class="grid grid-cols-2 md:grid-cols-5 gap-8 items-center justify-center opacity-70">
+        <img class="h-10 object-contain mx-auto grayscale" src="/nana-logo-transparent.webp" alt="Nana" />
+        <img class="h-10 object-contain mx-auto grayscale" src="/snowqueen.webp" alt="Snowqueen" />
+        <img class="h-10 object-contain mx-auto grayscale" src="/shelf_app.webp" alt="Shelf" />
+        <img class="h-10 object-contain mx-auto grayscale" src="/suez.webp" alt="Suez" />
+        <img class="h-10 object-contain mx-auto grayscale" src="/janitor_app.webp" alt="Janitor" />
+      </div>
+    </div>
+  </section>
+
+  <!-- Final CTA Section -->
+  <section class="relative py-20 bg-gray-900">
+    <div class="absolute inset-0 overflow-hidden">
+      <div class="absolute rounded-full -top-40 -left-40 w-80 h-80 animate-pulse bg-orange-500/10 blur-3xl"></div>
+      <div class="absolute rounded-full -right-40 -bottom-40 w-80 h-80 animate-pulse bg-red-500/10 blur-3xl" style="animation-delay: 2s;"></div>
+    </div>
+
+    <div class="relative px-6 mx-auto max-w-7xl lg:px-8">
+      <div class="text-center">
+        <h2 class="mb-6 text-4xl font-bold text-white sm:text-5xl">
+          Stop Losing Sleep Over
+          <br />
+          <span class="text-orange-400">Native App Problems</span>
+        </h2>
+
+        <p class="max-w-2xl mx-auto mt-6 mb-10 text-xl text-gray-300">
+          Have Capacitor experts on standby. When something breaks, we fix it fast.
+        </p>
+
+        <div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <a
+            href="https://pay.capgo.app/b/8wM8wNaKHbTMbsIfZg"
+            target="_blank"
+            class="inline-flex items-center justify-center px-8 py-4 text-lg font-bold text-white transition-all duration-200 bg-orange-600 rounded-xl hover:bg-orange-700 shadow-lg shadow-orange-500/25"
+          >
+            Get Premium Support - €1,000/mo
+            <svg class="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
+            </svg>
+          </a>
+        </div>
+
+        <p class="mt-6 text-sm text-gray-400">
+          Questions? <a href="https://cal.com/team/capgo/premium-support" target="_blank" class="text-orange-400 hover:underline">Schedule a call</a> to learn more.
+        </p>
+      </div>
+    </div>
+  </section>
+</Layout>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -209,6 +209,42 @@ if (plans.length > 0) {
         {m.we_don_t_bill_you_automatically_until_your_confirmation({}, { locale: Astro.locals.locale })}<br />
         {m.we_don_t_store_or_sell_your_data_to_anyone({}, { locale: Astro.locals.locale })}
       </p>
+
+      <!-- Premium Support Section -->
+      <div class="mt-16 mb-16 max-w-4xl mx-auto">
+        <div class="bg-gradient-to-r from-orange-50 to-red-50 rounded-2xl p-8 lg:p-10 border border-orange-200 shadow-lg">
+          <div class="flex flex-col lg:flex-row items-center gap-8">
+            <div class="flex-shrink-0">
+              <div class="w-20 h-20 bg-orange-100 rounded-2xl flex items-center justify-center">
+                <svg class="w-10 h-10 text-orange-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 5.636l-3.536 3.536m0 5.656l3.536 3.536M9.172 9.172L5.636 5.636m3.536 9.192l-3.536 3.536M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-5 0a4 4 0 11-8 0 4 4 0 018 0z" />
+                </svg>
+              </div>
+            </div>
+            <div class="flex-1 text-center lg:text-left">
+              <h3 class="text-2xl font-bold text-gray-900 mb-2">Premium Support for Capacitor Apps</h3>
+              <p class="text-gray-600 mb-4">
+                App crashing? Deployment stuck? We come in and save the day. Get 4 hours of expert support monthly at €250/hour.
+              </p>
+              <div class="flex flex-col sm:flex-row items-center gap-4 justify-center lg:justify-start">
+                <div class="flex items-baseline gap-1">
+                  <span class="text-3xl font-bold text-gray-900">€1,000</span>
+                  <span class="text-gray-500">/month</span>
+                </div>
+                <a
+                  href={getRelativeLocaleUrl(Astro.locals.locale, 'premium-support')}
+                  class="inline-flex items-center px-6 py-3 text-base font-semibold text-white bg-orange-600 rounded-xl hover:bg-orange-700 transition-colors shadow-md"
+                >
+                  Learn More
+                  <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                  </svg>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
     <Faq />
   </section>


### PR DESCRIPTION
## Summary

- Create new premium support page explaining 4-hour monthly retainer at €1000
- Add premium support section to pricing page with Learn More button
- Add premium support link to footer navigation
- Full SEO support with JSON-LD structured data

Customers can subscribe at https://pay.capgo.app/b/8wM8wNaKHbTMbsIfZg for emergency support when their Capacitor apps crash or have deployment issues.

🤖 Generated with Claude Code