### PR TITLE
[codex] add capacitor-proximity to docs and landing

### DIFF
--- a/apps/docs/public/icons/plugins/proximity.svg
+++ b/apps/docs/public/icons/plugins/proximity.svg
@@ -1,0 +1,8 @@
+<svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="56" height="56" rx="12" fill="#0F766E" />
+  <rect x="16" y="10" width="18" height="36" rx="5" fill="white" fill-opacity="0.18" stroke="white" stroke-width="2" />
+  <rect x="20" y="15" width="10" height="21" rx="2" fill="white" />
+  <circle cx="25" cy="41" r="2" fill="white" />
+  <path d="M39 18C42.3137 20.6667 44 24 44 28C44 32 42.3137 35.3333 39 38" stroke="white" stroke-width="2.5" stroke-linecap="round" />
+  <path d="M35 22C37 23.6667 38 25.6667 38 28C38 30.3333 37 32.3333 35 34" stroke="white" stroke-width="2.5" stroke-linecap="round" />
+</svg>

--- a/apps/docs/src/config/llmsCustomSets.ts
+++ b/apps/docs/src/config/llmsCustomSets.ts
@@ -70,6 +70,7 @@ Plugin NFC|NFC reading and writing plugin|docs/plugins/nfc/**
 Plugin Pay|Apple Pay and Google Pay integration plugin|docs/plugins/pay/**
 Plugin Passkey|browser-style WebAuthn passkey plugin with native shims and generated platform configuration|docs/plugins/passkey/**
 Plugin Privacy Screen|privacy screen plugin for hiding app content in system previews and screenshots|docs/plugins/privacy-screen/**
+Plugin Proximity|native proximity sensor plugin for face, hand, and surface detection|docs/plugins/proximity/**
 Plugin PDF Generator|PDF generation plugin|docs/plugins/pdf-generator/**
 Plugin Pedometer|step counting pedometer plugin|docs/plugins/pedometer/**
 Plugin Persona|Persona identity verification inquiry plugin|docs/plugins/persona/**

--- a/apps/docs/src/config/sidebar.mjs
+++ b/apps/docs/src/config/sidebar.mjs
@@ -141,6 +141,7 @@ const pluginEntries = [
     [linkItem('iOS setup', '/docs/plugins/passkey/ios'), linkItem('Android setup', '/docs/plugins/passkey/android'), linkItem('Backend notes', '/docs/plugins/passkey/backend')],
   ],
   ['Privacy Screen', 'privacy-screen', [linkItem('iOS behavior', '/docs/plugins/privacy-screen/ios'), linkItem('Android behavior', '/docs/plugins/privacy-screen/android')]],
+  ['Proximity', 'proximity'],
   ['PDF Generator', 'pdf-generator'],
   ['Pedometer', 'pedometer'],
   ['Persona', 'persona'],

--- a/apps/docs/src/content/docs/docs/plugins/proximity/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/proximity/getting-started.mdx
@@ -1,0 +1,192 @@
+---
+title: Getting Started
+description: Learn how to install and use the Proximity plugin to enable near-sensor behavior in your Capacitor app.
+sidebar:
+  order: 2
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+<Steps>
+1. **Install the package**
+   ```bash
+   bun add @capgo/capacitor-proximity
+   ```
+
+2. **Sync with native projects**
+   ```bash
+   bunx cap sync
+   ```
+</Steps>
+
+## Platform Behavior
+
+### iOS
+
+Works out of the box. The plugin enables and disables `UIDevice.isProximityMonitoringEnabled`, so iOS manages the exact screen-off behavior.
+
+### Android
+
+Works out of the box. The plugin listens to `Sensor.TYPE_PROXIMITY` and dims the current app window while the sensor is covered. No runtime permissions are required.
+
+### Web
+
+The plugin is not available on the web. `getStatus()` reports `available: false` and `platform: 'web'`.
+
+## Basic Usage
+
+Import the plugin, check whether the sensor is available, and enable it only for the flow that needs it:
+
+```typescript
+import { CapacitorProximity } from '@capgo/capacitor-proximity';
+
+const runProximityFlow = async () => {
+  const status = await CapacitorProximity.getStatus();
+
+  if (!status.available) {
+    console.warn('Proximity sensor not available on this device');
+    return;
+  }
+
+  await CapacitorProximity.enable();
+
+  try {
+    console.log('Proximity monitoring active');
+    // Run your near-ear, privacy, or face-down flow here.
+  } finally {
+    await CapacitorProximity.disable();
+  }
+};
+```
+
+## API Reference
+
+### enable()
+
+Enable proximity monitoring.
+
+```typescript
+await CapacitorProximity.enable();
+```
+
+- iOS: enables `UIDevice.isProximityMonitoringEnabled`
+- Android: starts monitoring `TYPE_PROXIMITY` and dims the current app window while the sensor is covered
+
+### disable()
+
+Disable proximity monitoring and restore normal behavior.
+
+```typescript
+await CapacitorProximity.disable();
+```
+
+### getStatus()
+
+Check whether the device supports proximity and whether monitoring is currently enabled.
+
+```typescript
+const status = await CapacitorProximity.getStatus();
+
+console.log(status.available);
+console.log(status.enabled);
+console.log(status.platform);
+```
+
+```typescript
+interface ProximityStatusResult {
+  available: boolean;
+  enabled: boolean;
+  platform: 'ios' | 'android' | 'web';
+}
+```
+
+### getPluginVersion()
+
+Read the native plugin version string.
+
+```typescript
+const { version } = await CapacitorProximity.getPluginVersion();
+console.log(version);
+```
+
+## Complete Example
+
+```typescript
+import { App } from '@capacitor/app';
+import { CapacitorProximity } from '@capgo/capacitor-proximity';
+
+export class ProximitySession {
+  private active = false;
+
+  async init() {
+    const status = await CapacitorProximity.getStatus();
+    if (!status.available) {
+      throw new Error('Proximity sensor not available on this device');
+    }
+
+    App.addListener('appStateChange', async ({ isActive }) => {
+      if (!this.active) {
+        return;
+      }
+
+      if (!isActive) {
+        await CapacitorProximity.disable();
+        return;
+      }
+
+      await CapacitorProximity.enable();
+    });
+  }
+
+  async start() {
+    if (this.active) {
+      return;
+    }
+
+    await CapacitorProximity.enable();
+    this.active = true;
+  }
+
+  async stop() {
+    if (!this.active) {
+      return;
+    }
+
+    await CapacitorProximity.disable();
+    this.active = false;
+  }
+
+  async debugVersion() {
+    const { version } = await CapacitorProximity.getPluginVersion();
+    console.log('Capacitor Proximity version:', version);
+  }
+}
+```
+
+## Best Practices
+
+1. **Check availability first**
+   ```typescript
+   const status = await CapacitorProximity.getStatus();
+   if (!status.available) {
+     return;
+   }
+   ```
+
+2. **Enable only when needed**
+   Keep proximity monitoring limited to the exact user flow that needs it, then call `disable()` immediately afterward.
+
+3. **Test on real devices**
+   Simulators and most desktop browsers do not expose a working proximity sensor.
+
+4. **Always clean up**
+   ```typescript
+   await CapacitorProximity.disable();
+   ```
+
+## Common Use Cases
+
+- Near-ear experiences for voice or call-style interactions
+- Privacy screens that should dim when a hand covers the sensor
+- Face-down or pocket-aware app behavior
+- Debugging native plugin installation with `getPluginVersion()`

--- a/apps/docs/src/content/docs/docs/plugins/proximity/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/proximity/index.mdx
@@ -1,0 +1,46 @@
+---
+title: "@capgo/capacitor-proximity"
+description: Enable native proximity monitoring in your Capacitor app for near-ear, face-down, and sensor-covered flows.
+tableOfContents: false
+next: false
+prev: false
+sidebar:
+  order: 1
+  label: "Introduction"
+hero:
+  tagline: Enable native proximity monitoring so your app can react when the device is held to the ear, covered by a hand, or placed face down.
+  image:
+    file: ~public/icons/plugins/proximity.svg
+  actions:
+    - text: Get started
+      link: /docs/plugins/proximity/getting-started/
+      icon: right-arrow
+      variant: primary
+    - text: Github
+      link: https://github.com/Cap-go/capacitor-proximity/
+      icon: external
+      variant: minimal
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+<CardGrid stagger>
+  <Card title="Simple Control" icon="rocket">
+    Turn proximity monitoring on when a flow starts and disable it cleanly when it ends
+  </Card>
+  <Card title="Native iOS Behavior" icon="device-mobile">
+    Uses `UIDevice.isProximityMonitoringEnabled` so iOS handles the screen behavior natively
+  </Card>
+  <Card title="Android Sensor Support" icon="setting">
+    Listens to `Sensor.TYPE_PROXIMITY` and dims the current app window while the sensor is covered
+  </Card>
+  <Card title="Availability Checks" icon="magnifier">
+    Verify whether the current device exposes a usable proximity sensor before enabling the feature
+  </Card>
+  <Card title="Version Reporting" icon="open-book">
+    Read the native plugin version at runtime for debugging, support, and diagnostics
+  </Card>
+  <Card title="Comprehensive Documentation" icon="puzzle">
+    Check the [Documentation](/docs/plugins/proximity/getting-started/) to install and integrate the plugin quickly.
+  </Card>
+</CardGrid>

--- a/apps/docs/src/content/docs/docs/plugins/proximity/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/proximity/index.mdx
@@ -10,7 +10,7 @@ sidebar:
 hero:
   tagline: Enable native proximity monitoring so your app can react when the device is held to the ear, covered by a hand, or placed face down.
   image:
-    file: ~public/icons/plugins/proximity.svg
+    file: /icons/plugins/proximity.svg
   actions:
     - text: Get started
       link: /docs/plugins/proximity/getting-started/

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -76,6 +76,7 @@ const actionDefinitionRows =
 @capgo/capacitor-mux-player|github.com/Cap-go|Stream adaptive bitrate video with Mux player for optimized playback quality|https://github.com/Cap-go/capacitor-mux-player/|Mux Player
 @capgo/capacitor-pay|github.com/Cap-go|Accept payments with Apple Pay and Google Pay for seamless checkout experience|https://github.com/Cap-go/capacitor-pay/|Pay
 @capgo/capacitor-privacy-screen|github.com/Cap-go|Protect app content in Android screenshots and obscure the iOS app switcher snapshot|https://github.com/Cap-go/capacitor-privacy-screen/|Privacy Screen
+@capgo/capacitor-proximity|github.com/Cap-go|Enable native proximity monitoring so your app can react when the device is near a face, hand, or surface|https://github.com/Cap-go/capacitor-proximity/|Proximity
 @capgo/capacitor-pdf-generator|github.com/Cap-go|Create PDF documents from HTML templates for invoices, reports, and receipts|https://github.com/Cap-go/capacitor-pdf-generator/|PDF Generator
 @capgo/capacitor-persistent-account|github.com/Cap-go|Preserve user authentication and account data across app reinstalls and updates|https://github.com/Cap-go/capacitor-persistent-account/|Persistent Account
 @capgo/capacitor-photo-library|github.com/Cap-go|Browse, save, and manage photos and videos in device photo library with permissions|https://github.com/Cap-go/capacitor-photo-library/|Photo Library
@@ -231,6 +232,7 @@ const pluginIconsByName: Record<string, string> = {
   '@capgo/capacitor-speech-synthesis': 'SpeakerWave',
   '@capgo/capacitor-ssl-pinning': 'ShieldCheck',
   '@capgo/capacitor-printer': 'Printer',
+  '@capgo/capacitor-proximity': 'Signal',
   '@capgo/capacitor-zip': 'ArchiveBox',
   '@capgo/capacitor-zebra-datawedge': 'QrCode',
   '@capgo/capacitor-wifi': 'Wifi',

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-proximity.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-proximity.md
@@ -1,0 +1,209 @@
+---
+locale: en
+---
+# Using @capgo/capacitor-proximity Package
+
+The `@capgo/capacitor-proximity` package enables native proximity monitoring in Capacitor apps. It gives you a small API to check sensor availability, enable monitoring for a focused flow, disable it when the flow ends, and read the native plugin version for debugging.
+
+This is useful for near-ear interfaces, privacy screens, or any experience that should react when the device is close to a face, hand, pocket, or flat surface.
+
+## Installation
+
+Install the package in your Capacitor project:
+
+```bash
+bun add @capgo/capacitor-proximity
+bunx cap sync
+```
+
+## How the plugin behaves
+
+### iOS
+
+On iOS, the plugin toggles `UIDevice.isProximityMonitoringEnabled`. Once enabled, iOS manages the actual display behavior.
+
+### Android
+
+On Android, the plugin listens to `Sensor.TYPE_PROXIMITY`. When the sensor is covered, it dims the current app window. When the sensor is no longer covered, the window returns to normal.
+
+### Web
+
+The plugin is not available on the web, so `getStatus()` returns `available: false`.
+
+## Basic usage
+
+Import the plugin and check the current status before enabling it:
+
+```typescript
+import { CapacitorProximity } from '@capgo/capacitor-proximity';
+
+async function setupProximity() {
+  const status = await CapacitorProximity.getStatus();
+
+  if (!status.available) {
+    console.warn('No proximity sensor on this device');
+    return;
+  }
+
+  console.log('Platform:', status.platform);
+  console.log('Already enabled:', status.enabled);
+}
+```
+
+When you need the feature, enable it only for that flow:
+
+```typescript
+import { CapacitorProximity } from '@capgo/capacitor-proximity';
+
+async function startNearEarFlow() {
+  const status = await CapacitorProximity.getStatus();
+
+  if (!status.available) {
+    return;
+  }
+
+  await CapacitorProximity.enable();
+
+  try {
+    console.log('Proximity monitoring enabled');
+    // Handle the interaction here.
+  } finally {
+    await CapacitorProximity.disable();
+  }
+}
+```
+
+## Example service
+
+Here is a small service you can reuse in an Ionic or Capacitor app:
+
+```typescript
+import { App } from '@capacitor/app';
+import { CapacitorProximity } from '@capgo/capacitor-proximity';
+
+export class ProximityService {
+  private active = false;
+
+  async init() {
+    const status = await CapacitorProximity.getStatus();
+
+    if (!status.available) {
+      console.warn('Proximity sensor is unavailable');
+      return false;
+    }
+
+    App.addListener('appStateChange', async ({ isActive }) => {
+      if (!this.active) {
+        return;
+      }
+
+      if (isActive) {
+        await CapacitorProximity.enable();
+        return;
+      }
+
+      await CapacitorProximity.disable();
+    });
+
+    return true;
+  }
+
+  async start() {
+    if (this.active) {
+      return;
+    }
+
+    await CapacitorProximity.enable();
+    this.active = true;
+  }
+
+  async stop() {
+    if (!this.active) {
+      return;
+    }
+
+    await CapacitorProximity.disable();
+    this.active = false;
+  }
+
+  async logVersion() {
+    const { version } = await CapacitorProximity.getPluginVersion();
+    console.log('Plugin version:', version);
+  }
+}
+```
+
+## API summary
+
+### `enable()`
+
+Turns proximity monitoring on.
+
+```typescript
+await CapacitorProximity.enable();
+```
+
+### `disable()`
+
+Turns proximity monitoring off and restores the default app behavior.
+
+```typescript
+await CapacitorProximity.disable();
+```
+
+### `getStatus()`
+
+Returns whether the sensor is available and whether monitoring is currently enabled.
+
+```typescript
+const status = await CapacitorProximity.getStatus();
+
+interface ProximityStatusResult {
+  available: boolean;
+  enabled: boolean;
+  platform: 'ios' | 'android' | 'web';
+}
+```
+
+### `getPluginVersion()`
+
+Returns the native plugin version string.
+
+```typescript
+const { version } = await CapacitorProximity.getPluginVersion();
+```
+
+## Best practices
+
+### Check support before enabling
+
+Always verify the device exposes a proximity sensor:
+
+```typescript
+const status = await CapacitorProximity.getStatus();
+if (!status.available) {
+  return;
+}
+```
+
+### Keep the feature scoped
+
+Do not leave proximity monitoring enabled for the entire app session unless you really need it. Start it for the exact flow, then stop it.
+
+### Test on real hardware
+
+Most simulators and desktop browsers do not provide a real proximity sensor, so test this feature on physical iOS and Android devices.
+
+### Clean up on exit
+
+Disable the plugin in cleanup paths, page teardown, or when the app goes to the background:
+
+```typescript
+await CapacitorProximity.disable();
+```
+
+## Conclusion
+
+`@capgo/capacitor-proximity` gives your Capacitor app a small, native-first way to react to proximity events without building separate platform code yourself. Use it when you need near-ear flows, privacy dimming, or controlled proximity monitoring in iOS and Android.
+
+For more details, read the [official documentation](https://capgo.app/docs/plugins/proximity/) or visit the [GitHub repository](https://github.com/Cap-go/capacitor-proximity).


### PR DESCRIPTION
## What changed
- add `@capgo/capacitor-proximity` to the website plugin registry and sidebar/search config
- add a dedicated proximity docs section, tutorial page, and docs icon

## Why
- expose the new Capgo proximity plugin on the landing site and docs so the GitHub homepage can point to a live docs URL

## Validation
- no local build or fetch steps run for this PR by request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Proximity plugin to the site and plugin listings, including navigation entry and action/icon support.

* **Documentation**
  * Added Proximity plugin landing page and Getting Started guide with installation, platform behavior (iOS/Android/Web), API reference (enable/disable/getStatus/getPluginVersion), examples, best practices, and use cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->