### PR TITLE
docs: add iOS ad-hoc distribution mode

### DIFF
--- a/src/content/docs/docs/cli/cloud-build/credentials.mdx
+++ b/src/content/docs/docs/cli/cloud-build/credentials.mdx
@@ -128,7 +128,8 @@ The stored file structure:
     "P12_PASSWORD": "...",
     "APPLE_KEY_ID": "ABC1234567",
     "APPLE_ISSUER_ID": "...",
-    "APP_STORE_CONNECT_TEAM_ID": "TEAM123456"
+    "APP_STORE_CONNECT_TEAM_ID": "TEAM123456",
+    "CAPGO_IOS_DISTRIBUTION": "app_store"
   }
 }
 ```

--- a/src/content/docs/docs/cli/cloud-build/ios.mdx
+++ b/src/content/docs/docs/cli/cloud-build/ios.mdx
@@ -601,7 +601,7 @@ Without an App Store Connect API key, build number auto-increment uses a timesta
 
 ### Creating an ad-hoc provisioning profile
 
-Follow the same steps as [Provisioning profile](#provisioning-profile), but in step 5, select **Ad Hoc** instead of App Store Connect:
+Follow the same steps as [Provisioning profile](#provisioning-profile), but in step 5, select **Ad Hoc** instead of **App Store**:
 
 1. Go to [Apple Developer Profiles](https://developer.apple.com/account/resources/profiles/list)
 2. Click the `+` button


### PR DESCRIPTION
## Summary
- Add new "Ad-Hoc Distribution Mode" section to iOS builds guide (`ios.mdx`)
- Document requirements, credential setup, build commands, and CI/CD workflow for ad-hoc builds
- Add `--ios-distribution` option and `CAPGO_IOS_DISTRIBUTION` env var to credentials reference (`credentials.mdx`)

## Changes
- **`ios.mdx`** — New section covering: when to use ad-hoc, requirements table, provisioning profile creation, saving credentials, running builds, and CI/CD example
- **`credentials.mdx`** — Added `--ios-distribution` to iOS options table, `CAPGO_IOS_DISTRIBUTION` to env vars table, and ad-hoc tip callout

## Companion PRs
- CLI: https://github.com/Cap-go/CLI/pull/528
- capgo_builder: https://github.com/Cap-go/capgo_builder/pull/37

## Test plan
- [ ] Verify docs build without errors
- [ ] Check links to new section work correctly
- [ ] Review ad-hoc requirements table accuracy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added iOS ad-hoc distribution mode documentation with step-by-step setup guides.
  * Introduced new `--ios-distribution` option for configuring iOS build distribution method.
  * Updated credentials requirements to reflect distribution-specific needs.
  * Added CI/CD workflow examples for ad-hoc distribution with GitHub Actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->