### PR TITLE
Add bug bounty payment timing note

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -284,6 +284,7 @@
   "bug_bounty_conduct_rule_2": "Do not spam us. More than three emails in a single day is considered spam and will be blocked.",
   "bug_bounty_conduct_rule_3": "We do not pay for reports that ignore these rules or are spam.",
   "bug_bounty_conduct_rule_4": "Only in-scope reports that follow this bug bounty program are accepted; anything else may be blocked.",
+  "bug_bounty_payment_note": "Payments are issued only after we have identified the issue, fixed it, opened a pull request, and you have verified after release that the fix works for you. This process typically takes 3-5 days. Please do not send messages like \"to get paid\"; payment happens only once the release is live and you've tested and validated the fix.",
   "build_from_anywhere": "Bauen Sie von jeder Maschine aus",
   "build_hours": "Bauzeiten",
   "build_in_public_on_twitter": "In der \u00d6ffentlichkeit auf Twitter bauen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -284,6 +284,7 @@
   "bug_bounty_conduct_rule_2": "Do not spam us. More than three emails in a single day is considered spam and will be blocked.",
   "bug_bounty_conduct_rule_3": "We do not pay for reports that ignore these rules or are spam.",
   "bug_bounty_conduct_rule_4": "Only in-scope reports that follow this bug bounty program are accepted; anything else may be blocked.",
+  "bug_bounty_payment_note": "Payments are issued only after we have identified the issue, fixed it, opened a pull request, and you have verified after release that the fix works for you. This process typically takes 3-5 days. Please do not send messages like \"to get paid\"; payment happens only once the release is live and you've tested and validated the fix.",
   "build_from_anywhere": "Build from any pc",
   "build_hours": "build hours",
   "build_in_public_on_twitter": "Build in public on Twitter",

--- a/messages/es.json
+++ b/messages/es.json
@@ -284,6 +284,7 @@
   "bug_bounty_conduct_rule_2": "Do not spam us. More than three emails in a single day is considered spam and will be blocked.",
   "bug_bounty_conduct_rule_3": "We do not pay for reports that ignore these rules or are spam.",
   "bug_bounty_conduct_rule_4": "Only in-scope reports that follow this bug bounty program are accepted; anything else may be blocked.",
+  "bug_bounty_payment_note": "Payments are issued only after we have identified the issue, fixed it, opened a pull request, and you have verified after release that the fix works for you. This process typically takes 3-5 days. Please do not send messages like \"to get paid\"; payment happens only once the release is live and you've tested and validated the fix.",
   "build_from_anywhere": "Construye desde cualquier m\u00e1quina",
   "build_hours": "horas de construcci\u00f3n",
   "build_in_public_on_twitter": "Construye en p\u00fablico en Twitter",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -284,6 +284,7 @@
   "bug_bounty_conduct_rule_2": "Do not spam us. More than three emails in a single day is considered spam and will be blocked.",
   "bug_bounty_conduct_rule_3": "We do not pay for reports that ignore these rules or are spam.",
   "bug_bounty_conduct_rule_4": "Only in-scope reports that follow this bug bounty program are accepted; anything else may be blocked.",
+  "bug_bounty_payment_note": "Payments are issued only after we have identified the issue, fixed it, opened a pull request, and you have verified after release that the fix works for you. This process typically takes 3-5 days. Please do not send messages like \"to get paid\"; payment happens only once the release is live and you've tested and validated the fix.",
   "build_from_anywhere": "Construisez \u00e0 partir de n'importe quel pc",
   "build_hours": "heures de construction",
   "build_in_public_on_twitter": "Construisez en public sur Twitter",

--- a/messages/id.json
+++ b/messages/id.json
@@ -284,6 +284,7 @@
   "bug_bounty_conduct_rule_2": "Do not spam us. More than three emails in a single day is considered spam and will be blocked.",
   "bug_bounty_conduct_rule_3": "We do not pay for reports that ignore these rules or are spam.",
   "bug_bounty_conduct_rule_4": "Only in-scope reports that follow this bug bounty program are accepted; anything else may be blocked.",
+  "bug_bounty_payment_note": "Payments are issued only after we have identified the issue, fixed it, opened a pull request, and you have verified after release that the fix works for you. This process typically takes 3-5 days. Please do not send messages like \"to get paid\"; payment happens only once the release is live and you've tested and validated the fix.",
   "build_from_anywhere": "Bangun dari mesin apa pun",
   "build_hours": "membangun jam",
   "build_in_public_on_twitter": "Bangun secara terbuka di Twitter",

--- a/messages/it.json
+++ b/messages/it.json
@@ -284,6 +284,7 @@
   "bug_bounty_conduct_rule_2": "Do not spam us. More than three emails in a single day is considered spam and will be blocked.",
   "bug_bounty_conduct_rule_3": "We do not pay for reports that ignore these rules or are spam.",
   "bug_bounty_conduct_rule_4": "Only in-scope reports that follow this bug bounty program are accepted; anything else may be blocked.",
