### PR TITLE
Update viaSocket integration copy

### DIFF
--- a/apps/web/src/config/integrations.ts
+++ b/apps/web/src/config/integrations.ts
@@ -9,12 +9,12 @@ export interface IntegrationEntry {
 
 export const integrations: IntegrationEntry[] = [
   {
-    name: 'ViaSocket',
+    name: 'viaSocket',
     href: 'https://viasocket.com/integrations/capgo',
     logo: '/logo_viaSocket.svg',
     target: '_blank',
     rel: 'noopener noreferrer',
-    description: 'Real-time socket integration for Capgo workflows.',
+    description: 'Enable event-based automation for Capgo workflows using viaSocket, with instant triggers and smooth data flow.',
   },
   {
     name: 'Codemagic',


### PR DESCRIPTION
## Summary
- rename the integration label from ViaSocket to viaSocket
- update the integration description copy on the integrations page

## Testing
- attempted `bun run check` in `apps/web` (fails in current repo state because `bunx paraglide-js` resolves to a 404)
- attempted `bunx prettier --check apps/web/src/config/integrations.ts` (fails to resolve `prettier-plugin-astro` from this workspace shape)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the viaSocket integration display name and description to better reflect its event-based automation capabilities in Capgo workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->