### PR TITLE
Add subprocessors page

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -3035,5 +3035,11 @@
   "appflow_support_open_title": "Open source plugins. Optional paid support.",
   "appflow_support_open_desc": "Every Capgo plugin is open source, so you can audit, fork, and self-host if you want. If you need guaranteed response times or migration help, paid support is optional - <a href=\"{url}\" class=\"text-emerald-300 hover:underline\">see support options</a>.",
   "appflow_enterprise_help_title": "Enterprise plugins and paid help (optional)",
-  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>."
+  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>.",
+  "subprocessors": "Subprocessors",
+  "subprocessors_description": "List of third-party subprocessors used to deliver Capgo.",
+  "subprocessors_title": "Subprocessors",
+  "subprocessors_intro": "Capgo relies on trusted third-party subprocessors to provide, secure, and improve the service. The list below describes the vendors and how they are used.",
+  "subprocessors_table_vendor": "Subprocessor",
+  "subprocessors_table_purpose": "Purpose"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -3064,5 +3064,11 @@
   "appflow_support_open_title": "Open source plugins. Optional paid support.",
   "appflow_support_open_desc": "Every Capgo plugin is open source, so you can audit, fork, and self-host if you want. If you need guaranteed response times or migration help, paid support is optional - <a href=\"{url}\" class=\"text-emerald-300 hover:underline\">see support options</a>.",
   "appflow_enterprise_help_title": "Enterprise plugins and paid help (optional)",
-  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>."
+  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>.",
+  "subprocessors": "Subprocessors",
+  "subprocessors_description": "List of third-party subprocessors used to deliver Capgo.",
+  "subprocessors_title": "Subprocessors",
+  "subprocessors_intro": "Capgo relies on trusted third-party subprocessors to provide, secure, and improve the service. The list below describes the vendors and how they are used.",
+  "subprocessors_table_vendor": "Subprocessor",
+  "subprocessors_table_purpose": "Purpose"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -3035,5 +3035,11 @@
   "appflow_support_open_title": "Open source plugins. Optional paid support.",
   "appflow_support_open_desc": "Every Capgo plugin is open source, so you can audit, fork, and self-host if you want. If you need guaranteed response times or migration help, paid support is optional - <a href=\"{url}\" class=\"text-emerald-300 hover:underline\">see support options</a>.",
   "appflow_enterprise_help_title": "Enterprise plugins and paid help (optional)",
-  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>."
+  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>.",
+  "subprocessors": "Subprocessors",
+  "subprocessors_description": "List of third-party subprocessors used to deliver Capgo.",
+  "subprocessors_title": "Subprocessors",
+  "subprocessors_intro": "Capgo relies on trusted third-party subprocessors to provide, secure, and improve the service. The list below describes the vendors and how they are used.",
+  "subprocessors_table_vendor": "Subprocessor",
+  "subprocessors_table_purpose": "Purpose"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -3035,5 +3035,11 @@
   "appflow_support_open_title": "Open source plugins. Optional paid support.",
   "appflow_support_open_desc": "Every Capgo plugin is open source, so you can audit, fork, and self-host if you want. If you need guaranteed response times or migration help, paid support is optional - <a href=\"{url}\" class=\"text-emerald-300 hover:underline\">see support options</a>.",
   "appflow_enterprise_help_title": "Enterprise plugins and paid help (optional)",
-  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>."
+  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>.",
+  "subprocessors": "Subprocessors",
+  "subprocessors_description": "List of third-party subprocessors used to deliver Capgo.",
+  "subprocessors_title": "Subprocessors",
+  "subprocessors_intro": "Capgo relies on trusted third-party subprocessors to provide, secure, and improve the service. The list below describes the vendors and how they are used.",
+  "subprocessors_table_vendor": "Subprocessor",
+  "subprocessors_table_purpose": "Purpose"
 }

--- a/messages/id.json
+++ b/messages/id.json
@@ -3035,5 +3035,11 @@
   "appflow_support_open_title": "Open source plugins. Optional paid support.",
   "appflow_support_open_desc": "Every Capgo plugin is open source, so you can audit, fork, and self-host if you want. If you need guaranteed response times or migration help, paid support is optional - <a href=\"{url}\" class=\"text-emerald-300 hover:underline\">see support options</a>.",
   "appflow_enterprise_help_title": "Enterprise plugins and paid help (optional)",
