### PR TITLE
docs: iOS multi-target signing documentation

### DIFF
--- a/src/content/docs/docs/cli/cloud-build/credentials.mdx
+++ b/src/content/docs/docs/cli/cloud-build/credentials.mdx
@@ -46,12 +46,35 @@ Store your build credentials locally for automatic use:
 npx @capgo/cli build credentials save --platform <ios|android> [options]
 ```
 
+### Update Credentials
+
+Partially update existing credentials without re-providing everything:
+
+```bash
+npx @capgo/cli build credentials update --platform <ios|android> [options]
+```
+
+The `update` command uses **additive merge** for provisioning profiles — new profiles are merged with existing ones. To replace the entire provisioning map instead, add `--overwrite-ios-provisioning-map`.
+
+Example — add an extension profile to existing credentials:
+
+```bash
+npx @capgo/cli build credentials update \
+  --platform ios \
+  --ios-provisioning-profile "com.example.app.widget=./widget_profile.mobileprovision"
+```
+
+The update command accepts the same options as `save` but all are optional — only the fields you provide are updated.
+
 ### List Credentials
 
 View currently saved credentials (passwords are masked):
 
 ```bash
 npx @capgo/cli build credentials list
+
+# List credentials for a specific app
+npx @capgo/cli build credentials list --appId com.example.app
 ```
 
 ### Clear Credentials
@@ -62,12 +85,19 @@ Remove saved credentials from your local machine:
 # Clear all credentials
 npx @capgo/cli build credentials clear
 
-# Clear only iOS credentials
-npx @capgo/cli build credentials clear --platform ios
-
-# Clear only Android credentials
-npx @capgo/cli build credentials clear --platform android
+# Clear credentials for a specific app + platform
+npx @capgo/cli build credentials clear --appId com.example.app --platform ios
 ```
+
+### Migrate Credentials
+
+Convert legacy single-profile format to the new multi-target format:
+
+```bash
+npx @capgo/cli build credentials migrate --platform ios
+```
+
+The migrate command detects old `BUILD_PROVISION_PROFILE_BASE64` credentials, converts them to `CAPGO_IOS_PROVISIONING_MAP`, and removes the legacy keys. See [Migration from Single Profile](/docs/cli/cloud-build/ios/#migration-from-single-profile) for details.
 
 ## Saving iOS Credentials
 
@@ -101,11 +131,12 @@ npx @capgo/cli build credentials save \
 | `--apple-issuer-id <id>` | App Store Connect API Issuer ID (UUID) | See note¹ |
 | `--apple-team-id <id>` | App Store Connect Team ID | Yes |
 | `--ios-distribution <mode>` | Distribution mode: `app_store` (default) or `ad_hoc` | No |
-| `--apple-id <email>` | Apple ID email (alternative auth) | No |
-| `--apple-app-password <password>` | App-specific password (alternative auth) | No |
+| `--output-upload` | Enable a time-limited Capgo download link for the build artifact | No (default: `false`) |
+| `--output-retention <seconds>` | How long to keep build outputs (e.g. `3600s`) | No (default: `3600s`) |
+| `--skip-build-number-bump` | Skip automatic build-number increment | No |
 
 <Aside type="note" title="¹ App Store Connect API Key Requirements">
-- **`app_store` mode** (default): All three options are **required** — they are used to upload your build to TestFlight / App Store.
+- **`app_store` mode** (default): All three API key options are **required** unless you pass `--output-upload` or `--skip-build-number-bump` (which bypass the need for API-driven submission).
 - **`ad_hoc` mode**: These options are **not required** — no App Store submission takes place. See [Ad-Hoc Distribution Mode](/docs/cli/cloud-build/ios/#ad-hoc-distribution-mode) for details.
 </Aside>
 
@@ -475,10 +506,11 @@ If you're currently using environment variables, you can migrate to saved creden
      --apple-team-id "$APP_STORE_CONNECT_TEAM_ID"
    ```
 
-   If you have existing credentials saved in the old format, run:
+   If you have existing credentials saved in the old format (single `BUILD_PROVISION_PROFILE_BASE64`), run:
    ```bash
    npx @capgo/cli build credentials migrate --platform ios
    ```
+   This converts the legacy single-profile to a `CAPGO_IOS_PROVISIONING_MAP` and removes the old `BUILD_PROVISION_PROFILE_BASE64` and `APPLE_PROFILE_NAME` keys.
 
 4. **Test the build**
    ```bash

--- a/src/content/docs/docs/cli/cloud-build/ios.mdx
+++ b/src/content/docs/docs/cli/cloud-build/ios.mdx
@@ -702,20 +702,25 @@ You need one distribution certificate for all targets — only provisioning prof
 
 ### Migration from Single Profile
 
-If you previously used `--provisioning-profile` (single profile), run:
+If you previously used `BUILD_PROVISION_PROFILE_BASE64` (single profile), run:
 
 ```bash
 npx @capgo/cli build credentials migrate --platform ios
 ```
 
-This converts your existing single-profile credentials to the new map format. After migration, add extension profiles:
+This converts your existing single-profile credentials to the new `CAPGO_IOS_PROVISIONING_MAP` format and removes the legacy keys (`BUILD_PROVISION_PROFILE_BASE64`, `APPLE_PROFILE_NAME`).
+
+After migration, add extension profiles with the `update` command (additive merge):
 
 ```bash
-npx @capgo/cli build credentials save \
+npx @capgo/cli build credentials update \
   --platform ios \
-  --ios-provisioning-profile "com.example.app.share-extension=./share_ext_profile.mobileprovision" \
-  # ... other options
+  --ios-provisioning-profile "com.example.app.share-extension=./share_ext_profile.mobileprovision"
 ```
+
+<Aside type="tip">
+Use `update` (not `save`) to add profiles to existing credentials. The `update` command merges new profiles with existing ones. Use `save` only when setting up all credentials from scratch.
+</Aside>
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Update credentials.mdx: replace old profile flags/env vars with `--ios-provisioning-profile` and `CAPGO_IOS_PROVISIONING_MAP`
- Update ios.mdx: replace old profile flags, add "Apps with Extensions" section
- Add migration instructions for `build credentials migrate --platform ios`
- Update CI/CD examples (GitHub Actions) with new env vars

## Related PRs
- CLI: Cap-go/CLI (feat/ios-multi-target-signing)
- Builder: Cap-go/capgo_builder (feat/ios-multi-target-signing)

## Test plan
- [ ] Review docs for accuracy against CLI implementation
- [ ] Verify all code examples use correct flag names
- [ ] Check that migration instructions are clear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Update Credentials flow with provisioning profile merge capabilities
  * Added Migrate Credentials command to convert legacy provisioning formats
  * Enhanced credential management options for listing and clearing per app and platform
  * Introduced new iOS CLI flags for build output control and version management
  * Documented multi-target provisioning support for extensions
  * Updated provisioning map references and migration guidance for workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->