### PR TITLE
Clarify bundle naming in Public API docs

### DIFF
--- a/src/content/docs/docs/public-api/app.mdx
+++ b/src/content/docs/docs/public-api/app.mdx
@@ -43,6 +43,8 @@ For getting a specific app:
 
 #### Response Type
 
+Note: `last_version` refers to the last bundle (version) uploaded for the app.
+
 ```typescript
 interface App {
   app_id: string
@@ -50,7 +52,7 @@ interface App {
   default_upload_channel: string
   icon_url: string
   id: string | null
-  last_version: string | null
+  last_version: string | null // last bundle (version) name
   name: string | null
   owner_org: string
   retention: number

--- a/src/content/docs/docs/public-api/bundles.mdx
+++ b/src/content/docs/docs/public-api/bundles.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Bundles"
-description: "Detailed guide for managing Capgo Bundles, covering listing, deleting, versioning, and storage optimization for app update packages."
+description: "Detailed guide for managing Capgo Bundles, covering listing, deleting, bundle (version) management, and storage optimization for app update packages."
 sidebar:
   order: 8
 ---
@@ -9,8 +9,8 @@ Bundles are the core update packages in Capgo. Each bundle contains the web asse
 
 ## Understanding Bundles
 
-A bundle represents a specific version of your app's web content and includes:
-- **Version**: Semantic version number of the bundle
+A bundle represents a specific bundle (version) of your app's web content and includes:
+- **Bundle (version)**: Semantic version number for the bundle
 - **Checksum**: Unique hash to verify bundle integrity
 - **Storage Info**: Details about where and how the bundle is stored
 - **Native Requirements**: Minimum native app version requirements
@@ -39,6 +39,8 @@ npm install adm-zip @tomasklaen/checksum
 ```
 
 #### Create Zip Bundle with JavaScript (Same as Capgo CLI)
+
+Note: In the examples below, `version` refers to the bundle (version) name used by the API.
 
 ```javascript
 const fs = require('node:fs');
@@ -172,7 +174,7 @@ Register the external bundle with Capgo using direct API calls:
 async function registerWithCapgo(appId, version, bundleUrl, checksum, apiKey) {
   const fetch = require('node-fetch');
   
-  // Create bundle version
+  // Create bundle (version)
   const response = await fetch('https://api.capgo.app/bundle/', {
     method: 'POST',
     headers: {
@@ -203,7 +205,7 @@ async function registerWithCapgo(appId, version, bundleUrl, checksum, apiKey) {
 | Parameter | Description | Required |
 |-----------|-------------|----------|
 | `app_id` | Your app identifier | Yes |
-| `version` | Semantic version (e.g., "1.2.3") | Yes |
+| `version` | Bundle (version) semantic version (e.g., "1.2.3") | Yes |
 | `external_url` | **Publicly accessible** HTTPS URL where bundle can be downloaded (no auth required) | Yes |
 | `checksum` | SHA256 checksum of the zip file | Yes |
 
@@ -334,10 +336,10 @@ main();
 
 ## Best Practices
 
-1. **Version Management**: Use semantic versioning consistently
+1. **Bundle (version) Management**: Use semantic versioning consistently
 2. **Storage Optimization**: Remove unused bundles periodically
-3. **Version Compatibility**: Set appropriate minimum native version requirements
-4. **Backup Strategy**: Maintain backups of critical bundle versions
+3. **Bundle (version) Compatibility**: Set appropriate minimum native version requirements
+4. **Backup Strategy**: Maintain backups of critical bundles (versions)
 
 ## Endpoints
 
@@ -513,7 +515,7 @@ Update bundle metadata such as link and comment information.
 ```typescript
 interface UpdateMetadataBody {
   app_id: string
-  version_id: number
+  version_id: number // bundle (version) id
   link?: string
   comment?: string
 }
@@ -546,14 +548,14 @@ curl -X POST \
 
 `https://api.capgo.app/bundle/`
 
-Set a bundle to a specific channel. This links a bundle version to a channel for distribution.
+Set a bundle to a specific channel. This links a bundle (version) to a channel for distribution.
 
 #### Request Body
 
 ```typescript
 interface SetChannelBody {
   app_id: string
-  version_id: number
+  version_id: number // bundle (version) id
   channel_id: number
 }
 ```
@@ -592,7 +594,7 @@ Common error scenarios and their responses:
   "status": "KO"
 }
 
