### PR TITLE
fix: prevent Starlight <Steps> build failures in FR live-update docs

### DIFF
--- a/src/content/docs/fr/docs/live-updates/china-configuration.mdx
+++ b/src/content/docs/fr/docs/live-updates/china-configuration.mdx
@@ -113,17 +113,17 @@ export default config;
 
 1. Uploadez un bundle de test:
 
-```shell
-npx @capgo/cli@latest bundle upload --channel=production
-```
+    ```shell
+    npx @capgo/cli@latest bundle upload --channel=production
+    ```
 
 2. Installez l'application sur un appareil de test.
 
 3. Surveillez le processus:
 
-```shell
-npx @capgo/cli@latest app debug
-```
+    ```shell
+    npx @capgo/cli@latest app debug
+    ```
 
 4. Vérifiez que les requêtes partent bien vers `updater.capgo.com.cn`.
 

--- a/src/content/docs/fr/docs/live-updates/encryption.mdx
+++ b/src/content/docs/fr/docs/live-updates/encryption.mdx
@@ -135,22 +135,22 @@ npx @capgo/cli@latest bundle upload --key-v2
 
 1. Créer le zip:
 
-```shell
-npx @capgo/cli@latest bundle zip com.example.app --path ./dist --key-v2
-```
+    ```shell
+    npx @capgo/cli@latest bundle zip com.example.app --path ./dist --key-v2
+    ```
 
 2. Chiffrer:
 
-```shell
-npx @capgo/cli@latest bundle encrypt ./com.example.app.zip CHECKSUM_FROM_STEP_1
-```
+    ```shell
+    npx @capgo/cli@latest bundle encrypt ./com.example.app.zip CHECKSUM_FROM_STEP_1
+    ```
 
 3. Uploader sur votre stockage puis enregistrer l'URL:
 
-```shell
-aws s3 cp ./encrypted-bundle.zip s3://your-bucket/encrypted-bundle.zip
-npx @capgo/cli@latest bundle upload --external https://your-storage.com/encrypted-bundle.zip --iv-session-key IV_SESSION_KEY_FROM_STEP_2
-```
+    ```shell
+    aws s3 cp ./encrypted-bundle.zip s3://your-bucket/encrypted-bundle.zip
+    npx @capgo/cli@latest bundle upload --external https://your-storage.com/encrypted-bundle.zip --iv-session-key IV_SESSION_KEY_FROM_STEP_2
+    ```
 
 </Steps>
 
@@ -175,16 +175,16 @@ npx @capgo/cli@latest bundle upload --key-data-v2 "$CAPGO_PRIVATE_KEY"
 
 1. Générer de nouvelles clés:
 
-```shell
-mkdir ./new-keys && cd ./new-keys
-npx @capgo/cli@latest key create
-```
+    ```shell
+    mkdir ./new-keys && cd ./new-keys
+    npx @capgo/cli@latest key create
+    ```
 
 2. Enregistrer la nouvelle clé publique:
 
-```shell
-npx @capgo/cli@latest key save --key ./new-keys/.capgo_key_v2.pub
-```
+    ```shell
+    npx @capgo/cli@latest key save --key ./new-keys/.capgo_key_v2.pub
+    ```
 
 3. Publier une version native embarquant la nouvelle clé publique.
 


### PR DESCRIPTION
## Summary
- Fix invalid `<Steps>` markdown structure in French live-update docs by indenting fenced code blocks as list-item children.
- Update `china-configuration.mdx` and `encryption.mdx` so Starlight receives a single ordered list instead of `<ol>/<div>` siblings.
- Keep scope minimal to CI-blocking content only.

## Verification
- Reproduced the CI failure from run `22471503540` (job `65089293554`) and confirmed root cause (`AstroUserError` from `<Steps>`).
- Ran local checks/build with Bun:
  - `bun run build:prepare && bun run build` (pass)
  - `bun run build` (pass)
  - `bunx astro check` with increased memory (`NODE_OPTIONS=--max-old-space-size=16384`) (pass with warnings only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Enhanced code block indentation and formatting in French language documentation guides for improved visual presentation and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->