-  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>."
+  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>.",
+  "subprocessors": "Subprocessors",
+  "subprocessors_description": "List of third-party subprocessors used to deliver Capgo.",
+  "subprocessors_title": "Subprocessors",
+  "subprocessors_intro": "Capgo relies on trusted third-party subprocessors to provide, secure, and improve the service. The list below describes the vendors and how they are used.",
+  "subprocessors_table_vendor": "Subprocessor",
+  "subprocessors_table_purpose": "Purpose"
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -3035,5 +3035,11 @@
   "appflow_support_open_title": "Open source plugins. Optional paid support.",
   "appflow_support_open_desc": "Every Capgo plugin is open source, so you can audit, fork, and self-host if you want. If you need guaranteed response times or migration help, paid support is optional - <a href=\"{url}\" class=\"text-emerald-300 hover:underline\">see support options</a>.",
   "appflow_enterprise_help_title": "Enterprise plugins and paid help (optional)",
-  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>."
+  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>.",
+  "subprocessors": "Subprocessors",
+  "subprocessors_description": "List of third-party subprocessors used to deliver Capgo.",
+  "subprocessors_title": "Subprocessors",
+  "subprocessors_intro": "Capgo relies on trusted third-party subprocessors to provide, secure, and improve the service. The list below describes the vendors and how they are used.",
+  "subprocessors_table_vendor": "Subprocessor",
+  "subprocessors_table_purpose": "Purpose"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -3035,5 +3035,11 @@
   "appflow_support_open_title": "Open source plugins. Optional paid support.",
   "appflow_support_open_desc": "Every Capgo plugin is open source, so you can audit, fork, and self-host if you want. If you need guaranteed response times or migration help, paid support is optional - <a href=\"{url}\" class=\"text-emerald-300 hover:underline\">see support options</a>.",
   "appflow_enterprise_help_title": "Enterprise plugins and paid help (optional)",
-  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>."
+  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>.",
+  "subprocessors": "Subprocessors",
+  "subprocessors_description": "List of third-party subprocessors used to deliver Capgo.",
+  "subprocessors_title": "Subprocessors",
+  "subprocessors_intro": "Capgo relies on trusted third-party subprocessors to provide, secure, and improve the service. The list below describes the vendors and how they are used.",
+  "subprocessors_table_vendor": "Subprocessor",
+  "subprocessors_table_purpose": "Purpose"
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -3035,5 +3035,11 @@
   "appflow_support_open_title": "Open source plugins. Optional paid support.",
   "appflow_support_open_desc": "Every Capgo plugin is open source, so you can audit, fork, and self-host if you want. If you need guaranteed response times or migration help, paid support is optional - <a href=\"{url}\" class=\"text-emerald-300 hover:underline\">see support options</a>.",
   "appflow_enterprise_help_title": "Enterprise plugins and paid help (optional)",
-  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>."
+  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>.",
+  "subprocessors": "Subprocessors",
+  "subprocessors_description": "List of third-party subprocessors used to deliver Capgo.",
+  "subprocessors_title": "Subprocessors",
+  "subprocessors_intro": "Capgo relies on trusted third-party subprocessors to provide, secure, and improve the service. The list below describes the vendors and how they are used.",
+  "subprocessors_table_vendor": "Subprocessor",
+  "subprocessors_table_purpose": "Purpose"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -3035,5 +3035,11 @@
   "appflow_support_open_title": "Open source plugins. Optional paid support.",
   "appflow_support_open_desc": "Every Capgo plugin is open source, so you can audit, fork, and self-host if you want. If you need guaranteed response times or migration help, paid support is optional - <a href=\"{url}\" class=\"text-emerald-300 hover:underline\">see support options</a>.",
   "appflow_enterprise_help_title": "Enterprise plugins and paid help (optional)",
