### PR TITLE
Add Algora payout note to bug bounty

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -275,7 +275,7 @@
   "bug_bounty_how_to_report_step_4": "Geben Sie den genauen Dateipfad und die Zeilennummer(n) an, wo die Schwachstelle existiert",
   "bug_bounty_how_to_report_step_5": "Beschreiben Sie detailliert die Schritte zur Reproduktion und erläutern Sie die Sicherheitsauswirkungen",
   "bug_bounty_how_to_report_title": "So melden Sie",
-  "bug_bounty_important_note": "Wenn Sie nicht die genaue Codezeile in GitHub angeben können, wo das Problem existiert, ist Ihr Bericht nicht für das Bug Bounty Programm berechtigt. Berichte müssen ausschließlich über GitHub Security Advisory eingereicht werden.",
+  "bug_bounty_important_note": "Wenn Sie nicht die genaue Codezeile in GitHub angeben können, wo das Problem existiert, ist Ihr Bericht nicht für das Bug Bounty Programm berechtigt. Berichte müssen ausschließlich über GitHub Security Advisory eingereicht werden. Auszahlungen erfolgen über Algora.io. Bitte erstellen Sie dort ein Konto, damit wir Sie direkt über die Plattform bezahlen können.",
   "bug_bounty_intro": "Capgo setzt sich für Sicherheit und Transparenz ein. Unser gesamter Code ist Open Source, und wir begrüßen Sicherheitsforscher, die uns helfen, Schwachstellen in unserer Codebasis zu identifizieren.",
   "bug_bounty_open_source_desc": "Jedes Repository in der Capgo Organisation ist Open Source. Sie können unseren Code überprüfen, auditieren und dazu beitragen.",
   "bug_bounty_open_source_title": "Open Source Code",

--- a/messages/en.json
+++ b/messages/en.json
@@ -275,7 +275,7 @@
   "bug_bounty_how_to_report_step_4": "Include the exact file path and line number(s) where the vulnerability exists",
   "bug_bounty_how_to_report_step_5": "Provide detailed steps to reproduce the issue and explain the security impact",
   "bug_bounty_how_to_report_title": "How to Report",
-  "bug_bounty_important_note": "If you cannot provide the exact line of code in GitHub where the problem exists, your report will not be eligible for the Bug Bounty program. Reports must be submitted through GitHub Security Advisory only.",
+  "bug_bounty_important_note": "If you cannot provide the exact line of code in GitHub where the problem exists, your report will not be eligible for the Bug Bounty program. Reports must be submitted through GitHub Security Advisory only. Payments are handled via Algora.io; please create an account there so we can pay you directly on the platform.",
   "bug_bounty_intro": "Capgo is committed to security and transparency. All our code is open source, and we welcome security researchers to help us identify vulnerabilities in our codebase.",
   "bug_bounty_open_source_desc": "Every repository in the Capgo organization is open source. You can review, audit, and contribute to our code.",
   "bug_bounty_open_source_title": "Open Source Code",

--- a/messages/es.json
+++ b/messages/es.json
@@ -275,7 +275,7 @@
   "bug_bounty_how_to_report_step_4": "Incluya la ruta exacta del archivo y el número de línea(s) donde existe la vulnerabilidad",
   "bug_bounty_how_to_report_step_5": "Proporcione pasos detallados para reproducir el problema y explique el impacto de seguridad",
   "bug_bounty_how_to_report_title": "Cómo Reportar",
-  "bug_bounty_important_note": "Si no puede proporcionar la línea exacta de código en GitHub donde existe el problema, su reporte no será elegible para el programa Bug Bounty. Los reportes deben enviarse únicamente a través de GitHub Security Advisory.",
+  "bug_bounty_important_note": "Si no puede proporcionar la línea exacta de código en GitHub donde existe el problema, su reporte no será elegible para el programa Bug Bounty. Los reportes deben enviarse únicamente a través de GitHub Security Advisory. Los pagos se gestionan a través de Algora.io. Cree una cuenta allí para que podamos pagarle directamente en la plataforma.",
   "bug_bounty_intro": "Capgo está comprometido con la seguridad y la transparencia. Todo nuestro código es de código abierto, y damos la bienvenida a investigadores de seguridad para ayudarnos a identificar vulnerabilidades en nuestra base de código.",
   "bug_bounty_open_source_desc": "Cada repositorio en la organización Capgo es de código abierto. Puede revisar, auditar y contribuir a nuestro código.",
   "bug_bounty_open_source_title": "Código Abierto",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -275,7 +275,7 @@
   "bug_bounty_how_to_report_step_4": "Incluez le chemin exact du fichier et le(s) numéro(s) de ligne où se trouve la vulnérabilité",
   "bug_bounty_how_to_report_step_5": "Fournissez des étapes détaillées pour reproduire le problème et expliquez l'impact sur la sécurité",
   "bug_bounty_how_to_report_title": "Comment Signaler",
