### PR TITLE
Add Google Cloud as read replica subprocessor

### DIFF
--- a/src/pages/subprocessors.astro
+++ b/src/pages/subprocessors.astro
@@ -23,6 +23,10 @@ const subprocessors = [
     purpose: 'Read replicas for database scaling',
   },
   {
+    name: 'Google Cloud',
+    purpose: 'Read replicas for database scaling',
+  },
+  {
     name: 'GitHub',
     purpose: 'Source code hosting',
   },
@@ -64,7 +68,7 @@ const subprocessors = [
       )
     }
     <h1>{m.subprocessors_title({}, { locale })}</h1>
-    <p><em>{m.last_update({}, { locale })}: February 4, 2026</em></p>
+    <p><em>{m.last_update({}, { locale })}: February 15, 2026</em></p>
     <p>{m.subprocessors_intro({}, { locale })}</p>
     <div class="overflow-x-auto">
       <table>


### PR DESCRIPTION
This PR updates the subprocessors page to add Google Cloud as a provider used for read replicas and database scaling. It also updates the page's last update date to February 15, 2026 to reflect this legal page change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Google Cloud to the subprocessors list.
  * Updated subprocessors information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->