+  "bug_bounty_payment_note": "Payments are issued only after we have identified the issue, fixed it, opened a pull request, and you have verified after release that the fix works for you. This process typically takes 3-5 days. Please do not send messages like \"to get paid\"; payment happens only once the release is live and you've tested and validated the fix.",
   "build_from_anywhere": "Costruisci da qualsiasi macchina",
   "build_hours": "ore di costruzione",
   "build_in_public_on_twitter": "Construir en p\u00fablico en Twitter",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -284,6 +284,7 @@
   "bug_bounty_conduct_rule_2": "Do not spam us. More than three emails in a single day is considered spam and will be blocked.",
   "bug_bounty_conduct_rule_3": "We do not pay for reports that ignore these rules or are spam.",
   "bug_bounty_conduct_rule_4": "Only in-scope reports that follow this bug bounty program are accepted; anything else may be blocked.",
+  "bug_bounty_payment_note": "Payments are issued only after we have identified the issue, fixed it, opened a pull request, and you have verified after release that the fix works for you. This process typically takes 3-5 days. Please do not send messages like \"to get paid\"; payment happens only once the release is live and you've tested and validated the fix.",
   "build_from_anywhere": "\u3069\u306e\u30de\u30b7\u30f3\u304b\u3089\u3067\u3082\u69cb\u7bc9\u3059\u308b",
   "build_hours": "\u5efa\u8a2d\u6642\u9593",
   "build_in_public_on_twitter": "Twitter\u3067\u516c\u958b\u958b\u767a\u3092\u884c\u3046",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -284,6 +284,7 @@
   "bug_bounty_conduct_rule_2": "Do not spam us. More than three emails in a single day is considered spam and will be blocked.",
   "bug_bounty_conduct_rule_3": "We do not pay for reports that ignore these rules or are spam.",
   "bug_bounty_conduct_rule_4": "Only in-scope reports that follow this bug bounty program are accepted; anything else may be blocked.",
+  "bug_bounty_payment_note": "Payments are issued only after we have identified the issue, fixed it, opened a pull request, and you have verified after release that the fix works for you. This process typically takes 3-5 days. Please do not send messages like \"to get paid\"; payment happens only once the release is live and you've tested and validated the fix.",
   "build_from_anywhere": "\uc5b4\ub5a4 \uae30\uacc4\uc5d0\uc11c\ub4e0\uc9c0 \uad6c\ucd95\ud558\uc2ed\uc2dc\uc624",
   "build_hours": "\uac74\uc124 \uc2dc\uac04",
   "build_in_public_on_twitter": "Twitter\uc5d0\uc11c \uacf5\uac1c\uc801\uc73c\ub85c \uad6c\ucd95\ud558\uc138\uc694",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -284,6 +284,7 @@
   "bug_bounty_conduct_rule_2": "Do not spam us. More than three emails in a single day is considered spam and will be blocked.",
   "bug_bounty_conduct_rule_3": "We do not pay for reports that ignore these rules or are spam.",
   "bug_bounty_conduct_rule_4": "Only in-scope reports that follow this bug bounty program are accepted; anything else may be blocked.",
+  "bug_bounty_payment_note": "Payments are issued only after we have identified the issue, fixed it, opened a pull request, and you have verified after release that the fix works for you. This process typically takes 3-5 days. Please do not send messages like \"to get paid\"; payment happens only once the release is live and you've tested and validated the fix.",
   "build_from_anywhere": "\u4ece\u4efb\u4f55\u673a\u5668\u6784\u5efa",
   "build_hours": "\u5efa\u8bbe\u65f6\u95f4",
   "build_in_public_on_twitter": "\u5728Twitter\u4e0a\u516c\u5f00\u6784\u5efa",

--- a/src/pages/bug-bounty.astro
+++ b/src/pages/bug-bounty.astro
@@ -99,6 +99,12 @@ const repositories = [
       <li>{m.bug_bounty_conduct_rule_4({}, { locale: Astro.locals.locale })}</li>
     </ul>
 
+    <div class="not-prose my-6 p-4 rounded-lg border border-amber-700/50 bg-amber-900/20">
+      <p class="text-amber-200 text-sm">
+        <strong class="text-amber-100">{m.bug_bounty_important_label({}, { locale: Astro.locals.locale })}:</strong> {m.bug_bounty_payment_note({}, { locale: Astro.locals.locale })}
+      </p>
+    </div>
+
     <h2>{m.bug_bounty_how_to_report_title({}, { locale: Astro.locals.locale })}</h2>
     <ol>
       <li>{m.bug_bounty_how_to_report_step_1({}, { locale: Astro.locals.locale })}</li>


### PR DESCRIPTION
Adds a new payment timing note to the bug bounty page and exposes it via all locales.