-  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>."
+  "appflow_enterprise_help_desc": "If your Appflow stack includes Ionic enterprise plugins, use the <a href=\"{pluginsUrl}\" class=\"text-emerald-300 hover:underline\">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href=\"{supportUrl}\" class=\"text-emerald-300 hover:underline\">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href=\"{migrationUrl}\" class=\"text-emerald-300 hover:underline\">learn more</a>.",
+  "subprocessors": "Subprocessors",
+  "subprocessors_description": "List of third-party subprocessors used to deliver Capgo.",
+  "subprocessors_title": "Subprocessors",
+  "subprocessors_intro": "Capgo relies on trusted third-party subprocessors to provide, secure, and improve the service. The list below describes the vendors and how they are used.",
+  "subprocessors_table_vendor": "Subprocessor",
+  "subprocessors_table_purpose": "Purpose"
 }

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -128,6 +128,7 @@ const navigation: Record<string, NavigationItem[]> = {
     { name: m.bug_bounty({}, { locale: Astro.locals.locale }), href: getRelativeLocaleUrl(Astro.locals.locale, 'bug-bounty') },
     { name: m.dp({}, { locale: Astro.locals.locale }), href: getRelativeLocaleUrl(Astro.locals.locale, 'dp') },
     { name: m.dpa({}, { locale: Astro.locals.locale }), href: getRelativeLocaleUrl(Astro.locals.locale, 'dpa') },
+    { name: m.subprocessors({}, { locale: Astro.locals.locale }), href: getRelativeLocaleUrl(Astro.locals.locale, 'subprocessors') },
   ],
   hero: [
     {

--- a/src/pages/subprocessors.astro
+++ b/src/pages/subprocessors.astro
@@ -1,0 +1,88 @@
+---
+import Layout from '@/layouts/Layout.astro'
+import * as m from '@/paraglide/messages'
+import { defaultLocale } from '@/services/locale'
+
+const locale = Astro.locals.locale
+const title = [Astro.locals.runtimeConfig.public.brand, m.subprocessors({}, { locale })].join(' | ')
+const description = m.subprocessors_description({}, { locale })
+
+const content = { title, description }
+
+const subprocessors = [
+  {
+    name: 'Supabase',
+    purpose: 'Primary database',
+  },
+  {
+    name: 'Cloudflare',
+    purpose: 'Edge CDN, Workers runtime, Durable Objects, and security services',
+  },
+  {
+    name: 'PlanetScale',
+    purpose: 'Read replicas for database scaling',
+  },
+  {
+    name: 'GitHub',
+    purpose: 'Source code hosting',
+  },
+  {
+    name: 'CodeRabbit',
+    purpose: 'Automated code review',
+  },
+  {
+    name: 'SonarCloud',
+    purpose: 'Static code analysis and quality checks',
+  },
+  {
+    name: 'Sentry',
+    purpose: 'Error monitoring and performance tracking',
+  },
+  {
+    name: 'Stripe',
+    purpose: 'Payments and billing',
+  },
+  {
+    name: 'Bento',
+    purpose: 'Email marketing and lifecycle messaging',
+  },
+  {
+    name: 'Depot',
+    purpose: 'Build acceleration and caching',
+  },
+]
+---
+
+<Layout content={content}>
+  <div class="py-8 m-auto prose-sm prose prose-invert">
+    {
+      locale !== defaultLocale && (
+        <span class="text-xs">
+          Note: This is an automatically translated page from its English source. Only the English version should be used for legal actions. Please refer to the English source for
+          legal matters.
+        </span>
+      )
+    }
+    <h1>{m.subprocessors_title({}, { locale })}</h1>
+    <p><em>{m.last_update({}, { locale })}: February 4, 2026</em></p>
+    <p>{m.subprocessors_intro({}, { locale })}</p>
+    <div class="overflow-x-auto">
+      <table>
+        <thead>
+          <tr>
+            <th>{m.subprocessors_table_vendor({}, { locale })}</th>
+            <th>{m.subprocessors_table_purpose({}, { locale })}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {subprocessors.map((item) => (
+            <tr>
+              <td>{item.name}</td>
+              <td>{item.purpose}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</Layout>


### PR DESCRIPTION
Adds a subprocessors legal page and links it from the footer. Includes the current vendor list and a last updated date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Subprocessors section displaying information about third-party vendors and their purposes within the platform
  * Available in all supported languages
  * Added navigation link in the footer for easy access to subprocessors information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->