### PR TITLE
[codex] Fix Cordova AI prompt block rendering

### DIFF
--- a/apps/web/src/pages/solutions/cordova-to-capacitor-ai.astro
+++ b/apps/web/src/pages/solutions/cordova-to-capacitor-ai.astro
@@ -14,8 +14,9 @@ const description = m.solutions_cordova_to_capacitor_ai_description({}, { locale
 const pagePath = getRelativeLocaleUrl(locale, 'solutions/cordova-to-capacitor-ai')
 const pageUrl = `${baseUrl}${pagePath}`
 const homeUrl = `${baseUrl}${getRelativeLocaleUrl(locale, '/')}`
-const shellBlockClasses = 'overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm'
-const promptBlockClasses = 'overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm'
+const baseBlockClasses = 'overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm'
+const shellBlockClasses = baseBlockClasses
+const promptBlockClasses = baseBlockClasses
 const promptBlockStyle = 'white-space: pre-wrap; overflow-wrap: anywhere;'
 
 const dateModified = '2026-02-08T00:00:00.000Z'

--- a/apps/web/src/pages/solutions/cordova-to-capacitor-ai.astro
+++ b/apps/web/src/pages/solutions/cordova-to-capacitor-ai.astro
@@ -14,6 +14,9 @@ const description = m.solutions_cordova_to_capacitor_ai_description({}, { locale
 const pagePath = getRelativeLocaleUrl(locale, 'solutions/cordova-to-capacitor-ai')
 const pageUrl = `${baseUrl}${pagePath}`
 const homeUrl = `${baseUrl}${getRelativeLocaleUrl(locale, '/')}`
+const shellBlockClasses = 'overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm'
+const promptBlockClasses = 'overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm'
+const promptBlockStyle = 'white-space: pre-wrap; overflow-wrap: anywhere;'
 
 const dateModified = '2026-02-08T00:00:00.000Z'
 
@@ -142,8 +145,7 @@ const content = {
 
               <h3>{m.solutions_cordova_to_capacitor_ai_step1_title({}, { locale })}</h3>
               <p>{m.solutions_cordova_to_capacitor_ai_step1_subtitle({}, { locale })}</p>
-              <pre
-                class="overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm"><code class="text-gray-200"># In your Cordova project
+              <pre class={shellBlockClasses}><code class="text-gray-200"># In your Cordova project
 cordova plugin list
 cordova platform ls</code></pre>
               <ul>
@@ -154,20 +156,19 @@ cordova platform ls</code></pre>
               </ul>
 
               <h3>{m.solutions_cordova_to_capacitor_ai_step2_title({}, { locale })}</h3>
-              <pre class="overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm"><code class="text-gray-200">bun add @capacitor/core @capacitor/cli
+              <pre class={shellBlockClasses}><code class="text-gray-200">bun add @capacitor/core @capacitor/cli
 bunx cap init</code></pre>
               <p>
                 <span set:html={m.solutions_cordova_to_capacitor_ai_step2_body({}, { locale })} />
               </p>
 
               <h3>{m.solutions_cordova_to_capacitor_ai_step3_title({}, { locale })}</h3>
-              <pre
-                class="overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm"><code class="text-gray-200">bun add @capacitor/ios @capacitor/android
+              <pre class={shellBlockClasses}><code class="text-gray-200">bun add @capacitor/ios @capacitor/android
 bunx cap add ios
 bunx cap add android</code></pre>
 
               <h3>{m.solutions_cordova_to_capacitor_ai_step4_title({}, { locale })}</h3>
-              <pre class="overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm"><code class="text-gray-200">bun run build
+              <pre class={shellBlockClasses}><code class="text-gray-200">bun run build
 bunx cap sync</code></pre>
 
               <h2 id="plugins">{m.solutions_cordova_to_capacitor_ai_section_plugins_title({}, { locale })}</h2>
@@ -244,7 +245,8 @@ bunx cap sync</code></pre>
 
               <h3>{m.solutions_cordova_to_capacitor_ai_prompt1_title({}, { locale })}</h3>
               <pre
-                class="overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm"><code class="text-gray-200">You are a senior Capacitor engineer.
+                class={promptBlockClasses}
+                style={promptBlockStyle}><code class="text-gray-200">You are a senior Capacitor engineer.
 
 I am migrating a Cordova app to Capacitor. Here is my `cordova plugin list` output:
 &lt;PASTE HERE&gt;
@@ -263,7 +265,8 @@ Return a prioritized plan (highest risk first).</code></pre>
 
               <h3>{m.solutions_cordova_to_capacitor_ai_prompt2_title({}, { locale })}</h3>
               <pre
-                class="overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm"><code class="text-gray-200">You are migrating Cordova to Capacitor.
+                class={promptBlockClasses}
+                style={promptBlockStyle}><code class="text-gray-200">You are migrating Cordova to Capacitor.
 
 Here is my Cordova `config.xml`:
 &lt;PASTE HERE&gt;
@@ -276,7 +279,8 @@ Be explicit about file names and what to change.</code></pre>
 
               <h3>{m.solutions_cordova_to_capacitor_ai_prompt3_title({}, { locale })}</h3>
               <pre
-                class="overflow-x-auto rounded-lg bg-gray-900 p-4 text-sm"><code class="text-gray-200">You are the QA lead for a Cordova -&gt; Capacitor migration.
+                class={promptBlockClasses}
+                style={promptBlockStyle}><code class="text-gray-200">You are the QA lead for a Cordova -&gt; Capacitor migration.
 
 App description:
 &lt;PASTE HERE&gt;


### PR DESCRIPTION
## What changed
- wrapped the long AI prompt code blocks on the Cordova-to-Capacitor AI solution page
- kept the shorter shell command blocks using the existing horizontal-scroll behavior
- extracted shared block class/style constants in the page to keep the template consistent

## Why
The prompt blocks were rendered with `white-space: pre`, which made long prompt lines overflow badly on narrow viewports instead of displaying as readable multiline blocks.

## Impact
- mobile and narrow desktop layouts now show the AI prompts as readable wrapped blocks
- command snippets still preserve the current copy/paste-friendly presentation

## Validation
- `bunx prettier --write apps/web/src/pages/solutions/cordova-to-capacitor-ai.astro`
- `cd apps/web && bun run check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved text wrapping and overflow handling for code blocks and examples, ensuring long lines remain readable without breaking the page layout.
  * Enhanced formatting for AI-generated prompts with better text wrapping and word-breaking behavior.
  * Consistent styling applied across all code snippets and prompt sections.
  * Introduced shared styling for code and prompt blocks to standardize appearance and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->