### PR TITLE
Fix mobile hero margins

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -159,7 +159,7 @@ const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. $
         </div>
       </div>
 
-      <div class="relative z-10 max-w-4xl pt-16 mx-auto text-center sm:pt-24 lg:pt-32">
+      <div class="relative z-10 max-w-4xl px-4 pt-16 mx-auto text-center sm:px-6 sm:pt-24 lg:px-0 lg:pt-32">
         <h1 class="text-4xl font-bold leading-tight tracking-tight sm:text-5xl sm:leading-tight lg:text-6xl lg:leading-tight xl:text-7xl font-pj">
           {m.instant_updates_for_your({}, { locale: Astro.locals.locale })}
           <br />


### PR DESCRIPTION
Add mobile horizontal padding to the hero text wrapper so title and subtitle align with safe margins on small screens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved hero section layout with enhanced horizontal padding on mobile devices, ensuring better content spacing and alignment across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->