### PR TITLE
fix: move Aside and LinkCard out of Steps components

### DIFF
--- a/src/content/docs/de/docs/getting-started/add-an-app.mdx
+++ b/src/content/docs/de/docs/getting-started/add-an-app.mdx
@@ -33,11 +33,15 @@ Bevor Sie mit Capgo beginnen, stellen Sie sicher, dass Sie:
 1. Erstellen Sie Ihr Konto unter [https://capgo.app/register](https://capgo.app/register).
 ![signup screenshot](/signup.webp "signup screenshot")
 
-2. Verwenden Sie die Init-Befehle, um zu beginnen <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> Es werden Ihnen eine Reihe von Fragen gestellt. Beantworten Sie diese, um das automatische Setup abzuschließen.<Aside type="tip">Wenn Sie diese Schritte befolgen, sind Sie in kürzester Zeit einsatzbereit. Falls Sie während des Prozesses weitere Unterstützung benötigen, ist unser Support-Team [hier um zu helfen](https://support.capgo.app). Viel Spaß beim Onboarding!</Aside><LinkCard href="/docs/getting-started/onboarding/" title="Detaillierter Onboarding-Leitfaden" description="Sehen Sie den vollständigen Schritt-für-Schritt-Leitfaden für den CLI-Onboarding-Prozess" />
+2. Verwenden Sie die Init-Befehle, um zu beginnen <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> Es werden Ihnen eine Reihe von Fragen gestellt. Beantworten Sie diese, um das automatische Setup abzuschließen.
 
-3. Stellen Sie ein Live-Update bereit <LinkCard href="/docs/getting-started/deploy/" title="Stellen Sie ein Live-Update bereit" description="Erfahren Sie, wie Sie ein Live-Update für Ihre App bereitstellen" />
+3. Stellen Sie ein Live-Update bereit
 
 </Steps>
+
+<Aside type="tip">Wenn Sie diese Schritte befolgen, sind Sie in kürzester Zeit einsatzbereit. Falls Sie während des Prozesses weitere Unterstützung benötigen, ist unser Support-Team [hier um zu helfen](https://support.capgo.app). Viel Spaß beim Onboarding!</Aside>
+<LinkCard href="/docs/getting-started/onboarding/" title="Detaillierter Onboarding-Leitfaden" description="Sehen Sie den vollständigen Schritt-für-Schritt-Leitfaden für den CLI-Onboarding-Prozess" />
+<LinkCard href="/docs/getting-started/deploy/" title="Stellen Sie ein Live-Update bereit" description="Erfahren Sie, wie Sie ein Live-Update für Ihre App bereitstellen" />
 
 ### Manuelles Setup
 
@@ -51,28 +55,28 @@ Falls der Init-Befehl für Sie nicht funktioniert, können Sie eine App manuell 
 
 3. Installieren Sie das Plugin in Ihrer App: <Code code={`npm i @capgo/capacitor-updater`} lang="bash" />
 
-   <Aside type="note" title="Installation für ältere Capacitor-Versionen">
-   Der obige Befehl installiert die neueste Version (v8.x) für Capacitor 8. Für ältere Capacitor-Versionen verwenden Sie den entsprechenden npm-Tag:
-
-   ```bash
-   # Capacitor 7
-   npm i @capgo/capacitor-updater@lts-v7
-
-   # Capacitor 6
-   npm i @capgo/capacitor-updater@lts-v6
-
-   # Capacitor 5
-   npm i @capgo/capacitor-updater@lts-v5
-   ```
-
-   Jede Plugin-Hauptversion entspricht der Capacitor-Hauptversion (v8 → Capacitor 8, v7 → Capacitor 7, v6 → Capacitor 6, v5 → Capacitor 5). Minor-Versionen teilen denselben Funktionsumfang über alle Hauptversionen (z.B. 5.34.0, 6.34.0, 7.34.0 und 8.34.0 enthalten dieselben Funktionen).
-   </Aside>
-
 4. Konfigurieren Sie das Plugin in Ihrer `capacitor.config` <Code code={`{\n  "plugins": {\n    CapacitorUpdater: {\n      "appId": "Your appID",\n      "autoUpdate": true,\n      "version": "1.0.0"\n    }\n  }\n}`} lang="json" />
   [Siehe alle verfügbaren Optionen](/docs/plugin/settings/). Diese Informationen werden abgeleitet, wenn sie nicht bereitgestellt werden.
 
 5. Rufen Sie die Init-Methode so früh wie möglich in Ihrer App auf: <Code code={`import { CapacitorUpdater } from '@capgo/capacitor-updater';\nCapacitorUpdater.notifyAppReady();`} lang="typescript" />
 
-6. Stellen Sie ein Live-Update bereit <LinkCard href="/docs/getting-started/deploy/" title="Stellen Sie ein Live-Update bereit" description="Erfahren Sie, wie Sie ein Live-Update für Ihre App bereitstellen" />
+6. Stellen Sie ein Live-Update bereit
 
 </Steps>
+
+<Aside type="note" title="Installation für ältere Capacitor-Versionen">
+Der obige Befehl installiert die neueste Version (v8.x) für Capacitor 8. Für ältere Capacitor-Versionen verwenden Sie den entsprechenden npm-Tag:
+
+```bash
+# Capacitor 7
+npm i @capgo/capacitor-updater@lts-v7
+
+# Capacitor 6
+npm i @capgo/capacitor-updater@lts-v6
+
+# Capacitor 5
+npm i @capgo/capacitor-updater@lts-v5
+```
+
+Jede Plugin-Hauptversion entspricht der Capacitor-Hauptversion (v8 → Capacitor 8, v7 → Capacitor 7, v6 → Capacitor 6, v5 → Capacitor 5). Minor-Versionen teilen denselben Funktionsumfang über alle Hauptversionen (z.B. 5.34.0, 6.34.0, 7.34.0 und 8.34.0 enthalten dieselben Funktionen).
+</Aside>

--- a/src/content/docs/docs/getting-started/add-an-app.mdx
+++ b/src/content/docs/docs/getting-started/add-an-app.mdx
@@ -33,11 +33,16 @@ Before getting started with Capgo, make sure you have:
 1. Create your account at [https://capgo.app/register](https://capgo.app/register).
 ![signup screenshot](/signup.webp "signup screenshot")
 
-2. Use the Init commands to get started <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> You will be presented with a series of questions. Provide the necessary answers to complete the automated setup.<Aside type="tip">By following these steps, you'll be up and running in no time. If you need any further assistance during the process, our support team is [here to help](https://support.capgo.app). Happy onboarding!</Aside><LinkCard href="/docs/getting-started/onboarding/" title="Detailed Onboarding Guide" description="See the complete step-by-step guide for the CLI onboarding process" />
+2. Use the Init commands to get started <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> You will be presented with a series of questions. Provide the necessary answers to complete the automated setup.
 
-3. Deploy a live update <LinkCard href="/docs/getting-started/deploy/" title="Deploy a live update" description="Learn how to deploy a live update to your app" />
+3. Deploy a live update
 
 </Steps>
+
+<Aside type="tip">By following these steps, you'll be up and running in no time. If you need any further assistance during the process, our support team is [here to help](https://support.capgo.app). Happy onboarding!</Aside>
+
+<LinkCard href="/docs/getting-started/onboarding/" title="Detailed Onboarding Guide" description="See the complete step-by-step guide for the CLI onboarding process" />
+<LinkCard href="/docs/getting-started/deploy/" title="Deploy a live update" description="Learn how to deploy a live update to your app" />
 
 ### Manual setup
 
@@ -51,28 +56,28 @@ In case the init command doesn't work for you, you can manually add an app.
 
 3. Install the plugin in your app: <Code code={`npm i @capgo/capacitor-updater`} lang="bash" />
 
-   <Aside type="note" title="Installing for older Capacitor versions">
-   The command above installs the latest version (v8.x) for Capacitor 8. For older Capacitor versions, use the appropriate npm tag:
-
-   ```bash
-   # Capacitor 7
-   npm i @capgo/capacitor-updater@lts-v7
-
-   # Capacitor 6
-   npm i @capgo/capacitor-updater@lts-v6
-
-   # Capacitor 5
-   npm i @capgo/capacitor-updater@lts-v5
-   ```
-
-   Each plugin major version matches the Capacitor major version (v8 → Capacitor 8, v7 → Capacitor 7, v6 → Capacitor 6, v5 → Capacitor 5). Minor versions share the same feature set across all major versions (e.g., 5.34.0, 6.34.0, 7.34.0, and 8.34.0 all include the same features).
-   </Aside>
-
 4. Configure the plugin in your `capacitor.config` <Code code={`{\n  "plugins": {\n    CapacitorUpdater: {\n      "appId": "Your appID",\n      "autoUpdate": true,\n      "version": "1.0.0"\n    }\n  }\n}`} lang="json" />
   [See all option available](/docs/plugin/settings/). This information will be infer if not provided.
 
 5. Call the init method as early as possible in your app: <Code code={`import { CapacitorUpdater } from '@capgo/capacitor-updater';\nCapacitorUpdater.notifyAppReady();`} lang="typescript" />
 
-6. Deploy a live update <LinkCard href="/docs/getting-started/deploy/" title="Deploy a live update" description="Learn how to deploy a live update to your app" />
+6. Deploy a live update
 
 </Steps>
+
+<Aside type="note" title="Installing for older Capacitor versions">
+The command above (step 3) installs the latest version (v8.x) for Capacitor 8. For older Capacitor versions, use the appropriate npm tag:
+
+```bash
+# Capacitor 7
+npm i @capgo/capacitor-updater@lts-v7
+
+# Capacitor 6
+npm i @capgo/capacitor-updater@lts-v6
+
+# Capacitor 5
+npm i @capgo/capacitor-updater@lts-v5
+```
+
+Each plugin major version matches the Capacitor major version (v8 → Capacitor 8, v7 → Capacitor 7, v6 → Capacitor 6, v5 → Capacitor 5). Minor versions share the same feature set across all major versions (e.g., 5.34.0, 6.34.0, 7.34.0, and 8.34.0 all include the same features).
+</Aside>

--- a/src/content/docs/es/docs/getting-started/add-an-app.mdx
+++ b/src/content/docs/es/docs/getting-started/add-an-app.mdx
@@ -34,11 +34,15 @@ Antes de comenzar con Capgo, asegúrate de tener:
 1. Crea tu cuenta en [https://capgo.app/register](https://capgo.app/register).
 ![captura de pantalla de registro](/signup.webp "captura de pantalla de registro")
 
-2. Usa el comando Init para comenzar <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> Se te presentará una serie de preguntas. Proporciona las respuestas necesarias para completar la configuración automatizada.<Aside type="tip">Siguiendo estos pasos, estarás en funcionamiento en poco tiempo. Si necesitas más asistencia durante el proceso, nuestro equipo de soporte está [aquí para ayudar](https://support.capgo.app). ¡Feliz incorporación!</Aside><LinkCard href="/docs/getting-started/onboarding/" title="Guía Detallada de Incorporación" description="Vea la guía completa paso a paso para el proceso de incorporación CLI" /><LinkCard href="/docs/getting-started/onboarding/" title="Guía Detallada de Incorporación" description="Vea la guía completa paso a paso para el proceso de incorporación CLI" />
+2. Usa el comando Init para comenzar <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> Se te presentará una serie de preguntas. Proporciona las respuestas necesarias para completar la configuración automatizada.
 
-3. Implementa una actualización en vivo <LinkCard href="/docs/getting-started/Desplegar/" title="Implementar una actualización en vivo" description="Aprende cómo implementar una actualización en vivo en tu aplicación" />
+3. Implementa una actualización en vivo
 
 </Steps>
+
+<Aside type="tip">Siguiendo estos pasos, estarás en funcionamiento en poco tiempo. Si necesitas más asistencia durante el proceso, nuestro equipo de soporte está [aquí para ayudar](https://support.capgo.app). ¡Feliz incorporación!</Aside>
+<LinkCard href="/docs/getting-started/onboarding/" title="Guía Detallada de Incorporación" description="Vea la guía completa paso a paso para el proceso de incorporación CLI" />
+<LinkCard href="/docs/getting-started/Desplegar/" title="Implementar una actualización en vivo" description="Aprende cómo implementar una actualización en vivo en tu aplicación" />
 
 ### Configuración manual
 
@@ -52,28 +56,28 @@ En caso de que el comando init no funcione para ti, puedes añadir manualmente u
 
 3. Instala el Plugin en tu aplicación: <Code code={`npm i @capgo/capacitor-updater`} lang="bash" />
 
-   <Aside type="note" title="Instalación para versiones anteriores de Capacitor">
-   El comando anterior instala la última versión (v8.x) para Capacitor 8. Para versiones anteriores de Capacitor, usa la etiqueta npm apropiada:
-
-   ```bash
-   # Capacitor 7
-   npm i @capgo/capacitor-updater@lts-v7
-
-   # Capacitor 6
-   npm i @capgo/capacitor-updater@lts-v6
-
-   # Capacitor 5
-   npm i @capgo/capacitor-updater@lts-v5
-   ```
-
-   Cada versión mayor del plugin corresponde a la versión mayor de Capacitor (v8 → Capacitor 8, v7 → Capacitor 7, v6 → Capacitor 6, v5 → Capacitor 5). Las versiones menores comparten el mismo conjunto de características en todas las versiones mayores (ej., 5.34.0, 6.34.0, 7.34.0, y 8.34.0 incluyen las mismas características).
-   </Aside>
-
 4. Configura el Plugin en tu `capacitor.config` <Code code={`{\n  "plugins": {\n    CapacitorUpdater: {\n      "appId": "Your appID",\n      "autoUpdate": true,\n      "version": "1.0.0"\n    }\n  }\n}`} lang="JSON" />
   [Ver todas las opciones disponibles](/docs/plugin/settings/). Esta información se inferirá si no se proporciona.
 
 5. Llama al método init lo más temprano posible en tu aplicación: <Code code={`import { CapacitorUpdater } from '@capgo/capacitor-updater';\nCapacitorUpdater.notifyAppReady();`} lang="TypeScript" />
 
-6. Implementa una actualización en vivo <LinkCard href="/docs/getting-started/Desplegar/" title="Implementar una actualización en vivo" description="Aprende cómo implementar una actualización en vivo en tu aplicación" />
+6. Implementa una actualización en vivo
 
 </Steps>
+
+<Aside type="note" title="Instalación para versiones anteriores de Capacitor">
+El comando anterior instala la última versión (v8.x) para Capacitor 8. Para versiones anteriores de Capacitor, usa la etiqueta npm apropiada:
+
+```bash
+# Capacitor 7
+npm i @capgo/capacitor-updater@lts-v7
+
+# Capacitor 6
+npm i @capgo/capacitor-updater@lts-v6
+
+# Capacitor 5
+npm i @capgo/capacitor-updater@lts-v5
+```
+
+Cada versión mayor del plugin corresponde a la versión mayor de Capacitor (v8 → Capacitor 8, v7 → Capacitor 7, v6 → Capacitor 6, v5 → Capacitor 5). Las versiones menores comparten el mismo conjunto de características en todas las versiones mayores (ej., 5.34.0, 6.34.0, 7.34.0, y 8.34.0 incluyen las mismas características).
+</Aside>

--- a/src/content/docs/fr/getting-started/add-an-app.mdx
+++ b/src/content/docs/fr/getting-started/add-an-app.mdx
@@ -34,11 +34,15 @@ Before Commencer with Capgo, make sure you have:
 1. Créer your Compte at [https://capgo.Application/register](https://capgo.Application/register).
 ![signup screenshot](/signup.webp "signup screenshot")
 
-2. Use the Init commands to get started <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> You will be presented with a series of questions. Provide the necessary answers to complete the automated setup.<Aside type="tip">By following these steps, you'll be up and running in no time. If you need any further assistance during the process, our support team is [here to help](https://support.capgo.app). Happy onboarding!</Aside><LinkCard href="/docs/getting-started/onboarding/" title="Guide d'Intégration Détaillé" description="Voir le guide complet étape par étape pour le processus d'intégration CLI" /><LinkCard href="/docs/getting-started/onboarding/" title="Guide d'Intégration Détaillé" description="Voir le guide complet étape par étape pour le processus d'intégration CLI" />
+2. Use the Init commands to get started <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> You will be presented with a series of questions. Provide the necessary answers to complete the automated setup.
 
-3. Déployer a live Mise à jour <LinkCard href="/docs/getting-started/Déployer/" title="Déployer a live Mise à jour" description="Learn how to Déployer a live Mise à jour to your Application" />
+3. Déployer a live Mise à jour
 
 </Steps>
+
+<Aside type="tip">By following these steps, you'll be up and running in no time. If you need any further assistance during the process, our support team is [here to help](https://support.capgo.app). Happy onboarding!</Aside>
+<LinkCard href="/docs/getting-started/onboarding/" title="Guide d'Intégration Détaillé" description="Voir le guide complet étape par étape pour le processus d'intégration CLI" />
+<LinkCard href="/docs/getting-started/Déployer/" title="Déployer a live Mise à jour" description="Learn how to Déployer a live Mise à jour to your Application" />
 
 ### Manual Configuration
 
@@ -52,28 +56,28 @@ In case the init Commande doesn't work for you, you can manually Ajouter an Appl
 
 3. Install the plugin in your app: <Code code={`npm i @capgo/capacitor-updater`} lang="bash" />
 
-   <Aside type="note" title="Installation pour les anciennes versions de Capacitor">
-   La commande ci-dessus installe la dernière version (v8.x) pour Capacitor 8. Pour les anciennes versions de Capacitor, utilisez le tag npm approprié :
-
-   ```bash
-   # Capacitor 7
-   npm i @capgo/capacitor-updater@lts-v7
-
-   # Capacitor 6
-   npm i @capgo/capacitor-updater@lts-v6
-
-   # Capacitor 5
-   npm i @capgo/capacitor-updater@lts-v5
-   ```
-
-   Chaque version majeure du plugin correspond à la version majeure de Capacitor (v8 → Capacitor 8, v7 → Capacitor 7, v6 → Capacitor 6, v5 → Capacitor 5). Les versions mineures partagent le même ensemble de fonctionnalités sur toutes les versions majeures (par ex., 5.34.0, 6.34.0, 7.34.0 et 8.34.0 incluent les mêmes fonctionnalités).
-   </Aside>
-
 4. Configure the plugin in your `capacitor.config` <Code code={`{\n  "plugins": {\n    CapacitorUpdater: {\n      "appId": "Your appID",\n      "autoUpdate": true,\n      "version": "1.0.0"\n    }\n  }\n}`} lang="json" />
   [See all Option Disponible](/docs/plugin/Paramètres/). This Information will be infer if not provided.
 
 5. Call the init method as early as possible in your app: <Code code={`import { CapacitorUpdater } from '@capgo/capacitor-updater';\nCapacitorUpdater.notifyAppReady();`} lang="typescript" />
 
-6. Déployer a live Mise à jour <LinkCard href="/docs/getting-started/Déployer/" title="Déployer a live Mise à jour" description="Learn how to Déployer a live Mise à jour to your Application" />
+6. Déployer a live Mise à jour
 
 </Steps>
+
+<Aside type="note" title="Installation pour les anciennes versions de Capacitor">
+La commande ci-dessus installe la dernière version (v8.x) pour Capacitor 8. Pour les anciennes versions de Capacitor, utilisez le tag npm approprié :
+
+```bash
+# Capacitor 7
+npm i @capgo/capacitor-updater@lts-v7
+
+# Capacitor 6
+npm i @capgo/capacitor-updater@lts-v6
+
+# Capacitor 5
+npm i @capgo/capacitor-updater@lts-v5
+```
+
+Chaque version majeure du plugin correspond à la version majeure de Capacitor (v8 → Capacitor 8, v7 → Capacitor 7, v6 → Capacitor 6, v5 → Capacitor 5). Les versions mineures partagent le même ensemble de fonctionnalités sur toutes les versions majeures (par ex., 5.34.0, 6.34.0, 7.34.0 et 8.34.0 incluent les mêmes fonctionnalités).
+</Aside>

--- a/src/content/docs/id/docs/getting-started/add-an-app.mdx
+++ b/src/content/docs/id/docs/getting-started/add-an-app.mdx
@@ -33,11 +33,15 @@ Sebelum memulai dengan Capgo, pastikan Anda memiliki:
 1. Buat akun Anda di [https://capgo.app/register](https://capgo.app/register)
 ![signup screenshot](/signup.webp "signup screenshot")
 
-2. Gunakan perintah Init untuk memulai <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> Anda akan diberikan beberapa pertanyaan. Berikan jawaban yang diperlukan untuk menyelesaikan setup otomatis<Aside type="tip">Dengan mengikuti langkah-langkah ini, Anda akan siap menggunakan dalam waktu singkat. Jika Anda membutuhkan bantuan selama proses, tim support kami [siap membantu](https://support.capgo.app) Selamat mencoba!</Aside><LinkCard href="/docs/getting-started/onboarding/" title="Panduan Onboarding Terperinci" description="Lihat panduan lengkap langkah demi langkah untuk proses onboarding CLI" />
+2. Gunakan perintah Init untuk memulai <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> Anda akan diberikan beberapa pertanyaan. Berikan jawaban yang diperlukan untuk menyelesaikan setup otomatis
 
-3. Deploy live update <LinkCard href="/docs/getting-started/deploy/" title="Deploy live update" description="Pelajari cara deploy live update ke aplikasi Anda" />
+3. Deploy live update
 
 </Steps>
+
+<Aside type="tip">Dengan mengikuti langkah-langkah ini, Anda akan siap menggunakan dalam waktu singkat. Jika Anda membutuhkan bantuan selama proses, tim support kami [siap membantu](https://support.capgo.app) Selamat mencoba!</Aside>
+<LinkCard href="/docs/getting-started/onboarding/" title="Panduan Onboarding Terperinci" description="Lihat panduan lengkap langkah demi langkah untuk proses onboarding CLI" />
+<LinkCard href="/docs/getting-started/deploy/" title="Deploy live update" description="Pelajari cara deploy live update ke aplikasi Anda" />
 
 ### Setup manual
 
@@ -51,28 +55,28 @@ Jika perintah init tidak berhasil, Anda dapat menambahkan aplikasi secara manual
 
 3. Pasang plugin di aplikasi Anda: <Code code={`npm i @capgo/capacitor-updater`} lang="bash" />
 
-   <Aside type="note" title="Instalasi untuk versi Capacitor lama">
-   Perintah di atas menginstal versi terbaru (v8.x) untuk Capacitor 8. Untuk versi Capacitor lama, gunakan tag npm yang sesuai:
-
-   ```bash
-   # Capacitor 7
-   npm i @capgo/capacitor-updater@lts-v7
-
-   # Capacitor 6
-   npm i @capgo/capacitor-updater@lts-v6
-
-   # Capacitor 5
-   npm i @capgo/capacitor-updater@lts-v5
-   ```
-
-   Setiap versi mayor plugin sesuai dengan versi mayor Capacitor (v8 → Capacitor 8, v7 → Capacitor 7, v6 → Capacitor 6, v5 → Capacitor 5). Versi minor berbagi set fitur yang sama di semua versi mayor (misal, 5.34.0, 6.34.0, 7.34.0, dan 8.34.0 semua menyertakan fitur yang sama).
-   </Aside><LinkCard href="/docs/getting-started/onboarding/" title="Panduan Onboarding Terperinci" description="Lihat panduan lengkap langkah demi langkah untuk proses onboarding CLI" />
-
 4. Konfigurasi plugin di `capacitor.config` Anda <Code code={`{\n  "plugins": {\n    CapacitorUpdater: {\n      "appId": "Your appID",\n      "autoUpdate": true,\n      "version": "1.0.0"\n    }\n  }\n}`} lang="json" />
   [Lihat semua opsi yang tersedia](/docs/plugin/settings/). Informasi ini akan disimpulkan jika tidak disediakan.
 
 5. Panggil metode init sedini mungkin di aplikasi Anda: <Code code={`import { CapacitorUpdater } from '@capgo/capacitor-updater';\nCapacitorUpdater.notifyAppReady();`} lang="typescript" />
 
-5. Deploy live update <LinkCard href="/docs/getting-started/deploy/" title="Deploy live update" description="Pelajari cara deploy live update ke aplikasi Anda" />
+6. Deploy live update
 
 </Steps>
+
+<Aside type="note" title="Instalasi untuk versi Capacitor lama">
+Perintah di atas menginstal versi terbaru (v8.x) untuk Capacitor 8. Untuk versi Capacitor lama, gunakan tag npm yang sesuai:
+
+```bash
+# Capacitor 7
+npm i @capgo/capacitor-updater@lts-v7
+
+# Capacitor 6
+npm i @capgo/capacitor-updater@lts-v6
+
+# Capacitor 5
+npm i @capgo/capacitor-updater@lts-v5
+```
+
+Setiap versi mayor plugin sesuai dengan versi mayor Capacitor (v8 → Capacitor 8, v7 → Capacitor 7, v6 → Capacitor 6, v5 → Capacitor 5). Versi minor berbagi set fitur yang sama di semua versi mayor (misal, 5.34.0, 6.34.0, 7.34.0, dan 8.34.0 semua menyertakan fitur yang sama).
+</Aside>

--- a/src/content/docs/it/docs/getting-started/add-an-app.mdx
+++ b/src/content/docs/it/docs/getting-started/add-an-app.mdx
@@ -34,11 +34,15 @@ Prima di iniziare con Capgo, assicurati di avere:
 1. Crea il tuo account su [https://capgo.app/register](https://capgo.app/register)
 ![signup screenshot](/signup.webp "signup screenshot")
 
-2. Usa il comando Init per iniziare <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> Ti verranno presentate una serie di domande. Fornisci le risposte necessarie per completare la configurazione automatica<Aside type="tip">Seguendo questi passaggi, sarai operativo in pochissimo tempo. Se hai bisogno di ulteriore assistenza durante il processo, il nostro team di supporto è [qui per aiutarti](https://support.capgo.app) Buon onboarding!</Aside><LinkCard href="/docs/getting-started/onboarding/" title="Guida Dettagliata all'Onboarding" description="Vedi la guida completa passo dopo passo per il processo di onboarding CLI" />
+2. Usa il comando Init per iniziare <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> Ti verranno presentate una serie di domande. Fornisci le risposte necessarie per completare la configurazione automatica
 
-3. Distribuisci un aggiornamento live <LinkCard href="/docs/getting-started/deploy/" title="Deploy a live update" description="Impara come distribuire un aggiornamento live alla tua app" />
+3. Distribuisci un aggiornamento live
 
 </Steps>
+
+<Aside type="tip">Seguendo questi passaggi, sarai operativo in pochissimo tempo. Se hai bisogno di ulteriore assistenza durante il processo, il nostro team di supporto è [qui per aiutarti](https://support.capgo.app) Buon onboarding!</Aside>
+<LinkCard href="/docs/getting-started/onboarding/" title="Guida Dettagliata all'Onboarding" description="Vedi la guida completa passo dopo passo per il processo di onboarding CLI" />
+<LinkCard href="/docs/getting-started/deploy/" title="Deploy a live update" description="Impara come distribuire un aggiornamento live alla tua app" />
 
 ### Configurazione manuale
 
@@ -52,28 +56,28 @@ Nel caso in cui il comando init non funzioni, puoi aggiungere manualmente un'app
 
 3. Installa il plugin nella tua app: <Code code={`npm i @capgo/capacitor-updater`} lang="bash" />
 
-   <Aside type="note" title="Installazione per versioni precedenti di Capacitor">
-   Il comando sopra installa l'ultima versione (v8.x) per Capacitor 8. Per versioni precedenti di Capacitor, usa il tag npm appropriato:
-
-   ```bash
-   # Capacitor 7
-   npm i @capgo/capacitor-updater@lts-v7
-
-   # Capacitor 6
-   npm i @capgo/capacitor-updater@lts-v6
-
-   # Capacitor 5
-   npm i @capgo/capacitor-updater@lts-v5
-   ```
-
-   Ogni versione maggiore del plugin corrisponde alla versione maggiore di Capacitor (v8 → Capacitor 8, v7 → Capacitor 7, v6 → Capacitor 6, v5 → Capacitor 5). Le versioni minori condividono lo stesso set di funzionalità su tutte le versioni maggiori (es., 5.34.0, 6.34.0, 7.34.0 e 8.34.0 includono le stesse funzionalità).
-   </Aside><LinkCard href="/docs/getting-started/onboarding/" title="Guida Dettagliata all'Onboarding" description="Vedi la guida completa passo dopo passo per il processo di onboarding CLI" />
-
 4. Configura il plugin nel tuo `capacitor.config` <Code code={`{\n  "plugins": {\n    CapacitorUpdater: {\n      "appId": "Your appID",\n      "autoUpdate": true,\n      "version": "1.0.0"\n    }\n  }\n}`} lang="json" />
   [Vedi tutte le opzioni disponibili](/docs/plugin/settings/). Queste informazioni verranno dedotte se non fornite.
 
 5. Chiama il metodo init il prima possibile nella tua app: <Code code={`import { CapacitorUpdater } from '@capgo/capacitor-updater';\nCapacitorUpdater.notifyAppReady();`} lang="typescript" />
 
-5. Distribuisci un aggiornamento live <LinkCard href="/docs/getting-started/deploy/" title="Deploy a live update" description="Impara come distribuire un aggiornamento live alla tua app" />
+6. Distribuisci un aggiornamento live
 
 </Steps>
+
+<Aside type="note" title="Installazione per versioni precedenti di Capacitor">
+Il comando sopra installa l'ultima versione (v8.x) per Capacitor 8. Per versioni precedenti di Capacitor, usa il tag npm appropriato:
+
+```bash
+# Capacitor 7
+npm i @capgo/capacitor-updater@lts-v7
+
+# Capacitor 6
+npm i @capgo/capacitor-updater@lts-v6
+
+# Capacitor 5
+npm i @capgo/capacitor-updater@lts-v5
+```
+
+Ogni versione maggiore del plugin corrisponde alla versione maggiore di Capacitor (v8 → Capacitor 8, v7 → Capacitor 7, v6 → Capacitor 6, v5 → Capacitor 5). Le versioni minori condividono lo stesso set di funzionalità su tutte le versioni maggiori (es., 5.34.0, 6.34.0, 7.34.0 e 8.34.0 includono le stesse funzionalità).
+</Aside>

--- a/src/content/docs/ja/docs/getting-started/add-an-app.mdx
+++ b/src/content/docs/ja/docs/getting-started/add-an-app.mdx
@@ -33,11 +33,15 @@ Capgoを開始する前に、以下を確認してください：
 1. [https://capgo.app/register](https://capgo.app/register)でアカウントを作成
 ![signup screenshot](/signup.webp "signup screenshot")
 
-2. 初期化コマンドを使用して開始 <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> 一連の質問が表示されます。自動セットアップを完了するために必要な回答を提供してください。<Aside type="tip">これらの手順に従えば、すぐに使用開始できます。プロセス中にさらなるサポートが必要な場合は、サポートチームが[お手伝いします](https://support.capgo.app)。セットアップをお楽しみください！</Aside><LinkCard href="/docs/getting-started/onboarding/" title="詳細なオンボーディングガイド" description="CLIオンボーディングプロセスの完全なステップバイステップガイドをご覧ください" />
+2. 初期化コマンドを使用して開始 <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> 一連の質問が表示されます。自動セットアップを完了するために必要な回答を提供してください。
 
-3. ライブアップデートをデプロイ <LinkCard href="/docs/getting-started/deploy/" title="ライブアップデートをデプロイ" description="アプリにライブアップデートをデプロイする方法を学ぶ" />
+3. ライブアップデートをデプロイ
 
 </Steps>
+
+<Aside type="tip">これらの手順に従えば、すぐに使用開始できます。プロセス中にさらなるサポートが必要な場合は、サポートチームが[お手伝いします](https://support.capgo.app)。セットアップをお楽しみください！</Aside>
+<LinkCard href="/docs/getting-started/onboarding/" title="詳細なオンボーディングガイド" description="CLIオンボーディングプロセスの完全なステップバイステップガイドをご覧ください" />
+<LinkCard href="/docs/getting-started/deploy/" title="ライブアップデートをデプロイ" description="アプリにライブアップデートをデプロイする方法を学ぶ" />
 
 ### 手動セットアップ
 
@@ -51,28 +55,28 @@ Capgoを開始する前に、以下を確認してください：
 
 3. アプリにプラグインをインストール: <Code code={`npm i @capgo/capacitor-updater`} lang="bash" />
 
-   <Aside type="note" title="古いCapacitorバージョン用のインストール">
-   上記のコマンドは、Capacitor 8用の最新バージョン（v8.x）をインストールします。古いCapacitorバージョンの場合は、適切なnpmタグを使用してください：
-
-   ```bash
-   # Capacitor 7
-   npm i @capgo/capacitor-updater@lts-v7
-
-   # Capacitor 6
-   npm i @capgo/capacitor-updater@lts-v6
-
-   # Capacitor 5
-   npm i @capgo/capacitor-updater@lts-v5
-   ```
-
-   各プラグインのメジャーバージョンはCapacitorのメジャーバージョンに対応しています（v8 → Capacitor 8、v7 → Capacitor 7、v6 → Capacitor 6、v5 → Capacitor 5）。マイナーバージョンはすべてのメジャーバージョンで同じ機能セットを共有しています（例：5.34.0、6.34.0、7.34.0、8.34.0はすべて同じ機能を含みます）。
-   </Aside><LinkCard href="/docs/getting-started/onboarding/" title="詳細なオンボーディングガイド" description="CLIオンボーディングプロセスの完全なステップバイステップガイドをご覧ください" />
-
 4. `capacitor.config`でプラグインを設定: <Code code={`{\n  "plugins": {\n    CapacitorUpdater: {\n      "appId": "Your appID",\n      "autoUpdate": true,\n      "version": "1.0.0"\n    }\n  }\n}`} lang="json" />
   [利用可能なすべてのオプションを見る](/docs/plugin/settings/)。提供されない場合、この情報は推測されます。
 
 5. アプリでできるだけ早く初期化メソッドを呼び出す: <Code code={`import { CapacitorUpdater } from '@capgo/capacitor-updater';\nCapacitorUpdater.notifyAppReady();`} lang="typescript" />
 
-5. ライブアップデートをデプロイ <LinkCard href="/docs/getting-started/deploy/" title="ライブアップデートをデプロイ" description="アプリにライブアップデートをデプロイする方法を学ぶ" />
+6. ライブアップデートをデプロイ
 
 </Steps>
+
+<Aside type="note" title="古いCapacitorバージョン用のインストール">
+上記のコマンドは、Capacitor 8用の最新バージョン（v8.x）をインストールします。古いCapacitorバージョンの場合は、適切なnpmタグを使用してください：
+
+```bash
+# Capacitor 7
+npm i @capgo/capacitor-updater@lts-v7
+
+# Capacitor 6
+npm i @capgo/capacitor-updater@lts-v6
+
+# Capacitor 5
+npm i @capgo/capacitor-updater@lts-v5
+```
+
+各プラグインのメジャーバージョンはCapacitorのメジャーバージョンに対応しています（v8 → Capacitor 8、v7 → Capacitor 7、v6 → Capacitor 6、v5 → Capacitor 5）。マイナーバージョンはすべてのメジャーバージョンで同じ機能セットを共有しています（例：5.34.0、6.34.0、7.34.0、8.34.0はすべて同じ機能を含みます）。
+</Aside>

--- a/src/content/docs/ko/docs/getting-started/add-an-app.mdx
+++ b/src/content/docs/ko/docs/getting-started/add-an-app.mdx
@@ -33,11 +33,15 @@ Capgo를 시작하기 전에 다음을 확인하세요:
 1. [https://capgo.app/register](https://capgo.app/register)에서 계정을 생성하세요
 ![signup screenshot](/signup.webp "signup screenshot")
 
-2. 시작하기 위해 Init 명령어를 사용하세요 <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> 일련의 질문이 표시될 것입니다. 자동 설정을 완료하기 위해 필요한 답변을 제공하세요<Aside type="tip">이러한 단계를 따르면 곧바로 시작할 수 있습니다. 과정 중에 추가 도움이 필요하시다면, 저희 지원팀이 [도와드리겠습니다](https://support.capgo.app). 즐거운 온보딩 되세요!</Aside><LinkCard href="/docs/getting-started/onboarding/" title="상세한 온보딩 가이드" description="CLI 온보딩 프로세스에 대한 전체 단계별 가이드 보기" />
+2. 시작하기 위해 Init 명령어를 사용하세요 <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> 일련의 질문이 표시될 것입니다. 자동 설정을 완료하기 위해 필요한 답변을 제공하세요
 
-3. 실시간 업데이트 배포하기 <LinkCard href="/docs/getting-started/deploy/" title="실시간 업데이트 배포" description="앱에 실시간 업데이트를 배포하는 방법 알아보기" />
+3. 실시간 업데이트 배포하기
 
 </Steps>
+
+<Aside type="tip">이러한 단계를 따르면 곧바로 시작할 수 있습니다. 과정 중에 추가 도움이 필요하시다면, 저희 지원팀이 [도와드리겠습니다](https://support.capgo.app). 즐거운 온보딩 되세요!</Aside>
+<LinkCard href="/docs/getting-started/onboarding/" title="상세한 온보딩 가이드" description="CLI 온보딩 프로세스에 대한 전체 단계별 가이드 보기" />
+<LinkCard href="/docs/getting-started/deploy/" title="실시간 업데이트 배포" description="앱에 실시간 업데이트를 배포하는 방법 알아보기" />
 
 ### 수동 설정
 
@@ -51,28 +55,28 @@ Init 명령어가 작동하지 않는 경우, 수동으로 앱을 추가할 수 
 
 3. 앱에 플러그인을 설치하세요: <Code code={`npm i @capgo/capacitor-updater`} lang="bash" />
 
-   <Aside type="note" title="이전 Capacitor 버전용 설치">
-   위 명령어는 Capacitor 8용 최신 버전 (v8.x)을 설치합니다. 이전 Capacitor 버전의 경우 해당 npm 태그를 사용하세요:
-
-   ```bash
-   # Capacitor 7
-   npm i @capgo/capacitor-updater@lts-v7
-
-   # Capacitor 6
-   npm i @capgo/capacitor-updater@lts-v6
-
-   # Capacitor 5
-   npm i @capgo/capacitor-updater@lts-v5
-   ```
-
-   각 플러그인 주요 버전은 Capacitor 주요 버전과 일치합니다 (v8 → Capacitor 8, v7 → Capacitor 7, v6 → Capacitor 6, v5 → Capacitor 5). 모든 주요 버전의 동일한 마이너 버전은 같은 기능 세트를 공유합니다 (예: 5.34.0, 6.34.0, 7.34.0, 8.34.0 모두 동일한 기능 포함).
-   </Aside><LinkCard href="/docs/getting-started/onboarding/" title="상세한 온보딩 가이드" description="CLI 온보딩 프로세스에 대한 전체 단계별 가이드 보기" />
-
 4. 앱 설정 파일에서 플러그인을 구성하세요 <Code code={`{\n  "plugins": {\n    CapacitorUpdater: {\n      "appId": "Your appID",\n      "autoUpdate": true,\n      "version": "1.0.0"\n    }\n  }\n}`} lang="json" />
   [사용 가능한 모든 옵션 보기](/docs/plugin/settings/). 제공되지 않으면 이 정보가 유추됩니다.
 
 5. 앱에서 가능한 한 빨리 init 메소드를 호출하세요: <Code code={`import { CapacitorUpdater } from '@capgo/capacitor-updater';\nCapacitorUpdater.notifyAppReady();`} lang="typescript" />
 
-6. 실시간 업데이트 배포하기 <LinkCard href="/docs/getting-started/deploy/" title="실시간 업데이트 배포" description="앱에 실시간 업데이트를 배포하는 방법 알아보기" />
+6. 실시간 업데이트 배포하기
 
 </Steps>
+
+<Aside type="note" title="이전 Capacitor 버전용 설치">
+위 명령어는 Capacitor 8용 최신 버전 (v8.x)을 설치합니다. 이전 Capacitor 버전의 경우 해당 npm 태그를 사용하세요:
+
+```bash
+# Capacitor 7
+npm i @capgo/capacitor-updater@lts-v7
+
+# Capacitor 6
+npm i @capgo/capacitor-updater@lts-v6
+
+# Capacitor 5
+npm i @capgo/capacitor-updater@lts-v5
+```
+
+각 플러그인 주요 버전은 Capacitor 주요 버전과 일치합니다 (v8 → Capacitor 8, v7 → Capacitor 7, v6 → Capacitor 6, v5 → Capacitor 5). 모든 주요 버전의 동일한 마이너 버전은 같은 기능 세트를 공유합니다 (예: 5.34.0, 6.34.0, 7.34.0, 8.34.0 모두 동일한 기능 포함).
+</Aside>

--- a/src/content/docs/zh/docs/getting-started/add-an-app.mdx
+++ b/src/content/docs/zh/docs/getting-started/add-an-app.mdx
@@ -34,11 +34,15 @@ import { Aside, Steps, LinkCard, Code } from '@astrojs/starlight/components';
 1. 在 [https://capgo.app/register](https://capgo.app/register) 创建您的账户。
 ![注册截图](/signup.webp "注册截图")
 
-2. 使用 Init 命令开始 <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> 您将看到一系列问题。提供必要的答案以完成自动设置。<Aside type="tip">通过遵循这些步骤，您将很快启动并运行。如果您在此过程中需要任何进一步的帮助，我们的支持团队[随时为您提供帮助](https://support.capgo.app)。祝您入门顺利！</Aside><LinkCard href="/docs/getting-started/onboarding/" title="详细的入门指南" description="查看CLI入门流程的完整分步指南" />
+2. 使用 Init 命令开始 <Code code={`npx @capgo/cli@latest init [APIKEY]`} lang="bash" /> 您将看到一系列问题。提供必要的答案以完成自动设置。
 
-3. 部署实时更新 <LinkCard href="/docs/getting-started/deploy/" title="部署实时更新" description="了解如何将实时更新部署到您的应用" />
+3. 部署实时更新
 
 </Steps>
+
+<Aside type="tip">通过遵循这些步骤，您将很快启动并运行。如果您在此过程中需要任何进一步的帮助，我们的支持团队[随时为您提供帮助](https://support.capgo.app)。祝您入门顺利！</Aside>
+<LinkCard href="/docs/getting-started/onboarding/" title="详细的入门指南" description="查看CLI入门流程的完整分步指南" />
+<LinkCard href="/docs/getting-started/deploy/" title="部署实时更新" description="了解如何将实时更新部署到您的应用" />
 
 ### 手动设置
 
@@ -52,28 +56,28 @@ import { Aside, Steps, LinkCard, Code } from '@astrojs/starlight/components';
 
 3. 在您的应用中安装插件：<Code code={`npm i @capgo/capacitor-updater`} lang="bash" />
 
-   <Aside type="note" title="为旧版 Capacitor 安装">
-   上面的命令会安装最新版本 (v8.x)，适用于 Capacitor 8。对于旧版 Capacitor，请使用相应的 npm 标签：
-
-   ```bash
-   # Capacitor 7
-   npm i @capgo/capacitor-updater@lts-v7
-
-   # Capacitor 6
-   npm i @capgo/capacitor-updater@lts-v6
-
-   # Capacitor 5
-   npm i @capgo/capacitor-updater@lts-v5
-   ```
-
-   每个插件主版本对应 Capacitor 主版本（v8 → Capacitor 8，v7 → Capacitor 7，v6 → Capacitor 6，v5 → Capacitor 5）。所有主版本的相同次版本号具有相同的功能集（例如，5.34.0、6.34.0、7.34.0 和 8.34.0 都包含相同的功能）。
-   </Aside><LinkCard href="/docs/getting-started/onboarding/" title="详细的入门指南" description="查看CLI入门流程的完整分步指南" />
-
 4. 在您的 `capacitor.config` 中配置插件 <Code code={`{\n  "plugins": {\n    CapacitorUpdater: {\n      "appId": "Your appID",\n      "autoUpdate": true,\n      "version": "1.0.0"\n    }\n  }\n}`} lang="json" />
   [查看所有可用选项](/docs/plugin/settings/)。如果未提供，此信息将被推断。
 
 5. 在您的应用中尽早调用 init 方法：<Code code={`import { CapacitorUpdater } from '@capgo/capacitor-updater';\nCapacitorUpdater.notifyAppReady();`} lang="typescript" />
 
-6. 部署实时更新 <LinkCard href="/docs/getting-started/deploy/" title="部署实时更新" description="了解如何将实时更新部署到您的应用" />
+6. 部署实时更新
 
 </Steps>
+
+<Aside type="note" title="为旧版 Capacitor 安装">
+上面的命令会安装最新版本 (v8.x)，适用于 Capacitor 8。对于旧版 Capacitor，请使用相应的 npm 标签：
+
+```bash
+# Capacitor 7
+npm i @capgo/capacitor-updater@lts-v7
+
+# Capacitor 6
+npm i @capgo/capacitor-updater@lts-v6
+
+# Capacitor 5
+npm i @capgo/capacitor-updater@lts-v5
+```
+
+每个插件主版本对应 Capacitor 主版本（v8 → Capacitor 8，v7 → Capacitor 7，v6 → Capacitor 6，v5 → Capacitor 5）。所有主版本的相同次版本号具有相同的功能集（例如，5.34.0、6.34.0、7.34.0 和 8.34.0 都包含相同的功能）。
+</Aside>


### PR DESCRIPTION
## Summary
- Fixes the main branch build failure: `The <Steps> component expects its content to be a single ordered list (<ol>) but found multiple child elements: <ol>, <div>, <ol>, <div>.`
- Moves `<Aside>` and `<LinkCard>` components outside `<Steps>` blocks in all 9 language variants of `getting-started/add-an-app.mdx`

## Root cause
Starlight's `<Steps>` component only accepts a single `<ol>` child. `<Aside>` and `<LinkCard>` render as `<div>` elements, which break the component when placed inside `<Steps>`.

## Test plan
- [ ] Website build passes on CI
- [ ] Verify add-an-app page renders correctly in all languages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured the Getting Started guide with improved step-by-step clarity and modular sections
  * Added explicit plugin configuration examples and code snippets
  * Introduced version-specific installation instructions for Capacitor 7, 6, and 5
  * Separated auxiliary guidance and reference links from main steps for better readability
  * Enhanced across all supported language versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->