-// Invalid version format
+// Invalid bundle (version) format
 {
   "error": "Invalid version format",
   "status": "KO"
@@ -613,9 +615,9 @@ Common error scenarios and their responses:
 
 ## Common Use Cases
 
-1. **Cleanup Old Versions**
+1. **Cleanup Old Bundles (Versions)**
 ```typescript
-// Delete outdated beta versions
+// Delete outdated beta bundles (versions)
 {
   "app_id": "app_123",
   "version": "1.0.0-beta.1"
@@ -634,5 +636,5 @@ Common error scenarios and their responses:
 
 1. **Retention Policy**: Define how long to keep old bundles
 2. **Size Management**: Monitor bundle sizes and storage usage
-3. **Backup Strategy**: Consider backing up critical versions
+3. **Backup Strategy**: Consider backing up critical bundles (versions)
 4. **Cost Optimization**: Remove unnecessary bundles to optimize storage costs 

--- a/src/content/docs/docs/public-api/channels.mdx
+++ b/src/content/docs/docs/public-api/channels.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Channels"
-description: "Guide to managing app update channels in Capgo, covering version control, platform targeting, and update policies."
+description: "Guide to managing app update channels in Capgo, covering bundle (version) control, platform targeting, and update policies."
 sidebar:
   order: 6
 ---
@@ -11,7 +11,7 @@ Channels are the core mechanism for managing app updates in Capgo. They allow yo
 
 A channel represents a distribution track for your app updates. Each channel can be configured with specific rules and constraints:
 
-- **Version Control**: Specify which version users receive
+- **Bundle (version) Control**: Specify which bundle (version) users receive
 - **Platform Targeting**: Target specific platforms (iOS/Android)
 - **Update Policies**: Control how updates are delivered
 - **Device Restrictions**: Manage which devices can access updates
@@ -19,7 +19,7 @@ A channel represents a distribution track for your app updates. Each channel can
 ## Channel Configuration Options
 
 - **public**: Set as default channel for new devices
-- **disableAutoUpdateUnderNative**: Prevent updates when the device's native app version is newer than the update version available in the channel (e.g., device is on version 1.2.3, but channel has 1.2.2)
+- **disableAutoUpdateUnderNative**: Prevent updates when the device's native app version is newer than the update bundle (version) available in the channel (e.g., device is on native app version 1.2.3, but channel has bundle (version) 1.2.2)
 - **disableAutoUpdate**: Control update behavior ("major", "minor", "version_number", "none")
 - **ios/android**: Enable/disable for specific platforms
 - **allow_device_self_set**: Let devices choose their channel
@@ -31,7 +31,7 @@ A channel represents a distribution track for your app updates. Each channel can
 1. **Testing Channel**: Maintain a testing channel for internal validation
 2. **Staged Rollout**: Use multiple channels for gradual update deployment
 3. **Platform Separation**: Create separate channels for iOS and Android when needed
-4. **Version Control**: Use semantic versioning for clear update paths
+4. **Bundle (version) Control**: Use semantic versioning for clear update paths
 
 ## Endpoints
 
@@ -48,7 +48,7 @@ type disable_update = "major" | "minor" | "version_number" | "none"
 interface ChannelSet {
   app_id: string
   channel: string
-  version?: string
+  version?: string // bundle (version) name
   public?: boolean
   disableAutoUpdateUnderNative?: boolean
   disableAutoUpdate?: disable_update
@@ -122,7 +122,7 @@ interface Channel {
     created_at: string;
     name: string;
     app_id: string;
-    version: {
+    version: { // bundle (version) assigned to the channel
         id: number,
         name: string
     };
@@ -135,6 +135,8 @@ interface Channel {
     allow_dev: boolean;
 }
 ```
+
+In the response below, `version` refers to the bundle (version) assigned to the channel.
 
 #### Example Response
 
@@ -209,7 +211,7 @@ Common error scenarios and their responses:
   "status": "KO"
 }
 
