### PR TITLE
Add Capgo channel surfing blog post

### DIFF
--- a/src/content/blog/en/how-capgo-channel-switching-works.md
+++ b/src/content/blog/en/how-capgo-channel-switching-works.md
@@ -7,7 +7,7 @@ author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2025-01-21T00:00:00.000Z
 updated_at: 2025-01-21T00:00:00.000Z
-head_image: /capgo-feature-image.webp
+head_image: /capgo_channels_surfing.webp
 head_image_alt: Capgo channel switching illustration
 keywords: channels, channel surfing, OTA updates, capacitor, capgo, live updates, runtime switching, beta testing, QA
 tag: Tutorial


### PR DESCRIPTION
Adds comprehensive guide on runtime channel switching for Capgo. The article explains channel surfing—the ability to switch update channels at runtime without reinstalling—with practical examples, setup instructions, and best practices.

Key sections include how to enable self-assignment on channels, complete code examples for switching channels, building a channel switcher UI, testing procedures, and common pitfalls to avoid.

The article emphasizes that the only requirement for channel surfing is enabling "Allow devices to self associate" on each channel in the Capgo dashboard, with no code config changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * New article published explaining Capgo's runtime channel switching capabilities. Covers the API surface, practical implementation patterns with code examples, best practices for channel management, comprehensive testing strategies, and troubleshooting guidance for OTA updates and common deployment scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->