### PR TITLE
fix(ci): avoid failure when no blog sync changes

### DIFF
--- a/.github/workflows/blogs_sync_seobot.yml
+++ b/.github/workflows/blogs_sync_seobot.yml
@@ -34,7 +34,7 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add -A
-          git commit -m "chore: delete broken blogs, fix locales and code languages"
+          git diff --quiet && git diff --staged --quiet || git commit -m "chore: delete broken blogs, fix locales and code languages"
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:


### PR DESCRIPTION
Prevent the scheduled Sync Blog Posts from SEObot workflow from failing when there are no file changes after cleanup steps.\n\n- Replace unconditional second commit with guarded commit (same pattern already used earlier in workflow).\n- Keeps behavior unchanged when files change, avoids false-red runs when tree is clean.\n\nFailing run reference: https://github.com/Cap-go/website/actions/runs/22081309500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow to prevent unnecessary empty commits, improving development process efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->