-  "bug_bounty_important_note": "Si vous ne pouvez pas fournir la ligne exacte de code dans GitHub où le problème existe, votre rapport ne sera pas éligible au programme Bug Bounty. Les rapports doivent être soumis uniquement via GitHub Security Advisory.",
+  "bug_bounty_important_note": "Si vous ne pouvez pas fournir la ligne exacte de code dans GitHub où le problème existe, votre rapport ne sera pas éligible au programme Bug Bounty. Les rapports doivent être soumis uniquement via GitHub Security Advisory. Les paiements sont effectués via Algora.io. Veuillez y créer un compte afin que nous puissions vous payer directement sur la plateforme.",
   "bug_bounty_intro": "Capgo s'engage pour la sécurité et la transparence. Tout notre code est open source, et nous accueillons les chercheurs en sécurité pour nous aider à identifier les vulnérabilités dans notre code.",
   "bug_bounty_open_source_desc": "Chaque dépôt de l'organisation Capgo est open source. Vous pouvez examiner, auditer et contribuer à notre code.",
   "bug_bounty_open_source_title": "Code Open Source",

--- a/messages/id.json
+++ b/messages/id.json
@@ -275,7 +275,7 @@
   "bug_bounty_how_to_report_step_4": "Sertakan path file dan nomor baris yang tepat di mana kerentanan ada",
   "bug_bounty_how_to_report_step_5": "Berikan langkah-langkah detail untuk mereproduksi masalah dan jelaskan dampak keamanannya",
   "bug_bounty_how_to_report_title": "Cara Melaporkan",
-  "bug_bounty_important_note": "Jika Anda tidak dapat memberikan baris kode yang tepat di GitHub di mana masalah ada, laporan Anda tidak akan memenuhi syarat untuk program Bug Bounty. Laporan harus diajukan hanya melalui GitHub Security Advisory.",
+  "bug_bounty_important_note": "Jika Anda tidak dapat memberikan baris kode yang tepat di GitHub di mana masalah ada, laporan Anda tidak akan memenuhi syarat untuk program Bug Bounty. Laporan harus diajukan hanya melalui GitHub Security Advisory. Pembayaran dilakukan melalui Algora.io. Buat akun di sana agar kami dapat membayar Anda langsung melalui platform.",
   "bug_bounty_intro": "Capgo berkomitmen pada keamanan dan transparansi. Semua kode kami adalah open source, dan kami menyambut peneliti keamanan untuk membantu kami mengidentifikasi kerentanan dalam basis kode kami.",
   "bug_bounty_open_source_desc": "Setiap repositori di organisasi Capgo adalah open source. Anda dapat meninjau, mengaudit, dan berkontribusi pada kode kami.",
   "bug_bounty_open_source_title": "Kode Open Source",

--- a/messages/it.json
+++ b/messages/it.json
@@ -275,7 +275,7 @@
   "bug_bounty_how_to_report_step_4": "Includi il percorso esatto del file e il/i numero/i di riga dove esiste la vulnerabilità",
   "bug_bounty_how_to_report_step_5": "Fornisci passaggi dettagliati per riprodurre il problema e spiega l'impatto sulla sicurezza",
   "bug_bounty_how_to_report_title": "Come Segnalare",
-  "bug_bounty_important_note": "Se non riesci a fornire la riga esatta di codice in GitHub dove esiste il problema, il tuo report non sarà idoneo per il programma Bug Bounty. I report devono essere inviati esclusivamente tramite GitHub Security Advisory.",
+  "bug_bounty_important_note": "Se non riesci a fornire la riga esatta di codice in GitHub dove esiste il problema, il tuo report non sarà idoneo per il programma Bug Bounty. I report devono essere inviati esclusivamente tramite GitHub Security Advisory. I pagamenti vengono effettuati tramite Algora.io. Crea un account lì così possiamo pagarti direttamente sulla piattaforma.",
   "bug_bounty_intro": "Capgo è impegnata nella sicurezza e nella trasparenza. Tutto il nostro codice è open source, e accogliamo i ricercatori di sicurezza per aiutarci a identificare le vulnerabilità nel nostro codice.",
   "bug_bounty_open_source_desc": "Ogni repository nell'organizzazione Capgo è open source. Puoi rivedere, verificare e contribuire al nostro codice.",
   "bug_bounty_open_source_title": "Codice Open Source",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -275,7 +275,7 @@
   "bug_bounty_how_to_report_step_4": "脆弱性が存在する正確なファイルパスと行番号を含めてください",
   "bug_bounty_how_to_report_step_5": "問題を再現する詳細な手順を提供し、セキュリティへの影響を説明してください",
   "bug_bounty_how_to_report_title": "報告方法",
