### PR TITLE
fix(i18n): correct formatting in Spanish bandwidth message

### DIFF
--- a/messages/es.json
+++ b/messages/es.json
@@ -234,7 +234,7 @@
   "awesome_capacitor": "Asombroso Capacitor",
   "bandwidth": "Ancho de banda",
   "bandwidth_explanation": "En Capgo, medimos el ancho de banda mediante el seguimiento de la cantidad de datos transmitidos entre la ubicación de almacenamiento y los dispositivos del usuario a través de servidores en el borde. Esto nos ayuda a ofrecer actualizaciones en tiempo real.",
-  "bandwidth_gb": "Ancho de banda<br />(GiB)",
+  "bandwidth_gb": "Ancho de banda (GiB)",
   "beautiful_native_experience": "Hermosa experiencia nativa",
   "before_submitting_a_pr": "Antes de enviar un PR a cualquiera de los repositorios, por favor asegúrate de que lo siguiente esté hecho:",
   "benefit_from_our_deep_expertise_in_mobile_app_ci_cd_best_practices_without_the_need_to_build_and_maintain_a_complex_system_yourself": "Benefíciese de nuestra profunda experiencia en las mejores prácticas de CI/CD para aplicaciones móviles, sin necesidad de construir y mantener un sistema complejo por su cuenta.",


### PR DESCRIPTION
This pull request makes a small change to the Spanish translations file, updating the label for bandwidth to remove the HTML line break and improve clarity. 

- Updated the `bandwidth_gb` translation in `messages/es.json` to remove the `<br />` HTML tag and display the label as "Ancho de banda (GiB)" for better readability.

<img width="1128" height="706" alt="Captura de pantalla 2026-02-09 a las 1 54 52 p  m" src="https://github.com/user-attachments/assets/bfa181e8-25d2-478a-905b-19ec6ad97874" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected text formatting in Spanish language translations to improve display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->