### PR TITLE
[codex] Add enterprise SSO and build minute credit pricing

### DIFF
--- a/apps/web/src/components/pricing/CreditPricing.astro
+++ b/apps/web/src/components/pricing/CreditPricing.astro
@@ -8,6 +8,7 @@ export interface Props {
     step_max: number
     price_per_unit: number
     type: string
+    unit_factor: number
   }[]
 }
 
@@ -30,24 +31,36 @@ Object.keys(creditsByType).forEach((type) => {
   creditsByType[type].sort((a, b) => a.step_min - b.step_min)
 })
 
+const typeOrder = ['mau', 'bandwidth', 'storage', 'build_time']
+const sortedCreditTypes = Object.entries(creditsByType).sort(([typeA], [typeB]) => {
+  const orderA = typeOrder.indexOf(typeA)
+  const orderB = typeOrder.indexOf(typeB)
+
+  if (orderA === -1 && orderB === -1) return typeA.localeCompare(typeB)
+  if (orderA === -1) return 1
+  if (orderB === -1) return -1
+  return orderA - orderB
+})
+
 // Format large numbers
-function formatNumber(num: number, type?: string): string {
-  // Convert bytes to GiB for bandwidth and storage
+function formatNumber(num: number, type?: string, unitFactor = 1): string {
+  const normalizedValue = num / unitFactor
+
+  // Convert GiB values to TB when large enough
   if (type === 'bandwidth' || type === 'storage') {
-    const gb = num / (1024 * 1024 * 1024) // Convert bytes to GiB
-    if (gb >= 1000) {
-      return `${(gb / 1000).toFixed(0)} TB`
+    if (normalizedValue >= 1000) {
+      return `${(normalizedValue / 1000).toFixed(0)} TB`
     }
-    return `${gb.toFixed(0)} GiB`
+    return `${normalizedValue.toFixed(0)} GiB`
   }
 
-  if (num >= 1000000) {
-    return `${(num / 1000000).toFixed(0)}M`
+  if (normalizedValue >= 1000000) {
+    return `${(normalizedValue / 1000000).toFixed(0)}M`
   }
-  if (num >= 1000) {
-    return `${(num / 1000).toFixed(0)}k`
+  if (normalizedValue >= 1000) {
+    return `${(normalizedValue / 1000).toFixed(0)}k`
   }
-  return num.toString()
+  return normalizedValue.toString()
 }
 
 // Get type label
@@ -59,6 +72,8 @@ function getTypeLabel(type: string): string {
       return m.bandwidth_gb({}, { locale: Astro.locals.locale })
     case 'storage':
       return m.storage_gb({}, { locale: Astro.locals.locale })
+    case 'build_time':
+      return m.build_minutes({}, { locale: Astro.locals.locale })
     default:
       return type
   }
@@ -73,6 +88,8 @@ function getUnitLabel(type: string): string {
       return m.per_gb({}, { locale: Astro.locals.locale })
     case 'storage':
       return m.per_gb({}, { locale: Astro.locals.locale })
+    case 'build_time':
+      return `/ ${m.build_minutes({}, { locale: Astro.locals.locale })}`
     default:
       return m.per_unit({}, { locale: Astro.locals.locale })
   }
@@ -84,21 +101,21 @@ function formatPrice(price: number): string {
 }
 ---
 
-<section id="credit-pricing" class="py-12 px-0 mx-auto max-w-7xl sm:px-6 lg:px-8">
-  <div class="p-6 bg-white rounded-3xl shadow-xl sm:p-8 lg:p-12">
+<section id="credit-pricing" class="mx-auto max-w-7xl px-0 py-12 sm:px-6 lg:px-8">
+  <div class="rounded-3xl bg-white p-6 shadow-xl sm:p-8 lg:p-12">
     <div class="mb-6 text-center sm:mb-8">
-      <h2 class="inline-flex flex-col gap-2 items-center text-2xl font-bold text-gray-900 sm:flex-row sm:gap-3 sm:text-3xl">
+      <h2 class="inline-flex flex-col items-center gap-2 text-2xl font-bold text-gray-900 sm:flex-row sm:gap-3 sm:text-3xl">
         {m.credit_pricing({}, { locale: Astro.locals.locale })}
       </h2>
     </div>
 
-    <div class="grid gap-6 sm:gap-8 md:grid-cols-3">
+    <div class="grid gap-6 sm:gap-8 md:grid-cols-2 xl:grid-cols-4">
       {
-        Object.entries(creditsByType).map(([type, typeCredits]) => (
-          <div class="p-4 rounded-2xl border border-gray-200 sm:p-6">
-            <h3 class="flex items-center mb-4 text-lg font-semibold text-gray-900 sm:text-xl">
+        sortedCreditTypes.map(([type, typeCredits]) => (
+          <div class="rounded-2xl border border-gray-200 p-4 sm:p-6">
+            <h3 class="mb-4 flex items-center text-lg font-semibold text-gray-900 sm:text-xl">
               {type === 'mau' && (
-                <svg class="mr-2 w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="mr-2 h-5 w-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path
                     stroke-linecap="round"
                     stroke-linejoin="round"
@@ -108,12 +125,12 @@ function formatPrice(price: number): string {
                 </svg>
               )}
               {type === 'bandwidth' && (
-                <svg class="mr-2 w-4 h-4 text-orange-600" fill="currentColor" viewBox="0 0 24 24">
+                <svg class="mr-2 h-4 w-4 text-orange-600" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10" />
                 </svg>
               )}
               {type === 'storage' && (
-                <svg class="mr-2 w-5 h-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="mr-2 h-5 w-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path
                     stroke-linecap="round"
                     stroke-linejoin="round"
@@ -122,18 +139,24 @@ function formatPrice(price: number): string {
                   />
                 </svg>
               )}
+              {type === 'build_time' && (
+                <svg class="mr-2 h-5 w-5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6l4 2" />
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 22a10 10 0 100-20 10 10 0 000 20z" />
+                </svg>
+              )}
               {getTypeLabel(type)}
             </h3>
 
             <div class="space-y-3">
               {typeCredits.map((credit, index) => (
-                <div class="flex flex-col pb-3 space-y-1 border-b border-gray-100 sm:flex-row sm:justify-between sm:items-center sm:space-y-0 last:border-0">
+                <div class="flex flex-col space-y-1 border-b border-gray-100 pb-3 last:border-0 sm:flex-row sm:items-center sm:justify-between sm:space-y-0">
                   <div class="text-xs text-gray-600 sm:text-sm">
                     {index === 0
-                      ? `${m.first({}, { locale: Astro.locals.locale })} ${formatNumber(credit.step_max, type)}`
+                      ? `${m.first({}, { locale: Astro.locals.locale })} ${formatNumber(credit.step_max, type, credit.unit_factor)}`
                       : index === typeCredits.length - 1
-                        ? `${m.over({}, { locale: Astro.locals.locale })} ${formatNumber(credit.step_min, type)}`
-                        : `${m.next({}, { locale: Astro.locals.locale })} ${formatNumber(credit.step_max - credit.step_min, type)}`}
+                        ? `${m.over({}, { locale: Astro.locals.locale })} ${formatNumber(credit.step_min, type, credit.unit_factor)}`
+                        : `${m.next({}, { locale: Astro.locals.locale })} ${formatNumber(credit.step_max - credit.step_min, type, credit.unit_factor)}`}
                   </div>
                   <div class="text-xs font-medium text-gray-900 sm:text-sm">
                     ${formatPrice(credit.price_per_unit)} {getUnitLabel(type)}

--- a/apps/web/src/components/pricing/Plans.astro
+++ b/apps/web/src/components/pricing/Plans.astro
@@ -57,15 +57,14 @@ function buildTimeDisplay(buildTimeSeconds: number) {
 
   if (buildTimeHours >= 1) {
     return `${buildTimeHours} ${m.build_hours({}, { locale: Astro.locals.locale })}`
-  }
-  else {
+  } else {
     return `${buildTimeMinutes} ${m.build_minutes({}, { locale: Astro.locals.locale })}`
   }
 }
 ---
 
 <section id="plans">
-  <div class="grid grid-cols-1 mt-8 space-y-14 sm:grid-cols-2 sm:mt-14 sm:space-y-0 lg:grid-cols-4 lg:gap-6 lg:mt-10 xl:gap-8">
+  <div class="mt-8 grid grid-cols-1 space-y-14 sm:mt-14 sm:grid-cols-2 sm:space-y-0 lg:mt-10 lg:grid-cols-4 lg:gap-6 xl:gap-8">
     {
       pricing.map((plan) => (
         <div
@@ -79,16 +78,16 @@ function buildTimeDisplay(buildTimeSeconds: number) {
           data-plan={plan.name}
         >
           {plan.name === 'Maker' && (
-            <div class="absolute top-0 right-0 flex items-start -mt-10 border-0 sm:-mt-12 lg:-mt-16">
-              <svg class="w-auto h-16 text-blue-600" viewBox="0 0 83 64" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <div class="absolute top-0 right-0 -mt-10 flex items-start border-0 sm:-mt-12 lg:-mt-16">
+              <svg class="h-16 w-auto text-blue-600" viewBox="0 0 83 64" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                 <path d="M4.27758 62.7565C4.52847 63.5461 5.37189 63.9827 6.16141 63.7318L19.0274 59.6434C19.817 59.3925 20.2536 58.5491 20.0027 57.7595C19.7518 56.97 18.9084 56.5334 18.1189 56.7842L6.68242 60.4184L3.04824 48.982C2.79735 48.1924 1.95394 47.7558 1.16441 48.0067C0.374889 48.2576 -0.0617613 49.101 0.189127 49.8905L4.27758 62.7565ZM13.4871 47.8215L12.229 47.0047L13.4871 47.8215ZM39.0978 20.5925L38.1792 19.4067L39.0978 20.5925ZM7.03921 62.9919C8.03518 61.0681 13.1417 51.1083 14.7453 48.6383L12.229 47.0047C10.5197 49.6376 5.30689 59.8127 4.37507 61.6126L7.03921 62.9919ZM14.7453 48.6383C22.0755 37.3475 29.8244 29.6738 40.0164 21.7784L38.1792 19.4067C27.7862 27.4579 19.7827 35.3698 12.229 47.0047L14.7453 48.6383ZM40.0164 21.7784C52.6582 11.9851 67.634 7.57932 82.2576 3.44342L81.4412 0.556653C66.8756 4.67614 51.3456 9.20709 38.1792 19.4067L40.0164 21.7784Z" />
               </svg>
-              <span class="px-4 py-1 -mt-2 -ml-1 text-sm font-semibold text-white bg-blue-600 rounded-md">{m.most_popular({}, { locale: Astro.locals.locale })}</span>
+              <span class="-mt-2 -ml-1 rounded-md bg-blue-600 px-4 py-1 text-sm font-semibold text-white">{m.most_popular({}, { locale: Astro.locals.locale })}</span>
             </div>
           )}
-          <div class="px-4 py-5 bg-gray-50 rounded-t-2xl sm:p-6 sm:rounded-t-3xl">
+          <div class="rounded-t-2xl bg-gray-50 px-4 py-5 sm:rounded-t-3xl sm:p-6">
             <div class="flex items-start">
-              <span class="text-3xl shrink-0">{descToEmoji(plan.description)}</span>
+              <span class="shrink-0 text-3xl">{descToEmoji(plan.description)}</span>
               <div class="ml-6">
                 <h3 class="text-lg font-semibold text-gray-900">{plan.name.toUpperCase()}</h3>
                 <p class="mt-2 text-sm font-normal text-gray-500">{descToText(plan.description)}</p>
@@ -104,7 +103,9 @@ function buildTimeDisplay(buildTimeSeconds: number) {
             </div>
             <p class="mt-8" data-yearly-price style={yearly ? '' : 'display: none'}>
               <span class="text-gray-900">
-                <span>{m.billed_annually_at({}, { locale: Astro.locals.locale })} $<span data-yearly-total>{numberWithSpaces(plan.price_y)}</span></span>
+                <span>
+                  {m.billed_annually_at({}, { locale: Astro.locals.locale })} $<span data-yearly-total>{numberWithSpaces(plan.price_y)}</span>
+                </span>
               </span>
             </p>
             <p class="mt-8" data-monthly-price style={yearly ? 'display: none' : ''}>
@@ -131,7 +132,7 @@ function buildTimeDisplay(buildTimeSeconds: number) {
             </div>
             <ul class="mt-8 space-y-4 text-black">
               <li class="flex items-center">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 mr-1 text-blue-600 shrink-0" width="32" height="32" viewBox="0 0 32 32">
+                <svg xmlns="http://www.w3.org/2000/svg" class="mr-1 h-6 w-6 shrink-0 text-blue-600" width="32" height="32" viewBox="0 0 32 32">
                   <path
                     fill="currentColor"
                     d="M23 23c-5.656 0-7.858-6.41-7.949-6.684C15.034 16.265 13.208 11 9 11c-2.757 0-5 2.243-5 5s2.243 5 5 5c1.588 0 3.013-.732 4.237-2.176l1.526 1.293C13.164 22.003 11.172 23 9 23c-3.86 0-7-3.14-7-7s3.14-7 7-7c5.656 0 7.858 6.41 7.949 6.684C16.966 15.735 18.792 21 23 21c2.757 0 5-2.243 5-5s-2.243-5-5-5c-1.588 0-3.013.732-4.237 2.176l-1.526-1.293C18.836 9.997 20.828 9 23 9c3.86 0 7 3.14 7 7s-3.14 7-7 7"
@@ -140,7 +141,7 @@ function buildTimeDisplay(buildTimeSeconds: number) {
                 <span>{m.unlimited_live_updates({}, { locale: Astro.locals.locale })}</span>
               </li>
               <li class="flex items-center">
-                <svg class="w-5 h-5 mr-2 text-blue-600 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
+                <svg class="mr-2 h-5 w-5 shrink-0 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
                   <path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z" />
                 </svg>
                 <span>
@@ -148,13 +149,17 @@ function buildTimeDisplay(buildTimeSeconds: number) {
                     {numberWithSpaces(plan.mau)}
                     {plan.name === 'Enterprise' ? '+' : ''}
                   </span>{' '}
-                  <a href="#faq-mau" class="text-gray-900 hover:text-blue-600 transition-colors border-b border-dotted border-gray-400 hover:border-blue-600" title="Learn more about Monthly Active Users">
+                  <a
+                    href="#faq-mau"
+                    class="border-b border-dotted border-gray-400 text-gray-900 transition-colors hover:border-blue-600 hover:text-blue-600"
+                    title="Learn more about Monthly Active Users"
+                  >
                     {m.monthly_active_users({}, { locale: Astro.locals.locale })}
                   </a>
                 </span>
               </li>
               <li class="flex items-center">
-                <svg class="w-5 h-5 mr-2 text-blue-600 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
+                <svg class="mr-2 h-5 w-5 shrink-0 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
                   <path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z" />
                 </svg>
                 <span>
@@ -163,13 +168,17 @@ function buildTimeDisplay(buildTimeSeconds: number) {
                     {plan.name === 'Enterprise' ? '+' : ''}
                   </span>{' '}
                   GiB/{m.month({}, { locale: Astro.locals.locale })}{' '}
-                  <a href="#faq-bandwidth" class="text-gray-900 hover:text-blue-600 transition-colors border-b border-dotted border-gray-400 hover:border-blue-600" title="Learn more about Bandwidth">
+                  <a
+                    href="#faq-bandwidth"
+                    class="border-b border-dotted border-gray-400 text-gray-900 transition-colors hover:border-blue-600 hover:text-blue-600"
+                    title="Learn more about Bandwidth"
+                  >
                     {m.of_bandwidth({}, { locale: Astro.locals.locale })}
                   </a>
                 </span>
               </li>
               <li class="flex items-center">
-                <svg class="w-5 h-5 mr-2 text-blue-600 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
+                <svg class="mr-2 h-5 w-5 shrink-0 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
                   <path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z" />
                 </svg>
                 <span>
@@ -178,18 +187,26 @@ function buildTimeDisplay(buildTimeSeconds: number) {
                     {plan.name === 'Enterprise' ? '+' : ''}
                   </span>{' '}
                   GiB{' '}
-                  <a href="#faq-storage" class="text-gray-900 hover:text-blue-600 transition-colors border-b border-dotted border-gray-400 hover:border-blue-600" title="Learn more about Storage">
+                  <a
+                    href="#faq-storage"
+                    class="border-b border-dotted border-gray-400 text-gray-900 transition-colors hover:border-blue-600 hover:text-blue-600"
+                    title="Learn more about Storage"
+                  >
                     {m.of_storage({}, { locale: Astro.locals.locale })}
                   </a>
                 </span>
               </li>
               {plan.build_time_unit && plan.build_time_unit > 0 && (
                 <li class="flex items-center">
-                  <svg class="w-5 h-5 mr-2 text-blue-600 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
+                  <svg class="mr-2 h-5 w-5 shrink-0 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
                     <path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z" />
                   </svg>
                   <span>
-                    <a href="#faq-build-time" class="font-bold text-gray-900 hover:text-blue-600 transition-colors border-b border-dotted border-gray-400 hover:border-blue-600" title="Learn more about Build Time">
+                    <a
+                      href="#faq-build-time"
+                      class="border-b border-dotted border-gray-400 font-bold text-gray-900 transition-colors hover:border-blue-600 hover:text-blue-600"
+                      title="Learn more about Build Time"
+                    >
                       {buildTimeDisplay(plan.build_time_unit)}
                       {plan.name === 'Enterprise' ? '+' : ''}
                     </a>
@@ -199,7 +216,7 @@ function buildTimeDisplay(buildTimeSeconds: number) {
               {plan.name === 'Solo' && (
                 <>
                   <li class="flex items-center">
-                    <svg class="w-5 h-5 mr-2 text-blue-600 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
+                    <svg class="mr-2 h-5 w-5 shrink-0 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
                       <path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z" />
                     </svg>
                     <span>{m.community_support({}, { locale: Astro.locals.locale })}</span>
@@ -209,7 +226,7 @@ function buildTimeDisplay(buildTimeSeconds: number) {
               {(plan.name === 'Team' || plan.name === 'Enterprise') && (
                 <>
                   <li class="flex items-center">
-                    <svg class="w-5 h-5 mr-2 text-blue-600 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
+                    <svg class="mr-2 h-5 w-5 shrink-0 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
                       <path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z" />
                     </svg>
                     <span>{m.all_lower_tiers_benefits({}, { locale: Astro.locals.locale })}</span>
@@ -219,7 +236,7 @@ function buildTimeDisplay(buildTimeSeconds: number) {
               {plan.name === 'Maker' && (
                 <>
                   <li class="flex items-center">
-                    <svg class="w-5 h-5 mr-2 text-blue-600 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
+                    <svg class="mr-2 h-5 w-5 shrink-0 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
                       <path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z" />
                     </svg>
                     <span>{m.priority_bug_fixes_on_our_plugins({}, { locale: Astro.locals.locale })}</span>
@@ -229,7 +246,7 @@ function buildTimeDisplay(buildTimeSeconds: number) {
               {plan.name == 'Team' && (
                 <>
                   <li class="flex items-center">
-                    <svg class="w-5 h-5 mr-2 text-blue-600 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
+                    <svg class="mr-2 h-5 w-5 shrink-0 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
                       <path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z" />
                     </svg>
                     <span>{m.priority_support({}, { locale: Astro.locals.locale })}</span>
@@ -239,29 +256,39 @@ function buildTimeDisplay(buildTimeSeconds: number) {
               {plan.name === 'Enterprise' && (
                 <>
                   <li class="flex items-center">
-                    <svg class="w-5 h-5 mr-2 text-blue-600 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
+                    <svg class="mr-2 h-5 w-5 shrink-0 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
+                      <path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z" />
+                    </svg>
+                    <span>{m.single_sign_on_sso({}, { locale: Astro.locals.locale })}</span>
+                  </li>
+                  <li class="flex items-center">
+                    <svg class="mr-2 h-5 w-5 shrink-0 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
                       <path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z" />
                     </svg>
                     <span>{m.custom_domain({}, { locale: Astro.locals.locale })}</span>
                   </li>
                   <li class="flex items-center">
-                    <svg class="w-5 h-5 mr-2 text-blue-600 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
+                    <svg class="mr-2 h-5 w-5 shrink-0 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
                       <path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z" />
                     </svg>
                     <span>{m.direct_slack_channel_support({}, { locale: Astro.locals.locale })}</span>
                   </li>
                   <li class="flex items-center">
-                    <svg class="w-5 h-5 mr-2 text-blue-600 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
+                    <svg class="mr-2 h-5 w-5 shrink-0 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
                       <path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z" />
                     </svg>
                     <span>{m.SLA({}, { locale: Astro.locals.locale })}</span>
                   </li>
                   <li class="flex items-center">
-                    <svg class="w-5 h-5 mr-2 text-blue-600 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
+                    <svg class="mr-2 h-5 w-5 shrink-0 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="1em" viewBox="0 0 448 512">
                       <path d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z" />
                     </svg>
                     <span>
-                      <a href="#faq-soc2" class="text-gray-900 hover:text-blue-600 transition-colors border-b border-dotted border-gray-400 hover:border-blue-600" title="Learn more about SOC 2">
+                      <a
+                        href="#faq-soc2"
+                        class="border-b border-dotted border-gray-400 text-gray-900 transition-colors hover:border-blue-600 hover:text-blue-600"
+                        title="Learn more about SOC 2"
+                      >
                         {m.soc2_compliance({}, { locale: Astro.locals.locale })}
                       </a>
                     </span>
@@ -270,9 +297,9 @@ function buildTimeDisplay(buildTimeSeconds: number) {
               )}
             </ul>
           </div>
-          <div class="px-4 py-4 mt-auto border-t border-gray-200 bg-gray-50 rounded-b-2xl sm:px-6 sm:rounded-b-3xl">
-            <p class="text-sm text-center text-gray-600">
-              <a href="#credit-pricing" class="font-medium text-black border-b border-blue-600 hover:text-blue-600 focus:text-blue-600">
+          <div class="mt-auto rounded-b-2xl border-t border-gray-200 bg-gray-50 px-4 py-4 sm:rounded-b-3xl sm:px-6">
+            <p class="text-center text-sm text-gray-600">
+              <a href="#credit-pricing" class="border-b border-blue-600 font-medium text-black hover:text-blue-600 focus:text-blue-600">
                 {m.credit_based_overages({}, { locale: Astro.locals.locale })}
               </a>
             </p>
@@ -313,32 +340,32 @@ function buildTimeDisplay(buildTimeSeconds: number) {
         }
       })
     }
-    
+
     // Handle FAQ info icon clicks
-    document.querySelectorAll('a[href^="#faq-"]').forEach(link => {
+    document.querySelectorAll('a[href^="#faq-"]').forEach((link) => {
       link.addEventListener('click', (e) => {
         e.preventDefault()
         const targetId = link.getAttribute('href').substring(1)
         const targetElement = document.getElementById(targetId)
-        
+
         if (targetElement) {
           // Smooth scroll to the FAQ section
-          targetElement.scrollIntoView({ 
-            behavior: 'smooth', 
-            block: 'center' 
+          targetElement.scrollIntoView({
+            behavior: 'smooth',
+            block: 'center',
           })
-          
+
           // Auto-open the details element after scrolling
           setTimeout(() => {
             if (!targetElement.open) {
               targetElement.open = true
             }
-            
+
             // Add temporary highlight effect
             targetElement.style.boxShadow = '0 0 0 3px rgba(59, 130, 246, 0.5)'
             targetElement.style.borderRadius = '12px'
             targetElement.style.transition = 'box-shadow 0.3s ease'
-            
+
             // Remove highlight after 2 seconds
             setTimeout(() => {
               targetElement.style.boxShadow = 'none'
@@ -347,7 +374,7 @@ function buildTimeDisplay(buildTimeSeconds: number) {
         }
       })
     })
-    
+
     yearlyRadio?.addEventListener('change', () => updatePrices(true))
     monthlyRadio?.addEventListener('change', () => updatePrices(false))
   })


### PR DESCRIPTION
## Summary

- add Single Sign-On (SSO) to the Enterprise pricing plan card
- surface build minute credit pricing tiers from the live `build_time` credit API data
- normalize credit tier units so build minutes render in minutes and storage/bandwidth stay human-readable

## Why

The pricing page already marketed enterprise SSO elsewhere on the site, but not in the plan card itself, and the credit pricing table did not expose the new build minute overage pricing even though the backend API already served it.

## Validation

- `bun run check`
