### PR TITLE
Clarify Google offline refresh docs

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/social-login/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/social-login/getting-started.mdx
@@ -112,6 +112,8 @@ const active = await SocialLogin.isRefreshTokenAvailable({ refreshToken: 'a-toke
 
 `google.mode: 'offline'` returns `serverAuthCode` from login. In this mode logout, isLoggedIn, getAuthorizationCode, and refresh are not available.
 
+Use `serverAuthCode` only as input to your backend token exchange. If you need to call `SocialLogin.refresh()` in the app, use `google.mode: 'online'` instead.
+
 ### Apple
 
 Set `useProperTokenExchange: true` for strict token handling and `useBroadcastChannel: true` for Android simplified setup.

--- a/apps/docs/src/content/docs/docs/plugins/social-login/google/android.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/social-login/google/android.mdx
@@ -169,6 +169,10 @@ You may create multiple Android client IDs. This is required if you have multipl
       console.log(JSON.stringify(res))
       ```
 
+      :::caution
+      If you initialize Google with `mode: 'offline'`, `SocialLogin.login()` returns `serverAuthCode` for your backend exchange flow. Do not call `SocialLogin.refresh({ provider: 'google' })` in the app in that mode. Exchange `serverAuthCode` on your backend, store the Google refresh token there, and refresh on the backend.
+      :::
+
 5. Configure the emulator for testing
    
    1. Go into `Device manager` and click the plus button

--- a/apps/docs/src/content/docs/docs/plugins/social-login/google/general.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/social-login/google/general.mdx
@@ -113,6 +113,10 @@ There are multiple ways to use Google Login with Capacitor. Here is a table that
 **Offline mode REQUIRES a backend server.** When using offline mode, the frontend receives minimal information (primarily just a server auth code). Without a backend to exchange this code for tokens and user information, offline mode provides no useful data to your frontend application.
 :::
 
+:::caution
+`SocialLogin.refresh({ provider: 'google' })` does **not** work with `google.mode: 'offline'`. In offline mode the plugin only gives you `serverAuthCode`, and your backend must exchange that code for access and refresh tokens, then refresh those tokens on the backend.
+:::
+
 If you still do not know which one you should choose, please consider the following scenarios:
 
 1. You want the user to login, immediately after you are going to issue him a custom JWT. Your app will NOT call Google APIs
@@ -233,3 +237,5 @@ async function fullLogin() {
   }
 }
 ```
+
+Notice what is missing here: there is no `SocialLogin.refresh()` call in the app. That is intentional. In Google offline mode, refresh happens after your backend exchanges `serverAuthCode` and stores the refresh token securely.

--- a/apps/docs/src/content/docs/docs/plugins/social-login/google/ios.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/social-login/google/ios.mdx
@@ -185,7 +185,7 @@ In this part, you will learn how to setup Google login in iOS.
       :::
 
       :::caution
-      **About offline mode:** When using `mode: 'offline'`, the login response will not contain user data directly. Instead, you'll receive a server auth code that must be exchanged for user information via your backend server. See the [general setup guide](/docs/plugins/social-login/google/general/#using-offline-access-with-your-own-backend) for implementation details.
+      **About offline mode:** When using `mode: 'offline'`, the login response will not contain user data directly. Instead, you'll receive a server auth code that must be exchanged for user information via your backend server. `SocialLogin.refresh({ provider: 'google' })` is not available in this mode; refresh must happen on your backend after exchanging `serverAuthCode`. See the [general setup guide](/docs/plugins/social-login/google/general/#using-offline-access-with-your-own-backend) for implementation details.
       :::
    
    3. Implement the login function. Create a button and run the following code on click
@@ -210,6 +210,7 @@ In this part, you will learn how to setup Google login in iOS.
       })
       // res contains serverAuthCode, not user data
       // Send serverAuthCode to your backend to get user information
+      // Do not call SocialLogin.refresh() in offline mode
       console.log('Server auth code:', res.result.serverAuthCode)
       ```
 
@@ -243,7 +244,6 @@ await SocialLogin.login({
   options: {}
 });
 ```
-
 
 
 

--- a/apps/docs/src/content/docs/docs/plugins/social-login/google/web.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/social-login/google/web.mdx
@@ -115,6 +115,10 @@ In order to use it, you have to do the following:
    ```
    :::
 
+   :::caution
+   On Web, `SocialLogin.refresh({ provider: 'google' })` is not implemented, even when using `google.mode: 'online'`. If you need a fresh Google token on Web, call `SocialLogin.login({ provider: 'google', ... })` again.
+   :::
+
    3. Create a login button that calls `SocialLogin.login` when clicked
   
       ```typescript
@@ -126,4 +130,3 @@ In order to use it, you have to do the following:
       console.log(JSON.stringify(res));
       ```
 </Steps>
-


### PR DESCRIPTION
## What
- add explicit website warnings that Google `mode: 'offline'` is a backend exchange flow and that `SocialLogin.refresh({ provider: 'google' })` should not be called in-app in that mode
- surface the warning in the getting started guide, general Google guide, iOS guide, and Android guide

## Why
- users are still reading the docs as if Google refresh should work from the app after choosing offline mode
- the missing piece is that offline mode only returns `serverAuthCode`; token refresh belongs on the backend after exchanging that code
- the Android page especially needed the warning because that is where many users copy their implementation

## How
- add short caution notes in the platform and general docs where users make the integration choice
- keep the guidance consistent with the plugin API docs and native error messages
- verify the docs site builds with the updated MDX pages
- AI-assisted with Codex

## Testing
- `bunx prettier --write apps/docs/src/content/docs/docs/plugins/social-login/getting-started.mdx apps/docs/src/content/docs/docs/plugins/social-login/google/general.mdx apps/docs/src/content/docs/docs/plugins/social-login/google/ios.mdx apps/docs/src/content/docs/docs/plugins/social-login/google/android.mdx`
- `bun run build:docs`

## Not Tested
- production deployment preview after CI publishes the site artifacts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Google "offline" mode: the returned authorization code is for backend token exchange only.
  * Stated that in-app token refresh is not available in offline mode — refresh must be performed on the backend after exchanging the code.
  * Noted that on Web a fresh login is required to obtain a new Google token (refresh is not implemented).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->