-  "bug_bounty_important_note": "問題が存在するGitHub上の正確なコード行を提供できない場合、あなたの報告はバグ報奨金プログラムの対象外となります。報告はGitHub Security Advisoryを通じてのみ提出する必要があります。",
+  "bug_bounty_important_note": "問題が存在するGitHub上の正確なコード行を提供できない場合、あなたの報告はバグ報奨金プログラムの対象外となります。報告はGitHub Security Advisoryを通じてのみ提出する必要があります。報酬の支払いはAlgora.ioで行います。そこでアカウントを作成していただき、プラットフォーム上で直接お支払いします。",
   "bug_bounty_intro": "Capgoはセキュリティと透明性に取り組んでいます。私たちのコードはすべてオープンソースであり、セキュリティ研究者の方々がコードベースの脆弱性を特定するお手伝いをしていただくことを歓迎しています。",
   "bug_bounty_open_source_desc": "Capgo組織内のすべてのリポジトリはオープンソースです。コードのレビュー、監査、貢献が可能です。",
   "bug_bounty_open_source_title": "オープンソースコード",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -275,7 +275,7 @@
   "bug_bounty_how_to_report_step_4": "취약점이 존재하는 정확한 파일 경로와 라인 번호를 포함합니다",
   "bug_bounty_how_to_report_step_5": "문제를 재현하는 자세한 단계를 제공하고 보안 영향을 설명합니다",
   "bug_bounty_how_to_report_title": "신고 방법",
-  "bug_bounty_important_note": "문제가 존재하는 GitHub의 정확한 코드 라인을 제공할 수 없는 경우, 귀하의 신고는 버그 바운티 프로그램 대상이 아닙니다. 신고는 반드시 GitHub Security Advisory를 통해서만 제출해야 합니다.",
+  "bug_bounty_important_note": "문제가 존재하는 GitHub의 정확한 코드 라인을 제공할 수 없는 경우, 귀하의 신고는 버그 바운티 프로그램 대상이 아닙니다. 신고는 반드시 GitHub Security Advisory를 통해서만 제출해야 합니다. 지급은 Algora.io를 통해 이루어집니다. 그곳에 계정을 만들어 주시면 플랫폼에서 직접 지급합니다.",
   "bug_bounty_intro": "Capgo는 보안과 투명성에 전념하고 있습니다. 모든 코드는 오픈소스이며, 코드베이스의 취약점을 식별하는 데 도움을 줄 보안 연구자들을 환영합니다.",
   "bug_bounty_open_source_desc": "Capgo 조직의 모든 리포지토리는 오픈소스입니다. 코드를 검토하고, 감사하고, 기여할 수 있습니다.",
   "bug_bounty_open_source_title": "오픈소스 코드",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -275,7 +275,7 @@
   "bug_bounty_how_to_report_step_4": "包含漏洞存在的精确文件路径和行号",
   "bug_bounty_how_to_report_step_5": "提供详细的重现步骤并解释安全影响",
   "bug_bounty_how_to_report_title": "如何报告",
-  "bug_bounty_important_note": "如果您无法提供问题所在的GitHub中精确的代码行，您的报告将不符合漏洞赏金计划的资格。报告必须仅通过GitHub Security Advisory提交。",
+  "bug_bounty_important_note": "如果您无法提供问题所在的GitHub中精确的代码行，您的报告将不符合漏洞赏金计划的资格。报告必须仅通过GitHub Security Advisory提交。奖励将通过 Algora.io 支付。请在该平台创建账户，我们将直接在平台上向您付款。",
   "bug_bounty_intro": "Capgo致力于安全和透明。我们所有的代码都是开源的，我们欢迎安全研究人员帮助我们识别代码库中的漏洞。",
   "bug_bounty_open_source_desc": "Capgo组织中的每个仓库都是开源的。您可以审查、审计和贡献我们的代码。",
   "bug_bounty_open_source_title": "开源代码",


### PR DESCRIPTION
Add an Algora.io payout note to the Bug Bounty important notice across locales so reporters know to create an account for direct payment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bug bounty program information across all supported languages to clarify that payments are processed via Algora.io and request participants to create an account on the platform to receive direct payments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->