### PR TITLE
Add GitHub raw link to doc copy menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@
 
 This is the source code for the Capgo website, built with [Astro](https://astro.build/).
 
+## Documentation
+
+- Live docs: https://capgo.app/docs/
+- Source files: `src/content/docs/docs` (English) and `src/content/docs/<locale>/docs` (localized)
+
 ## Development
 
 To start the development server, run:
@@ -39,27 +44,29 @@ The source code is licensed under the GNU AFFERO GENERAL PUBLIC license. See the
 
 ## 🚀 Project Structure
 
-Inside of your Astro project, you'll see the following folders and files:
+Key folders and files in this repo:
 
 ```
 /
 ├── public/
-│   └── favicon.svg
 ├── src/
 │   ├── components/
-│   │   └── Card.astro
+│   ├── content/
+│   │   ├── docs/              # Capgo documentation content (console guides, plugin docs, how-tos)
+│   │   ├── blog/              # Blog posts by locale
+│   │   ├── plugins-tutorials/ # Plugin tutorials by locale
+│   │   └── i18n/              # Starlight UI translations
 │   ├── layouts/
-│   │   └── Layout.astro
-│   └── pages/
-│       └── index.astro
+│   ├── pages/                 # Marketing pages + JSON endpoints
+│   ├── assets/
+│   ├── css/
+│   ├── config/
+│   └── content.config.ts      # Content collections config
+├── messages/                  # Paraglide UI strings
 └── package.json
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
-
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-Any static assets, like images, can be placed in the `public/` directory.
+Astro routes live in `src/pages/`. The docs site is powered by Starlight and content collections from `src/content`.
 
 ## 🧞 Commands
 

--- a/messages/de.json
+++ b/messages/de.json
@@ -2912,5 +2912,18 @@
   "your_live_update_solution_for_capacitor_apps": "Ihre Live-Update-Lösung für Capacitor-Apps",
   "youre_in_good_company": "Du bist in guter Gesellschaft.",
   "zero_trust_security": "Zero-Trust-Sicherheit",
-  "zero_vendor_lockin_pay_provider_directly": "Null Anbieterbindung, zahlen Sie Ihren Anbieter direkt."
+  "zero_vendor_lockin_pay_provider_directly": "Null Anbieterbindung, zahlen Sie Ihren Anbieter direkt.",
+  "copy_page": "Seite kopieren",
+  "copy_page_options": "Optionen zum Kopieren der Seite",
+  "copy_page_as_markdown": "Seite als Markdown für LLMs kopieren",
+  "view_as_markdown": "Als Markdown ansehen",
+  "view_page_as_plain_text": "Diese Seite als Klartext ansehen",
+  "view_raw_on_github": "Rohdatei auf GitHub ansehen",
+  "open_raw_on_github": "Die rohe Markdown-Datei auf GitHub öffnen",
+  "open_in_chatgpt": "In ChatGPT öffnen",
+  "open_in_claude": "In Claude öffnen",
+  "open_in_perplexity": "In Perplexity öffnen",
+  "ask_questions_about_page": "Fragen zu dieser Seite stellen",
+  "copied": "Kopiert!",
+  "failed_to_copy": "Kopieren fehlgeschlagen"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -2930,6 +2930,8 @@
   "copy_page_as_markdown": "Copy page as Markdown for LLMs",
   "view_as_markdown": "View as Markdown",
   "view_page_as_plain_text": "View this page as plain text",
+  "view_raw_on_github": "View raw on GitHub",
+  "open_raw_on_github": "Open the raw Markdown file on GitHub",
   "open_in_chatgpt": "Open in ChatGPT",
   "open_in_claude": "Open in Claude",
   "open_in_perplexity": "Open in Perplexity",

--- a/messages/es.json
+++ b/messages/es.json
@@ -2912,5 +2912,18 @@
   "your_live_update_solution_for_capacitor_apps": "Tu solución de actualización en vivo para aplicaciones de condensador",
   "youre_in_good_company": "Estás en buena compañía.",
   "zero_trust_security": "Seguridad de Cero Confianza",
-  "zero_vendor_lockin_pay_provider_directly": "cero bloqueo de proveedor, paga directamente a tu proveedor."
+  "zero_vendor_lockin_pay_provider_directly": "cero bloqueo de proveedor, paga directamente a tu proveedor.",
+  "copy_page": "Copiar página",
+  "copy_page_options": "Opciones para copiar la página",
+  "copy_page_as_markdown": "Copiar página como Markdown para LLMs",
+  "view_as_markdown": "Ver como Markdown",
+  "view_page_as_plain_text": "Ver esta página como texto sin formato",
+  "view_raw_on_github": "Ver raw en GitHub",
+  "open_raw_on_github": "Abrir el archivo Markdown raw en GitHub",
+  "open_in_chatgpt": "Abrir en ChatGPT",
+  "open_in_claude": "Abrir en Claude",
+  "open_in_perplexity": "Abrir en Perplexity",
+  "ask_questions_about_page": "Hacer preguntas sobre esta página",
+  "copied": "¡Copiado!",
+  "failed_to_copy": "Error al copiar"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2912,5 +2912,18 @@
   "your_live_update_solution_for_capacitor_apps": "Votre solution de mises à jour en direct pour les applications Capacitor",
   "youre_in_good_company": "Vous êtes en bonne compagnie.",
   "zero_trust_security": "Sécurité Zéro-Confiance",
-  "zero_vendor_lockin_pay_provider_directly": "aucune dépendance à un fournisseur, payez votre fournisseur directement."
+  "zero_vendor_lockin_pay_provider_directly": "aucune dépendance à un fournisseur, payez votre fournisseur directement.",
+  "copy_page": "Copier la page",
+  "copy_page_options": "Options de copie de la page",
+  "copy_page_as_markdown": "Copier la page en Markdown pour les LLMs",
+  "view_as_markdown": "Voir en Markdown",
+  "view_page_as_plain_text": "Voir cette page en texte brut",
+  "view_raw_on_github": "Voir le raw sur GitHub",
+  "open_raw_on_github": "Ouvrir le fichier Markdown raw sur GitHub",
+  "open_in_chatgpt": "Ouvrir dans ChatGPT",
+  "open_in_claude": "Ouvrir dans Claude",
+  "open_in_perplexity": "Ouvrir dans Perplexity",
+  "ask_questions_about_page": "Poser des questions sur cette page",
+  "copied": "Copié !",
+  "failed_to_copy": "Échec de la copie"
 }

--- a/messages/id.json
+++ b/messages/id.json
@@ -2912,5 +2912,18 @@
   "your_live_update_solution_for_capacitor_apps": "Solusi Pembaruan Langsung Anda untuk Aplikasi Kapasitor",
   "youre_in_good_company": "Anda tidak sendirian.",
   "zero_trust_security": "Keamanan Zero-Trust",
-  "zero_vendor_lockin_pay_provider_directly": "tanpa ketergantungan vendor, bayar langsung ke penyedia Anda."
+  "zero_vendor_lockin_pay_provider_directly": "tanpa ketergantungan vendor, bayar langsung ke penyedia Anda.",
+  "copy_page": "Salin halaman",
+  "copy_page_options": "Opsi menyalin halaman",
+  "copy_page_as_markdown": "Salin halaman sebagai Markdown untuk LLM",
+  "view_as_markdown": "Lihat sebagai Markdown",
+  "view_page_as_plain_text": "Lihat halaman ini sebagai teks biasa",
+  "view_raw_on_github": "Lihat raw di GitHub",
+  "open_raw_on_github": "Buka file Markdown raw di GitHub",
+  "open_in_chatgpt": "Buka di ChatGPT",
+  "open_in_claude": "Buka di Claude",
+  "open_in_perplexity": "Buka di Perplexity",
+  "ask_questions_about_page": "Ajukan pertanyaan tentang halaman ini",
+  "copied": "Tersalin!",
+  "failed_to_copy": "Gagal menyalin"
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -2912,5 +2912,18 @@
   "your_live_update_solution_for_capacitor_apps": "La tua soluzione di aggiornamento live per le app con Capacitor",
   "youre_in_good_company": "Sei in buona compagnia.",
   "zero_trust_security": "Sicurezza Zero-Trust",
-  "zero_vendor_lockin_pay_provider_directly": "nessun blocco del fornitore, paga direttamente il tuo fornitore."
+  "zero_vendor_lockin_pay_provider_directly": "nessun blocco del fornitore, paga direttamente il tuo fornitore.",
+  "copy_page": "Copia pagina",
+  "copy_page_options": "Opzioni di copia pagina",
+  "copy_page_as_markdown": "Copia pagina come Markdown per LLM",
+  "view_as_markdown": "Visualizza come Markdown",
+  "view_page_as_plain_text": "Visualizza questa pagina come testo semplice",
+  "view_raw_on_github": "Visualizza il raw su GitHub",
+  "open_raw_on_github": "Apri il file Markdown raw su GitHub",
+  "open_in_chatgpt": "Apri in ChatGPT",
+  "open_in_claude": "Apri in Claude",
+  "open_in_perplexity": "Apri in Perplexity",
+  "ask_questions_about_page": "Fai domande su questa pagina",
+  "copied": "Copiato!",
+  "failed_to_copy": "Copia non riuscita"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -2912,5 +2912,18 @@
   "your_live_update_solution_for_capacitor_apps": "キャパシタアプリのためのライブアップデートソリューション",
   "youre_in_good_company": "あなたは良い仲間と一緒にいます。",
   "zero_trust_security": "ゼロトラストセキュリティ",
-  "zero_vendor_lockin_pay_provider_directly": "ベンダーロックインゼロ、プロバイダーに直接支払いを行います。"
+  "zero_vendor_lockin_pay_provider_directly": "ベンダーロックインゼロ、プロバイダーに直接支払いを行います。",
+  "copy_page": "ページをコピー",
+  "copy_page_options": "ページコピーのオプション",
+  "copy_page_as_markdown": "LLM向けにMarkdownとしてページをコピー",
+  "view_as_markdown": "Markdownで表示",
+  "view_page_as_plain_text": "このページをプレーンテキストで表示",
+  "view_raw_on_github": "GitHubでrawを表示",
+  "open_raw_on_github": "GitHubでraw Markdownファイルを開く",
+  "open_in_chatgpt": "ChatGPTで開く",
+  "open_in_claude": "Claudeで開く",
+  "open_in_perplexity": "Perplexityで開く",
+  "ask_questions_about_page": "このページについて質問する",
+  "copied": "コピーしました！",
+  "failed_to_copy": "コピーに失敗しました"
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2912,5 +2912,18 @@
   "your_live_update_solution_for_capacitor_apps": "Capacitor 앱을 위한 실시간 업데이트 솔루션",
   "youre_in_good_company": "당신은 좋은 동료와 함께 있습니다.",
   "zero_trust_security": "제로 트러스트 보안",
-  "zero_vendor_lockin_pay_provider_directly": "공급 업체에 대한 제로 잠금, 공급 업체에 직접 지불하세요."
+  "zero_vendor_lockin_pay_provider_directly": "공급 업체에 대한 제로 잠금, 공급 업체에 직접 지불하세요.",
+  "copy_page": "페이지 복사",
+  "copy_page_options": "페이지 복사 옵션",
+  "copy_page_as_markdown": "LLM용 Markdown으로 페이지 복사",
+  "view_as_markdown": "Markdown으로 보기",
+  "view_page_as_plain_text": "이 페이지를 일반 텍스트로 보기",
+  "view_raw_on_github": "GitHub에서 raw 보기",
+  "open_raw_on_github": "GitHub에서 raw Markdown 파일 열기",
+  "open_in_chatgpt": "ChatGPT에서 열기",
+  "open_in_claude": "Claude에서 열기",
+  "open_in_perplexity": "Perplexity에서 열기",
+  "ask_questions_about_page": "이 페이지에 대해 질문하기",
+  "copied": "복사됨!",
+  "failed_to_copy": "복사 실패"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -2912,5 +2912,18 @@
   "your_live_update_solution_for_capacitor_apps": "您的电容器应用实时更新解决方案",
   "youre_in_good_company": "你处在好的环境中。",
   "zero_trust_security": "零信任安全性",
-  "zero_vendor_lockin_pay_provider_directly": "零供应商锁定，直接向您的提供商支付。"
+  "zero_vendor_lockin_pay_provider_directly": "零供应商锁定，直接向您的提供商支付。",
+  "copy_page": "复制页面",
+  "copy_page_options": "页面复制选项",
+  "copy_page_as_markdown": "为 LLM 复制页面为 Markdown",
+  "view_as_markdown": "查看 Markdown",
+  "view_page_as_plain_text": "以纯文本查看此页面",
+  "view_raw_on_github": "在 GitHub 查看 raw",
+  "open_raw_on_github": "在 GitHub 打开 raw Markdown 文件",
+  "open_in_chatgpt": "在 ChatGPT 中打开",
+  "open_in_claude": "在 Claude 中打开",
+  "open_in_perplexity": "在 Perplexity 中打开",
+  "ask_questions_about_page": "就此页面提问",
+  "copied": "已复制！",
+  "failed_to_copy": "复制失败"
 }

--- a/src/components/doc/CopyPage.astro
+++ b/src/components/doc/CopyPage.astro
@@ -2,7 +2,7 @@
 import type { StarlightRouteData } from '@astrojs/starlight/route-data'
 import * as m from '@/paraglide/messages'
 
-const { entry } = Astro.locals.starlightRoute as StarlightRouteData
+const { entry, editUrl } = Astro.locals.starlightRoute as StarlightRouteData
 const pageSlug = entry?.slug || ''
 
 const translations = {
@@ -11,6 +11,8 @@ const translations = {
   copyPageAsMarkdown: m.copy_page_as_markdown({}, { locale: Astro.locals.locale }),
   viewAsMarkdown: m.view_as_markdown({}, { locale: Astro.locals.locale }),
   viewPageAsPlainText: m.view_page_as_plain_text({}, { locale: Astro.locals.locale }),
+  viewRawOnGithub: m.view_raw_on_github({}, { locale: Astro.locals.locale }),
+  openRawOnGithub: m.open_raw_on_github({}, { locale: Astro.locals.locale }),
   openInChatgpt: m.open_in_chatgpt({}, { locale: Astro.locals.locale }),
   openInClaude: m.open_in_claude({}, { locale: Astro.locals.locale }),
   openInPerplexity: m.open_in_perplexity({}, { locale: Astro.locals.locale }),
@@ -51,6 +53,21 @@ const translations = {
       <div>
         <div class="menu-item-title">{translations.viewAsMarkdown}</div>
         <div class="menu-item-subtitle">{translations.viewPageAsPlainText}</div>
+      </div>
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="external-icon">
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+        <polyline points="15 3 21 3 21 9"/>
+        <line x1="10" x2="21" y1="14" y2="3"/>
+      </svg>
+    </a>
+
+    <a class="menu-item view-github-raw" role="menuitem" target="_blank" rel="noopener noreferrer" hidden>
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <text x="2" y="18" font-size="16" font-weight="bold" fill="currentColor">GH</text>
+      </svg>
+      <div>
+        <div class="menu-item-title">{translations.viewRawOnGithub}</div>
+        <div class="menu-item-subtitle">{translations.openRawOnGithub}</div>
       </div>
       <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="external-icon">
         <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
@@ -110,7 +127,7 @@ const translations = {
   </div>
 </div>
 
-<script is:inline define:vars={{ translations }}>
+<script is:inline define:vars={{ translations, editUrl: editUrl?.toString() ?? '' }}>
   // Toggle menu visibility
   const buttons = document.querySelectorAll('.copy-page-button')
   buttons.forEach((button) => {
@@ -233,6 +250,28 @@ const translations = {
     if (pageSlug) {
       // Link to the local .md file served by vite-plugin-static-copy
       link.href = `/${pageSlug}.md`
+    }
+  })
+
+  // View raw on GitHub
+  function getRawGithubUrl() {
+    if (!editUrl) return ''
+    if (editUrl.includes('/edit/')) {
+      return editUrl.replace('/edit/', '/raw/')
+    }
+    if (editUrl.includes('/blob/')) {
+      return editUrl.replace('/blob/', '/raw/')
+    }
+    return editUrl
+  }
+
+  document.querySelectorAll('.view-github-raw').forEach((link) => {
+    const rawUrl = getRawGithubUrl()
+    if (rawUrl) {
+      link.href = rawUrl
+      link.hidden = false
+    } else {
+      link.hidden = true
     }
   })
 


### PR DESCRIPTION
Adds a raw GitHub link to the doc copy menu and wires it to edit URLs. Updates README documentation/structure notes. Adds copy-menu translations across locales.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub raw content viewing option
  * Added page copying in multiple formats (Markdown, plain text)
  * Integrated AI tool shortcuts (ChatGPT, Claude, Perplexity)
  * Added page-specific questioning feature
  * Expanded localization across 9 languages with new UI action labels

* **Documentation**
  * Reorganized and clarified project structure documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->