-// Invalid version format
+// Invalid bundle (version) format
 {
   "error": "Invalid version format. Use semantic versioning",
   "status": "KO"

--- a/src/content/docs/docs/public-api/devices.mdx
+++ b/src/content/docs/docs/public-api/devices.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Devices"
-description: "Docs for managing devices via Capgo API, covering tracking, versioning, and channel assignments for app installations."
+description: "Docs for managing devices via Capgo API, covering tracking, bundle (version) assignment, and channel management for app installations."
 sidebar:
   order: 7
 ---
 
-Devices represent individual installations of your app that are managed by Capgo. The Devices API allows you to track and manage devices, including their versions, channels, and update status.
+Devices represent individual installations of your app that are managed by Capgo. The Devices API allows you to track and manage devices, including their bundles (versions), channels, and update status.
 
 :::note[Data Retention]
 Device data is retained for **90 days** from the last device activity. Devices that haven't connected to Capgo within this period will be automatically removed from the system. Active devices are continuously tracked as they check for updates.
@@ -15,14 +15,14 @@ Device data is retained for **90 days** from the last device activity. Devices t
 
 Each device has unique characteristics and states:
 - **Platform**: iOS or Android
-- **Version**: Current bundle version and native build version
+- **Bundle (version)**: Current bundle (version) and native build version
 - **Environment**: Production or development, emulator or physical device
 - **Channel**: Current update channel assignment
 - **Custom ID**: Optional identifier for your own tracking purposes
 
 ## Best Practices
 
-1. **Version Tracking**: Monitor device versions to ensure update adoption
+1. **Bundle (version) Tracking**: Monitor device bundle (version) adoption to ensure update uptake
 2. **Channel Management**: Assign devices to appropriate channels based on testing needs
 3. **Environment Awareness**: Handle different environments (prod/dev/emulator) appropriately
 4. **Custom Identification**: Use custom IDs to integrate with your existing systems
@@ -33,7 +33,7 @@ Each device has unique characteristics and states:
 
 `https://api.capgo.app/device/`
 
-Link a device to a specific version or channel.
+Link a device to a specific bundle (version) or channel.
 
 #### Request Body
 
@@ -41,7 +41,7 @@ Link a device to a specific version or channel.
 interface DeviceLink {
   app_id: string
   device_id: string
-  version_id?: string // version name
+  version_id?: string // bundle (version) name
   channel?: string    // channel name
 }
 ```
@@ -111,8 +111,8 @@ interface Device {
   updated_at: string;
   device_id: string;
   custom_id: string;
-  version?: number;
-  version_name: string | null;
+  version?: number; // bundle (version) id
+  version_name: string | null; // bundle (version) name
   channel?: string;
   app_id: string;
   platform: "ios" | "android";
@@ -134,8 +134,8 @@ interface Device {
   updated_at: string;
   device_id: string;
   custom_id: string;
-  version?: number;
-  version_name: string | null;
+  version?: number; // bundle (version) id
+  version_name: string | null; // bundle (version) name
   channel?: string;
   app_id: string;
   platform: "ios" | "android";
@@ -245,7 +245,7 @@ Common error scenarios and their responses:
   "status": "KO"
 }
 
-// Invalid version
+// Invalid bundle (version)
 {
   "error": "Version not found",
   "status": "KO"
@@ -291,7 +291,7 @@ Common error scenarios and their responses:
 
 ## Tips for Device Management
 
-1. **Monitoring**: Regularly check device status and version distribution
+1. **Monitoring**: Regularly check device status and bundle (version) distribution
 2. **Testing**: Use custom IDs to identify test devices easily
 3. **Troubleshooting**: Track device updates and channel assignments
-4. **Version Control**: Monitor native app versions to ensure compatibility 
+4. **Native Version Control**: Monitor native app versions to ensure compatibility 

--- a/src/content/docs/docs/public-api/index.mdx
+++ b/src/content/docs/docs/public-api/index.mdx
@@ -80,19 +80,19 @@ Example error response:
 
 <LinkCard
 	title="Channels"
-	description="Control app update channels, versions, and update policies"
+	description="Control app update channels, bundles (versions), and update policies"
 	href="/docs/public-api/channels/"
 />
 
 <LinkCard
 	title="Devices"
-	description="Track and manage devices running your app, including version and channel assignments"
+	description="Track and manage devices running your app, including bundle (version) and channel assignments"
 	href="/docs/public-api/devices/"
 />
 
 <LinkCard
 	title="Bundles"
-	description="Handle app bundles, including uploading, listing, and managing versions"
+	description="Handle app bundles, including uploading, listing, and managing bundles (versions)"
 	href="/docs/public-api/bundles/"
 />
 

--- a/src/content/docs/docs/public-api/organizations.mdx
+++ b/src/content/docs/docs/public-api/organizations.mdx
@@ -150,7 +150,7 @@ curl -X PUT \
 
 `https://api.capgo.app/organization/`
 
-Delete an existing organization. Requires admin role. This action is irreversible and will remove all associated apps, versions, and resources.
+Delete an existing organization. Requires admin role. This action is irreversible and will remove all associated apps, bundles (versions), and resources.
 
 #### Query Parameters
 

--- a/src/content/docs/docs/public-api/statistics.mdx
+++ b/src/content/docs/docs/public-api/statistics.mdx
@@ -143,7 +143,7 @@ curl -H "authorization: your-api-key" \
 
 ### GET /statistics/app/:app_id/bundle_usage
 
-Get bundle usage statistics for a specific app, showing the distribution of versions among users over a specified period.
+Get bundle usage statistics for a specific app, showing the distribution of bundles (versions) among users over a specified period.
 
 #### Query Parameters
 
@@ -221,7 +221,7 @@ Common error scenarios and their responses:
 2. **Resource Optimization**: Track storage and bandwidth usage to optimize costs
 3. **Capacity Planning**: Use trends to plan for future resource needs
 4. **Usage Reports**: Generate periodic usage reports for stakeholders
-5. **Version Distribution Analysis**: Understand how users are distributed across different app versions with bundle usage statistics
+5. **Bundle (version) Distribution Analysis**: Understand how users are distributed across different app bundles (versions) with bundle usage statistics
 
 ## Tips for Analysis
 
@@ -229,4 +229,4 @@ Common error scenarios and their responses:
 2. **Track Ratios**: Monitor bandwidth per user or storage per app
 3. **Set Alerts**: Create alerts for unusual spikes in usage
 4. **Regular Backups**: Export statistics regularly for historical analysis
-5. **Version Adoption**: Use bundle usage to track adoption rates of new versions
+5. **Bundle (version) Adoption**: Use bundle usage to track adoption rates of new bundles (versions)


### PR DESCRIPTION
Update Public API docs to emphasize bundle naming while keeping API fields intact. Add clarifying notes where version fields refer to bundle names or IDs.