### PR TITLE
fix: display yearly total for all pricing plans

### DIFF
--- a/src/components/pricing/Plans.astro
+++ b/src/components/pricing/Plans.astro
@@ -104,11 +104,7 @@ function buildTimeDisplay(buildTimeSeconds: number) {
             </div>
             <p class="mt-8" data-yearly-price style={yearly ? '' : 'display: none'}>
               <span class="text-gray-900">
-                {plan.name === 'Enterprise' ? (
-                  <span>{m.billed_monthly({}, { locale: Astro.locals.locale })}</span>
-                ) : (
-                  <span>{m.billed_annually_at({}, { locale: Astro.locals.locale })} ${plan.price_y}</span>
-                )}
+                <span>{m.billed_annually_at({}, { locale: Astro.locals.locale })} $<span data-yearly-total>{numberWithSpaces(plan.price_y)}</span></span>
               </span>
             </p>
             <p class="mt-8" data-monthly-price style={yearly ? 'display: none' : ''}>


### PR DESCRIPTION
Fixed the pay-as-you-go plan yearly pricing display. Now shows the yearly total amount for all plans when yearly billing is selected, instead of just showing 'Billed monthly' without the total.