### PR TITLE
[codex] improve Capgo landing AI readiness

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,13 +10,14 @@
     "@iconify-json/heroicons": "1.2.3"
   },
   "scripts": {
+    "validate:agent-skills": "bun ../../scripts/validate-agent-skills-digests.mjs",
     "paraglide:compile": "bunx paraglide-js compile --project ../../project.inlang --outdir ./src/paraglide --emit-ts-declarations --silent",
     "astro": "astro",
     "dev": "bun run paraglide:compile && NODE_OPTIONS=${NODE_OPTIONS:---max-old-space-size=16384} astro dev",
     "start": "bun run paraglide:compile && NODE_OPTIONS=${NODE_OPTIONS:---max-old-space-size=16384} astro dev",
     "clean:build-cache": "rm -rf dist .astro/content-modules.mjs .astro/content-assets.mjs",
     "build": "bun run paraglide:compile && bun run clean:build-cache && NODE_OPTIONS=${NODE_OPTIONS:---max-old-space-size=16384} BUILD_CONCURRENCY=${BUILD_CONCURRENCY:-1} UV_THREADPOOL_SIZE=${UV_THREADPOOL_SIZE:-16} astro build && rm -rf dist/.prerender",
-    "check": "bun run paraglide:compile && astro check",
+    "check": "bun run validate:agent-skills && bun run paraglide:compile && astro check",
     "preview": "bun run build && bun run preview:worker",
     "preview:astro": "astro preview",
     "preview:worker": "wrangler dev",

--- a/apps/web/public/.well-known/agent-skills/capgo-cli-mcp/SKILL.md
+++ b/apps/web/public/.well-known/agent-skills/capgo-cli-mcp/SKILL.md
@@ -10,7 +10,7 @@ Use this skill when an agent needs direct Capgo operations instead of only readi
 ## Start the server
 
 ```bash
-bunx @capgo/cli@latest mcp
+bunx @capgo/cli@7.93.1 mcp
 ```
 
 ## Authentication
@@ -18,7 +18,7 @@ bunx @capgo/cli@latest mcp
 Authenticate with a Capgo API key before starting the server or configure the key in the MCP client runtime.
 
 ```bash
-bunx @capgo/cli@latest login
+bunx @capgo/cli@7.93.1 login
 ```
 
 API keys are available from:

--- a/apps/web/public/.well-known/agent-skills/capgo-cli-mcp/SKILL.md
+++ b/apps/web/public/.well-known/agent-skills/capgo-cli-mcp/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: capgo-cli-mcp
+description: Run the local Capgo CLI MCP server with bunx so agents can manage live updates, channels, bundles, stats, apps, and native builds.
+---
+
+# Capgo CLI MCP
+
+Use this skill when an agent needs direct Capgo operations instead of only reading docs.
+
+## Start the server
+
+```bash
+bunx @capgo/cli@latest mcp
+```
+
+## Authentication
+
+Authenticate with a Capgo API key before starting the server or configure the key in the MCP client runtime.
+
+```bash
+bunx @capgo/cli@latest login
+```
+
+API keys are available from:
+
+- https://console.capgo.app/dashboard/apikeys/
+
+## What the server exposes
+
+- App management
+- Bundle uploads and cleanup
+- Channel creation and updates
+- Organization access
+- Device statistics and logs
+- Native build requests
+- Encryption key generation
+
+## Working rules
+
+- Treat the Capgo MCP server as a local `stdio` server, not a remote HTTP endpoint.
+- Prefer `bunx` in Capgo environments.
+- Use the published Capgo API docs when you need field-level details the MCP tool description does not include.

--- a/apps/web/public/.well-known/agent-skills/capgo-mobile-signing-tools/SKILL.md
+++ b/apps/web/public/.well-known/agent-skills/capgo-mobile-signing-tools/SKILL.md
@@ -16,6 +16,8 @@ Use this skill when a developer needs release-signing artifacts quickly from the
 
 ## API endpoints
 
+Base URL: `https://capgo.app`
+
 - `POST /api/tools/ios-certificate-generator`
 - `POST /api/tools/android-keystore-generator`
 - `GET /api/tools/ios-udid-finder/profile`

--- a/apps/web/public/.well-known/agent-skills/capgo-mobile-signing-tools/SKILL.md
+++ b/apps/web/public/.well-known/agent-skills/capgo-mobile-signing-tools/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: capgo-mobile-signing-tools
+description: Use Capgo's browser-based signing tools to generate iOS CSRs, create Android keystores, and capture iPhone or iPad UDIDs.
+---
+
+# Capgo Mobile Signing Tools
+
+Use this skill when a developer needs release-signing artifacts quickly from the browser.
+
+## Tools
+
+- iOS certificate generator: https://capgo.app/tools/ios-certificate-generator/
+- Android keystore generator: https://capgo.app/tools/android-keystore-generator/
+- iOS UDID finder: https://capgo.app/tools/ios-udid-finder/
+- Overview page: https://capgo.app/tools/
+
+## API endpoints
+
+- `POST /api/tools/ios-certificate-generator`
+- `POST /api/tools/android-keystore-generator`
+- `GET /api/tools/ios-udid-finder/profile`
+- `GET /api/tools/ios-udid-finder/result`
+
+## Outputs
+
+- The iOS tool returns a CSR and a PEM private key.
+- The Android tool returns a PKCS#12 keystore, certificate PEM, and fingerprints.
+- The UDID flow installs a lightweight Apple profile and then exposes the captured device payload in the browser session.
+
+## Working rules
+
+- Use the browser UI when a human needs to download or install a profile.
+- Use the JSON endpoints for automation where browser interaction is not required.
+- Keep generated private keys and keystores out of source control.

--- a/apps/web/public/.well-known/agent-skills/capgo-public-api/SKILL.md
+++ b/apps/web/public/.well-known/agent-skills/capgo-public-api/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: capgo-public-api
+description: Use Capgo's public API docs and API-key authentication model to manage organizations, apps, channels, devices, bundles, statistics, and API keys.
+---
+
+# Capgo Public API
+
+Use this skill when the task requires programmatic work with Capgo Cloud instead of manual dashboard navigation.
+
+## Base URLs
+
+- Product site: https://capgo.app
+- API docs: https://capgo.app/docs/public-api/
+- API base: https://api.capgo.app
+
+## Authentication
+
+Send a Capgo API key in the `authorization` header.
+
+```bash
+curl -H "authorization: $CAPGO_API_KEY" https://api.capgo.app/organization/
+```
+
+Create or rotate API keys in the dashboard:
+
+- https://console.capgo.app/dashboard/apikeys/
+
+## Main resource groups
+
+- `/organization/` and `/organization/members/`
+- `/app/`
+- `/apikey/`
+- `/channel/`
+- `/bundle/`
+- `/device/`
+- `/statistics/...`
+
+## Working rules
+
+- Prefer the published docs for request and response details before guessing fields.
+- Use least-privilege API keys (`read`, `upload`, `write`, `all`).
+- Handle `429` responses with retry backoff.
+- Expect JSON success payloads with `data` or `status`, and JSON failures with `error`.

--- a/apps/web/public/.well-known/agent-skills/capgo-site-routing/SKILL.md
+++ b/apps/web/public/.well-known/agent-skills/capgo-site-routing/SKILL.md
@@ -19,7 +19,7 @@ Use this skill when a user lands on Capgo and needs the shortest path to the rig
 
 ## Routing hints
 
-- Send teams comparing plans, credits, or enterprise limits to pricing.
-- Send CI, certificates, and mobile release questions to native build or signing tools.
-- Send integration and automation work to the public API docs or the CLI MCP skill.
-- Send AI agent workflow questions to the Capgo skills page and the CLI MCP skill.
+- Route teams comparing plans, credits, or enterprise limits to pricing.
+- Direct CI, certificates, and mobile release questions to native build or signing tools.
+- Refer integration and automation work to the public API docs or the CLI MCP skill.
+- Forward AI agent workflow questions to the Capgo skills page and the CLI MCP skill.

--- a/apps/web/public/.well-known/agent-skills/capgo-site-routing/SKILL.md
+++ b/apps/web/public/.well-known/agent-skills/capgo-site-routing/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: capgo-site-routing
+description: Route developers to the right Capgo landing pages for pricing, native builds, signing tools, API docs, AI skills, and enterprise workflows.
+---
+
+# Capgo Site Routing
+
+Use this skill when a user lands on Capgo and needs the shortest path to the right page.
+
+## Page map
+
+- Pricing: https://capgo.app/pricing/
+- Signup: https://capgo.app/register/
+- Native build: https://capgo.app/native-build/
+- Mobile signing tools: https://capgo.app/tools/
+- Public API docs: https://capgo.app/docs/public-api/
+- AI skills: https://capgo.app/skills/
+- Enterprise: https://capgo.app/enterprise/
+
+## Routing hints
+
+- Send teams comparing plans, credits, or enterprise limits to pricing.
+- Send CI, certificates, and mobile release questions to native build or signing tools.
+- Send integration and automation work to the public API docs or the CLI MCP skill.
+- Send AI agent workflow questions to the Capgo skills page and the CLI MCP skill.

--- a/apps/web/public/.well-known/agent-skills/index.json
+++ b/apps/web/public/.well-known/agent-skills/index.json
@@ -13,21 +13,21 @@
       "type": "skill-md",
       "description": "Use Capgo's browser-based signing tools to generate iOS CSRs, create Android keystores, and capture iPhone or iPad UDIDs.",
       "url": "/.well-known/agent-skills/capgo-mobile-signing-tools/SKILL.md",
-      "digest": "sha256:7b00ed87ef3feea2bf2af33e7c4b31e603b631de788772b2a42f031a36554a8a"
+      "digest": "sha256:468de87ad549972ee8801b7a1289dce660a8995f73408afd9647082c70f44080"
     },
     {
       "name": "capgo-cli-mcp",
       "type": "skill-md",
       "description": "Run the local Capgo CLI MCP server with bunx so agents can manage live updates, channels, bundles, stats, apps, and native builds.",
       "url": "/.well-known/agent-skills/capgo-cli-mcp/SKILL.md",
-      "digest": "sha256:6a77f5d7e1b68ca54549623c1c6022cd0ed378ddde3f64b4d90b858237bfd071"
+      "digest": "sha256:e1c0aaa429f632690f6d8485b77a827518014a1b4b589c307b16695c78508756"
     },
     {
       "name": "capgo-site-routing",
       "type": "skill-md",
       "description": "Route developers to the right Capgo landing pages for pricing, native builds, signing tools, API docs, AI skills, and enterprise workflows.",
       "url": "/.well-known/agent-skills/capgo-site-routing/SKILL.md",
-      "digest": "sha256:0ee21c44f0f4e51fab18e68a75df591278beecced781b5fcf96b9557763a1cc4"
+      "digest": "sha256:4ee6bbca584fe7e15c96a003ef2181bbd660a5c1e47f3c5e810cfc9cee14771e"
     }
   ]
 }

--- a/apps/web/public/.well-known/agent-skills/index.json
+++ b/apps/web/public/.well-known/agent-skills/index.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "capgo-public-api",
+      "type": "skill-md",
+      "description": "Use Capgo's public API docs and API-key authentication model to manage organizations, apps, channels, devices, bundles, statistics, and API keys.",
+      "url": "/.well-known/agent-skills/capgo-public-api/SKILL.md",
+      "digest": "sha256:a28a7cf3713230bdf6ea8c8f8b48e167f51050cd618ed4d60852fde6086584ef"
+    },
+    {
+      "name": "capgo-mobile-signing-tools",
+      "type": "skill-md",
+      "description": "Use Capgo's browser-based signing tools to generate iOS CSRs, create Android keystores, and capture iPhone or iPad UDIDs.",
+      "url": "/.well-known/agent-skills/capgo-mobile-signing-tools/SKILL.md",
+      "digest": "sha256:7b00ed87ef3feea2bf2af33e7c4b31e603b631de788772b2a42f031a36554a8a"
+    },
+    {
+      "name": "capgo-cli-mcp",
+      "type": "skill-md",
+      "description": "Run the local Capgo CLI MCP server with bunx so agents can manage live updates, channels, bundles, stats, apps, and native builds.",
+      "url": "/.well-known/agent-skills/capgo-cli-mcp/SKILL.md",
+      "digest": "sha256:6a77f5d7e1b68ca54549623c1c6022cd0ed378ddde3f64b4d90b858237bfd071"
+    },
+    {
+      "name": "capgo-site-routing",
+      "type": "skill-md",
+      "description": "Route developers to the right Capgo landing pages for pricing, native builds, signing tools, API docs, AI skills, and enterprise workflows.",
+      "url": "/.well-known/agent-skills/capgo-site-routing/SKILL.md",
+      "digest": "sha256:0ee21c44f0f4e51fab18e68a75df591278beecced781b5fcf96b9557763a1cc4"
+    }
+  ]
+}

--- a/apps/web/public/.well-known/api-catalog
+++ b/apps/web/public/.well-known/api-catalog
@@ -1,0 +1,25 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://capgo.app/api/tools/",
+      "service-desc": [
+        {
+          "href": "https://capgo.app/.well-known/capgo-tools-openapi.json",
+          "type": "application/openapi+json"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://capgo.app/tools/",
+          "type": "text/html"
+        }
+      ],
+      "status": [
+        {
+          "href": "https://capgo.app/.well-known/tool-api-status.json",
+          "type": "application/health+json"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/web/public/.well-known/capgo-tools-openapi.json
+++ b/apps/web/public/.well-known/capgo-tools-openapi.json
@@ -340,7 +340,7 @@
             "type": "string"
           }
         },
-        "required": ["udid", "deviceName", "product", "version", "serial", "imei", "meid", "challenge"]
+        "required": ["udid", "deviceName", "product", "version", "serial", "challenge"]
       },
       "UdidResult": {
         "type": "object",

--- a/apps/web/public/.well-known/capgo-tools-openapi.json
+++ b/apps/web/public/.well-known/capgo-tools-openapi.json
@@ -196,32 +196,50 @@
         ]
       },
       "AndroidKeystoreRequest": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/SigningIdentityInput"
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "commonName": {
+            "type": "string",
+            "description": "Full name used in the signing subject."
           },
-          {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "alias": {
-                "type": "string",
-                "pattern": "^[A-Za-z0-9._-]+$"
-              },
-              "password": {
-                "type": "string",
-                "minLength": 8
-              },
-              "validityYears": {
-                "type": "integer",
-                "minimum": 1,
-                "maximum": 35,
-                "default": 10
-              }
-            },
-            "required": ["alias", "password"]
+          "emailAddress": {
+            "type": "string",
+            "format": "email"
+          },
+          "organization": {
+            "type": "string"
+          },
+          "organizationalUnit": {
+            "type": "string"
+          },
+          "localityName": {
+            "type": "string"
+          },
+          "stateOrProvinceName": {
+            "type": "string"
+          },
+          "countryName": {
+            "type": "string",
+            "pattern": "^[A-Z]{2}$",
+            "description": "ISO 3166-1 alpha-2 country code."
+          },
+          "alias": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9._-]+$"
+          },
+          "password": {
+            "type": "string",
+            "minLength": 8
+          },
+          "validityYears": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 35,
+            "default": 10
           }
-        ]
+        },
+        "required": ["commonName", "emailAddress", "countryName", "alias", "password"]
       },
       "BaseToolFile": {
         "type": "object",

--- a/apps/web/public/.well-known/capgo-tools-openapi.json
+++ b/apps/web/public/.well-known/capgo-tools-openapi.json
@@ -1,0 +1,389 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Capgo Website Tools API",
+    "summary": "Public browser-facing utility endpoints for Capgo mobile signing workflows.",
+    "description": "These endpoints power the Capgo website tools for generating iOS certificate requests, creating Android signing keystores, and retrieving iOS UDID capture results.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://capgo.app",
+      "description": "Production"
+    }
+  ],
+  "paths": {
+    "/api/tools/ios-certificate-generator": {
+      "post": {
+        "operationId": "createIosCertificateRequest",
+        "summary": "Generate an iOS certificate signing request and private key bundle.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IosCertificateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "CSR bundle generated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IosCertificateBundle"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/tools/android-keystore-generator": {
+      "post": {
+        "operationId": "createAndroidKeystore",
+        "summary": "Generate a PKCS#12 Android signing keystore and certificate summary.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AndroidKeystoreRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Keystore bundle generated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AndroidKeystoreBundle"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/tools/ios-udid-finder/profile": {
+      "get": {
+        "operationId": "downloadIosUdidProfile",
+        "summary": "Return a configuration profile that triggers iOS UDID collection.",
+        "parameters": [
+          {
+            "name": "locale",
+            "in": "query",
+            "description": "Optional locale code used when redirecting back to the localized result page.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unsigned or signed mobile configuration profile.",
+            "content": {
+              "application/x-apple-aspen-config": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          }
+        }
+      }
+    },
+    "/api/tools/ios-udid-finder/result": {
+      "get": {
+        "operationId": "getIosUdidResult",
+        "summary": "Read the latest captured iOS device payload from the current browser session.",
+        "responses": {
+          "200": {
+            "description": "Current UDID capture state.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UdidResult"
+                }
+              }
+            }
+          },
+          "405": {
+            "$ref": "#/components/responses/MethodNotAllowed"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "SigningIdentityInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "commonName": {
+            "type": "string",
+            "description": "Full name used in the signing subject."
+          },
+          "emailAddress": {
+            "type": "string",
+            "format": "email"
+          },
+          "organization": {
+            "type": "string"
+          },
+          "organizationalUnit": {
+            "type": "string"
+          },
+          "localityName": {
+            "type": "string"
+          },
+          "stateOrProvinceName": {
+            "type": "string"
+          },
+          "countryName": {
+            "type": "string",
+            "pattern": "^[A-Z]{2}$",
+            "description": "ISO 3166-1 alpha-2 country code."
+          }
+        },
+        "required": ["commonName", "emailAddress", "countryName"]
+      },
+      "IosCertificateRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SigningIdentityInput"
+          }
+        ]
+      },
+      "AndroidKeystoreRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SigningIdentityInput"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "alias": {
+                "type": "string",
+                "pattern": "^[A-Za-z0-9._-]+$"
+              },
+              "password": {
+                "type": "string",
+                "minLength": 8
+              },
+              "validityYears": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 35,
+                "default": 10
+              }
+            },
+            "required": ["alias", "password"]
+          }
+        ]
+      },
+      "BaseToolFile": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "fileName": {
+            "type": "string"
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "encoding": {
+            "type": "string",
+            "enum": ["text", "base64"]
+          },
+          "content": {
+            "type": "string"
+          }
+        },
+        "required": ["fileName", "mimeType", "encoding", "content"]
+      },
+      "IosCertificateBundle": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "summary": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "subject": {
+                "type": "string"
+              },
+              "keyType": {
+                "type": "string"
+              },
+              "hashAlgorithm": {
+                "type": "string"
+              }
+            },
+            "required": ["subject", "keyType", "hashAlgorithm"]
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BaseToolFile"
+            }
+          }
+        },
+        "required": ["summary", "files"]
+      },
+      "AndroidKeystoreBundle": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "summary": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "subject": {
+                "type": "string"
+              },
+              "alias": {
+                "type": "string"
+              },
+              "validityYears": {
+                "type": "integer"
+              },
+              "fingerprintSha1": {
+                "type": "string"
+              },
+              "fingerprintSha256": {
+                "type": "string"
+              }
+            },
+            "required": ["subject", "alias", "validityYears", "fingerprintSha1", "fingerprintSha256"]
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BaseToolFile"
+            }
+          }
+        },
+        "required": ["summary", "files"]
+      },
+      "UdidDevicePayload": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "udid": {
+            "type": "string"
+          },
+          "deviceName": {
+            "type": "string"
+          },
+          "product": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "serial": {
+            "type": "string"
+          },
+          "imei": {
+            "type": "string"
+          },
+          "meid": {
+            "type": "string"
+          },
+          "challenge": {
+            "type": "string"
+          }
+        },
+        "required": ["udid", "deviceName", "product", "version", "serial", "imei", "meid", "challenge"]
+      },
+      "UdidResult": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "payload": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/UdidDevicePayload"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": ["payload"]
+      },
+      "ApiError": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": ["error"]
+      }
+    },
+    "responses": {
+      "ValidationError": {
+        "description": "The request body was missing required fields or contained invalid values.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ApiError"
+            }
+          }
+        }
+      },
+      "MethodNotAllowed": {
+        "description": "The endpoint does not allow the requested HTTP method.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ApiError"
+            }
+          }
+        }
+      },
+      "InternalError": {
+        "description": "An internal error occurred while generating the requested artifact.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ApiError"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/public/.well-known/capgo-tools-openapi.json
+++ b/apps/web/public/.well-known/capgo-tools-openapi.json
@@ -12,6 +12,7 @@
       "description": "Production"
     }
   ],
+  "security": [],
   "paths": {
     "/api/tools/ios-certificate-generator": {
       "post": {
@@ -252,6 +253,8 @@
           },
           "files": {
             "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
             "items": {
               "$ref": "#/components/schemas/BaseToolFile"
             }
@@ -287,6 +290,8 @@
           },
           "files": {
             "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
             "items": {
               "$ref": "#/components/schemas/BaseToolFile"
             }

--- a/apps/web/public/.well-known/capgo-tools-openapi.json
+++ b/apps/web/public/.well-known/capgo-tools-openapi.json
@@ -42,6 +42,9 @@
           "400": {
             "$ref": "#/components/responses/ValidationError"
           },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
           "405": {
             "$ref": "#/components/responses/MethodNotAllowed"
           },
@@ -79,6 +82,9 @@
           "400": {
             "$ref": "#/components/responses/ValidationError"
           },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
           "405": {
             "$ref": "#/components/responses/MethodNotAllowed"
           },
@@ -113,6 +119,12 @@
                 }
               }
             }
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
           },
           "405": {
             "$ref": "#/components/responses/MethodNotAllowed"
@@ -371,6 +383,25 @@
       },
       "MethodNotAllowed": {
         "description": "The endpoint does not allow the requested HTTP method.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ApiError"
+            }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "Too many requests were received from this client. Retry after the indicated cooldown window.",
+        "headers": {
+          "Retry-After": {
+            "description": "Seconds to wait before retrying the request.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
         "content": {
           "application/json": {
             "schema": {

--- a/apps/web/public/.well-known/mcp/server-card.json
+++ b/apps/web/public/.well-known/mcp/server-card.json
@@ -21,6 +21,6 @@
     "required": true,
     "schemes": ["bearer"]
   },
-  "instructions": "Start the local server with `bunx @capgo/cli@latest mcp` after authenticating with a Capgo API key. Use the MCP client configuration that matches your agent runtime.",
+  "instructions": "Start the local server with `bunx @capgo/cli@7.93.1 mcp` after authenticating with a Capgo API key. Use the MCP client configuration that matches your agent runtime.",
   "tools": ["dynamic"]
 }

--- a/apps/web/public/.well-known/mcp/server-card.json
+++ b/apps/web/public/.well-known/mcp/server-card.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/mcp-server-card/v1.json",
+  "version": "1.0",
+  "protocolVersion": "2025-06-18",
+  "serverInfo": {
+    "name": "capgo-cli-mcp",
+    "title": "Capgo CLI MCP Server",
+    "version": "7.93.1"
+  },
+  "description": "Local stdio MCP server bundled with @capgo/cli for managing Capgo apps, bundles, channels, statistics, organizations, and native builds.",
+  "documentationUrl": "https://github.com/Cap-go/CLI#readme",
+  "transport": {
+    "type": "stdio"
+  },
+  "capabilities": {
+    "tools": {
+      "listChanged": true
+    }
+  },
+  "authentication": {
+    "required": true,
+    "schemes": ["bearer"]
+  },
+  "instructions": "Start the local server with `bunx @capgo/cli@latest mcp` after authenticating with a Capgo API key. Use the MCP client configuration that matches your agent runtime.",
+  "tools": ["dynamic"]
+}

--- a/apps/web/public/.well-known/tool-api-status.json
+++ b/apps/web/public/.well-known/tool-api-status.json
@@ -1,0 +1,11 @@
+{
+  "status": "pass",
+  "serviceId": "capgo-tools-api",
+  "version": "1.0.0",
+  "description": "Health document for Capgo's public website tools API.",
+  "links": {
+    "self": "https://capgo.app/.well-known/tool-api-status.json",
+    "openapi": "https://capgo.app/.well-known/capgo-tools-openapi.json",
+    "docs": "https://capgo.app/tools/"
+  }
+}

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -10,18 +10,28 @@
 
 /.well-known/api-catalog
   Content-Type: application/linkset+json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, HEAD
+  Access-Control-Expose-Headers: Link, ETag
 
 /.well-known/capgo-tools-openapi.json
   Content-Type: application/openapi+json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, HEAD
+  Access-Control-Expose-Headers: Link, ETag
 
 /.well-known/tool-api-status.json
   Content-Type: application/health+json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, HEAD
+  Access-Control-Expose-Headers: Link, ETag
 
 /.well-known/mcp/server-card.json
   Content-Type: application/json; charset=utf-8
   Access-Control-Allow-Origin: *
-  Access-Control-Allow-Methods: GET
+  Access-Control-Allow-Methods: GET, HEAD
   Access-Control-Allow-Headers: Content-Type
+  Access-Control-Expose-Headers: Link, ETag
   Cache-Control: public, max-age=3600
 
 /sitemap.xml

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,6 +1,28 @@
+/
+  Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"
+  Link: </.well-known/capgo-tools-openapi.json>; rel="service-desc"; type="application/openapi+json"
+  Link: </docs/public-api/>; rel="service-doc"; type="text/html"
+  Link: </tools/>; rel="service-doc"; type="text/html"
+
 /assets/*
   cache-control: max-age=31536000
   cache-control: immutable
+
+/.well-known/api-catalog
+  Content-Type: application/linkset+json; charset=utf-8
+
+/.well-known/capgo-tools-openapi.json
+  Content-Type: application/openapi+json; charset=utf-8
+
+/.well-known/tool-api-status.json
+  Content-Type: application/health+json; charset=utf-8
+
+/.well-known/mcp/server-card.json
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET
+  Access-Control-Allow-Headers: Content-Type
+  Cache-Control: public, max-age=3600
 
 /sitemap.xml
   Content-Type: text/xml

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
+Content-Signal: ai-train=no, search=yes, ai-input=yes
 
 Sitemap: https://capgo.app/sitemap-index.xml

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
 Allow: /
-Content-Signal: ai-train=no, search=yes, ai-input=yes
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
 
 Sitemap: https://capgo.app/sitemap-index.xml

--- a/apps/web/src/components/WebMcpTools.astro
+++ b/apps/web/src/components/WebMcpTools.astro
@@ -40,54 +40,55 @@ const tools = [
     path: getRelativeLocaleUrl(locale, 'skills'),
   },
 ]
+
+const script = `;(() => {
+  if (typeof navigator === 'undefined') return
+
+  const modelContext = navigator.modelContext
+  if (!modelContext || typeof modelContext.registerTool !== 'function') return
+
+  const tools = ${JSON.stringify(tools)}
+  const controller = new AbortController()
+
+  const registerNavigationTool = (tool) => {
+    modelContext.registerTool(
+      {
+        name: tool.name,
+        title: tool.title,
+        description: tool.description,
+        inputSchema: {
+          type: 'object',
+          additionalProperties: false,
+        },
+        execute: async () => {
+          const url = new URL(tool.path, window.location.origin).toString()
+          window.location.assign(url)
+          return {
+            status: 'navigating',
+            url,
+          }
+        },
+      },
+      { signal: controller.signal },
+    )
+  }
+
+  for (const tool of tools) {
+    try {
+      registerNavigationTool(tool)
+    } catch (error) {
+      console.debug('Capgo WebMCP registration skipped', tool.name, error)
+    }
+  }
+
+  window.addEventListener(
+    'pagehide',
+    () => {
+      controller.abort()
+    },
+    { once: true },
+  )
+})()`
 ---
 
-<script is:inline define:vars={{ tools }}>
-  ;(() => {
-    if (typeof navigator === 'undefined') return
-
-    const modelContext = navigator.modelContext
-    if (!modelContext || typeof modelContext.registerTool !== 'function') return
-
-    const controller = new AbortController()
-
-    const registerNavigationTool = (tool) => {
-      modelContext.registerTool(
-        {
-          name: tool.name,
-          title: tool.title,
-          description: tool.description,
-          inputSchema: {
-            type: 'object',
-            additionalProperties: false,
-          },
-          execute: async () => {
-            const url = new URL(tool.path, window.location.origin).toString()
-            window.location.assign(url)
-            return {
-              status: 'navigating',
-              url,
-            }
-          },
-        },
-        { signal: controller.signal },
-      )
-    }
-
-    for (const tool of tools) {
-      try {
-        registerNavigationTool(tool)
-      } catch (error) {
-        console.debug('Capgo WebMCP registration skipped', tool.name, error)
-      }
-    }
-
-    window.addEventListener(
-      'pagehide',
-      () => {
-        controller.abort()
-      },
-      { once: true },
-    )
-  })()
-</script>
+<script is:inline set:html={script} />

--- a/apps/web/src/components/WebMcpTools.astro
+++ b/apps/web/src/components/WebMcpTools.astro
@@ -1,0 +1,93 @@
+---
+import { getRelativeLocaleUrl } from 'astro:i18n'
+
+const locale = Astro.locals.locale
+const tools = [
+  {
+    name: 'capgo.open_pricing',
+    title: 'Open pricing',
+    description: 'Navigate to Capgo pricing to compare plans, credits, and enterprise options.',
+    path: getRelativeLocaleUrl(locale, 'pricing'),
+  },
+  {
+    name: 'capgo.open_signup',
+    title: 'Start signup',
+    description: 'Navigate to the Capgo signup page to create an account.',
+    path: getRelativeLocaleUrl(locale, 'register'),
+  },
+  {
+    name: 'capgo.open_native_build',
+    title: 'Open native build',
+    description: 'Navigate to Capgo native build information for iOS and Android build workflows.',
+    path: getRelativeLocaleUrl(locale, 'native-build'),
+  },
+  {
+    name: 'capgo.open_tools',
+    title: 'Open signing tools',
+    description: 'Navigate to Capgo browser-based mobile signing tools for iOS certificates, UDID capture, and Android keystores.',
+    path: getRelativeLocaleUrl(locale, 'tools'),
+  },
+  {
+    name: 'capgo.open_public_api_docs',
+    title: 'Open public API docs',
+    description: 'Navigate to Capgo public API documentation and authentication guidance.',
+    path: getRelativeLocaleUrl(locale, 'docs/public-api'),
+  },
+  {
+    name: 'capgo.open_ai_skills',
+    title: 'Open AI skills',
+    description: 'Navigate to Capgo AI agent skills and MCP workflow information.',
+    path: getRelativeLocaleUrl(locale, 'skills'),
+  },
+]
+---
+
+<script is:inline define:vars={{ tools }}>
+  ;(() => {
+    if (typeof navigator === 'undefined') return
+
+    const modelContext = navigator.modelContext
+    if (!modelContext || typeof modelContext.registerTool !== 'function') return
+
+    const controller = new AbortController()
+
+    const registerNavigationTool = (tool) => {
+      modelContext.registerTool(
+        {
+          name: tool.name,
+          title: tool.title,
+          description: tool.description,
+          inputSchema: {
+            type: 'object',
+            additionalProperties: false,
+          },
+          execute: async () => {
+            const url = new URL(tool.path, window.location.origin).toString()
+            window.location.assign(url)
+            return {
+              status: 'navigating',
+              url,
+            }
+          },
+        },
+        { signal: controller.signal },
+      )
+    }
+
+    for (const tool of tools) {
+      try {
+        registerNavigationTool(tool)
+      } catch (error) {
+        console.debug('Capgo WebMCP registration skipped', tool.name, error)
+      }
+    }
+
+    window.addEventListener(
+      'pagehide',
+      () => {
+        controller.abort()
+      },
+      { once: true },
+    )
+  })()
+</script>

--- a/apps/web/src/layouts/Layout.astro
+++ b/apps/web/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import Footer from '../components/Footer.astro'
 import Header from '../components/Header.astro'
 import SEO from '../components/SEO.astro'
 import PostHog from '../components/posthog.astro'
+import WebMcpTools from '../components/WebMcpTools.astro'
 import globalStylesHref from '../css/global.css?url'
 
 const content = Astro.props.content ?? {}
@@ -23,10 +24,13 @@ const enableThirdPartyScripts = !isLocalhost && !disableThirdPartyScripts
     {enableThirdPartyScripts && <PostHog />}
   </head>
   <body>
-    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-blue-600 focus:text-white focus:rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400">
+    <a
+      href="#main-content"
+      class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-blue-600 focus:px-4 focus:py-2 focus:text-white focus:ring-2 focus:ring-blue-400 focus:outline-none"
+    >
       Skip to main content
     </a>
-    <div class="overflow-x-hidden text-white bg-gray-900">
+    <div class="overflow-x-hidden bg-gray-900 text-white">
       <Header />
       <main id="main-content">
         <slot />
@@ -45,7 +49,8 @@ const enableThirdPartyScripts = !isLocalhost && !disableThirdPartyScripts
         />
       )
     }
-    {enableThirdPartyScripts && <script is:inline type="text/javascript" src="https://widget.senja.io/js/iframeResizer.min.js"></script>}
-    {enableThirdPartyScripts && <script is:inline defer data-website-id="66bcb7fa4038d5b1e5ea89eb" data-domain="capgo.app" src="https://datafa.st/js/script.js"></script>}
+    <WebMcpTools />
+    {enableThirdPartyScripts && <script is:inline type="text/javascript" src="https://widget.senja.io/js/iframeResizer.min.js" />}
+    {enableThirdPartyScripts && <script is:inline defer data-website-id="66bcb7fa4038d5b1e5ea89eb" data-domain="capgo.app" src="https://datafa.st/js/script.js" />}
   </body>
 </html>

--- a/apps/web/src/lib/tools/api.ts
+++ b/apps/web/src/lib/tools/api.ts
@@ -22,6 +22,21 @@ const UDID_CHALLENGE_COOKIE = 'ios_udid_challenge'
 const UDID_RESULT_PATH = '/tools/ios-udid-finder/result/'
 const UDID_RESULT_API_PATH = '/api/tools/ios-udid-finder/result'
 const UDID_CALLBACK_PATH = '/api/tools/ios-udid-finder/callback'
+const HEAVY_TOOL_RATE_LIMIT = 10
+const HEAVY_TOOL_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000
+
+type RequestGuard = (request: Request) => Response | null
+
+type RateLimiterOptions = {
+  limit: number
+  windowMs: number
+  errorMessage?: string
+}
+
+type RateLimitEntry = {
+  count: number
+  resetAt: number
+}
 
 function webJson(body: unknown, status = 200, headers: HeadersInit = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -57,6 +72,68 @@ function getCookie(request: Request, name: string): string | null {
   }
 
   return null
+}
+
+function getClientIdentifier(request: Request): string {
+  const forwardedFor =
+    request.headers.get('cf-connecting-ip') ??
+    request.headers.get('x-forwarded-for') ??
+    request.headers.get('x-real-ip') ??
+    request.headers.get('true-client-ip') ??
+    request.headers.get('fly-client-ip')
+
+  if (forwardedFor) {
+    const [firstHop] = forwardedFor.split(',')
+    const normalized = firstHop?.trim()
+    if (normalized) {
+      return normalized
+    }
+  }
+
+  const userAgent = request.headers.get('user-agent')?.trim()
+  return userAgent ? `ua:${userAgent}` : 'anonymous'
+}
+
+function pruneExpiredRateLimitEntries(entries: Map<string, RateLimitEntry>, now: number): void {
+  for (const [key, entry] of entries) {
+    if (entry.resetAt <= now) {
+      entries.delete(key)
+    }
+  }
+}
+
+function createRateLimiter({ limit, windowMs, errorMessage = 'Too many requests. Please wait a few minutes and try again.' }: RateLimiterOptions): RequestGuard {
+  const entries = new Map<string, RateLimitEntry>()
+  let nextPruneAt = 0
+
+  return (request) => {
+    const now = Date.now()
+    if (now >= nextPruneAt) {
+      pruneExpiredRateLimitEntries(entries, now)
+      nextPruneAt = now + windowMs
+    }
+
+    const clientId = getClientIdentifier(request)
+    const existing = entries.get(clientId)
+
+    if (!existing || existing.resetAt <= now) {
+      entries.set(clientId, {
+        count: 1,
+        resetAt: now + windowMs,
+      })
+      return null
+    }
+
+    if (existing.count >= limit) {
+      const retryAfter = Math.max(1, Math.ceil((existing.resetAt - now) / 1000))
+      return webJson({ error: errorMessage }, 429, {
+        'Retry-After': String(retryAfter),
+      })
+    }
+
+    existing.count += 1
+    return null
+  }
 }
 
 function appendCookie(headers: Headers, name: string, value: string, path: string, maxAge: number, secure: boolean, httpOnly = false): void {
@@ -113,41 +190,46 @@ async function handleSigningRequest<TInput, TResponse>(
 }
 
 async function handleUdidProfile(request: Request, env: ToolApiEnv): Promise<Response> {
-  const baseUrl = new URL(request.url)
-  const challenge = crypto.randomUUID()
-  const locale = normalizeLocale(baseUrl.searchParams.get('locale'))
-  const callbackUrl = new URL(UDID_CALLBACK_PATH, baseUrl)
-  callbackUrl.searchParams.set('challenge', challenge)
-  if (locale) {
-    callbackUrl.searchParams.set('locale', locale)
+  try {
+    const baseUrl = new URL(request.url)
+    const challenge = crypto.randomUUID()
+    const locale = normalizeLocale(baseUrl.searchParams.get('locale'))
+    const callbackUrl = new URL(UDID_CALLBACK_PATH, baseUrl)
+    callbackUrl.searchParams.set('challenge', challenge)
+    if (locale) {
+      callbackUrl.searchParams.set('locale', locale)
+    }
+
+    const profile = createUdidMobileconfig({
+      callbackUrl: callbackUrl.toString(),
+      organization: 'Capgo',
+      displayName: 'Capgo Device Identifier',
+      description: 'Install this profile to retrieve your iPhone or iPad UDID and device details.',
+      challenge,
+    })
+
+    const signedProfile = await signMobileconfig(profile, {
+      certificatePem: env.IOS_UDID_PROFILE_SIGNING_CERT_PEM,
+      privateKeyPem: env.IOS_UDID_PROFILE_SIGNING_KEY_PEM,
+      chainPem: env.IOS_UDID_PROFILE_SIGNING_CHAIN_PEM,
+    })
+
+    const secure = baseUrl.protocol === 'https:'
+    const headers = new Headers({
+      'Cache-Control': 'no-store',
+      'Content-Disposition': 'attachment; filename="capgo-udid.mobileconfig"',
+      'Content-Type': 'application/x-apple-aspen-config',
+    })
+    appendCookie(headers, UDID_CHALLENGE_COOKIE, challenge, UDID_CALLBACK_PATH, 300, secure, true)
+
+    return new Response(signedProfile ? new Uint8Array(signedProfile) : profile, {
+      status: 200,
+      headers,
+    })
+  } catch (error) {
+    console.error('Unexpected UDID profile generation failure', error)
+    return webJson({ error: 'Internal server error generating the UDID profile.' }, 500)
   }
-
-  const profile = createUdidMobileconfig({
-    callbackUrl: callbackUrl.toString(),
-    organization: 'Capgo',
-    displayName: 'Capgo Device Identifier',
-    description: 'Install this profile to retrieve your iPhone or iPad UDID and device details.',
-    challenge,
-  })
-
-  const signedProfile = await signMobileconfig(profile, {
-    certificatePem: env.IOS_UDID_PROFILE_SIGNING_CERT_PEM,
-    privateKeyPem: env.IOS_UDID_PROFILE_SIGNING_KEY_PEM,
-    chainPem: env.IOS_UDID_PROFILE_SIGNING_CHAIN_PEM,
-  })
-
-  const secure = baseUrl.protocol === 'https:'
-  const headers = new Headers({
-    'Cache-Control': 'no-store',
-    'Content-Disposition': 'attachment; filename="capgo-udid.mobileconfig"',
-    'Content-Type': 'application/x-apple-aspen-config',
-  })
-  appendCookie(headers, UDID_CHALLENGE_COOKIE, challenge, UDID_CALLBACK_PATH, 300, secure, true)
-
-  return new Response(signedProfile ? new Uint8Array(signedProfile) : profile, {
-    status: 200,
-    headers,
-  })
 }
 
 async function handleUdidCallback(request: Request): Promise<Response> {
@@ -197,39 +279,73 @@ function methodNotAllowed(): Response {
   return webJson({ error: 'Method not allowed.' }, 405)
 }
 
+type RouteHandler = (request: Request, env: ToolApiEnv) => Promise<Response>
+
 type RouteDefinition = {
   methods: readonly string[]
-  handle: (request: Request, env: ToolApiEnv) => Promise<Response>
+  handle: RouteHandler
 }
+
+function withRequestGuard(guard: RequestGuard, handle: RouteHandler): RouteHandler {
+  return async (request, env) => {
+    const response = guard(request)
+    if (response) {
+      return response
+    }
+
+    return await handle(request, env)
+  }
+}
+
+const iosCertificateRateLimiter = createRateLimiter({
+  limit: HEAVY_TOOL_RATE_LIMIT,
+  windowMs: HEAVY_TOOL_RATE_LIMIT_WINDOW_MS,
+})
+
+const androidKeystoreRateLimiter = createRateLimiter({
+  limit: HEAVY_TOOL_RATE_LIMIT,
+  windowMs: HEAVY_TOOL_RATE_LIMIT_WINDOW_MS,
+})
+
+const iosUdidProfileRateLimiter = createRateLimiter({
+  limit: HEAVY_TOOL_RATE_LIMIT,
+  windowMs: HEAVY_TOOL_RATE_LIMIT_WINDOW_MS,
+})
 
 const toolRouteDefinitions: Record<string, RouteDefinition> = {
   '/api/tools/android-keystore-generator': {
     methods: ['POST'],
-    handle: async (request) =>
-      await handleSigningRequest(
-        request,
-        normalizeAndroidKeystoreInput,
-        createAndroidKeystoreBundle,
-        'Unable to validate the Android keystore request.',
-        'Internal server error generating the Android keystore.',
-        'Unexpected Android keystore generation failure',
-      ),
+    handle: withRequestGuard(
+      androidKeystoreRateLimiter,
+      async (request) =>
+        await handleSigningRequest(
+          request,
+          normalizeAndroidKeystoreInput,
+          createAndroidKeystoreBundle,
+          'Unable to validate the Android keystore request.',
+          'Internal server error generating the Android keystore.',
+          'Unexpected Android keystore generation failure',
+        ),
+    ),
   },
   '/api/tools/ios-certificate-generator': {
     methods: ['POST'],
-    handle: async (request) =>
-      await handleSigningRequest(
-        request,
-        normalizeIosCertificateInput,
-        createIosCertificateBundle,
-        'Unable to validate the iOS certificate request.',
-        'Internal server error generating the iOS certificate request.',
-        'Unexpected iOS certificate generation failure',
-      ),
+    handle: withRequestGuard(
+      iosCertificateRateLimiter,
+      async (request) =>
+        await handleSigningRequest(
+          request,
+          normalizeIosCertificateInput,
+          createIosCertificateBundle,
+          'Unable to validate the iOS certificate request.',
+          'Internal server error generating the iOS certificate request.',
+          'Unexpected iOS certificate generation failure',
+        ),
+    ),
   },
   '/api/tools/ios-udid-finder/profile': {
     methods: ['GET'],
-    handle: async (request, env) => await handleUdidProfile(request, env),
+    handle: withRequestGuard(iosUdidProfileRateLimiter, async (request, env) => await handleUdidProfile(request, env)),
   },
   '/api/tools/ios-udid-finder/callback': {
     methods: ['GET', 'POST'],

--- a/apps/web/src/lib/tools/api.ts
+++ b/apps/web/src/lib/tools/api.ts
@@ -24,17 +24,20 @@ const UDID_RESULT_API_PATH = '/api/tools/ios-udid-finder/result'
 const UDID_CALLBACK_PATH = '/api/tools/ios-udid-finder/callback'
 const HEAVY_TOOL_RATE_LIMIT = 10
 const HEAVY_TOOL_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000
+const HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES = 2048
 
 type RequestGuard = (request: Request) => Response | null
 
 type RateLimiterOptions = {
   limit: number
   windowMs: number
+  maxEntries?: number
   errorMessage?: string
 }
 
 type RateLimitEntry = {
   count: number
+  lastAccess: number
   resetAt: number
 }
 
@@ -102,7 +105,28 @@ function pruneExpiredRateLimitEntries(entries: Map<string, RateLimitEntry>, now:
   }
 }
 
-function createRateLimiter({ limit, windowMs, errorMessage = 'Too many requests. Please wait a few minutes and try again.' }: RateLimiterOptions): RequestGuard {
+function evictLeastRecentlyUsedEntry(entries: Map<string, RateLimitEntry>): void {
+  let oldestKey: string | null = null
+  let oldestAccess = Number.POSITIVE_INFINITY
+
+  for (const [key, entry] of entries) {
+    if (entry.lastAccess < oldestAccess) {
+      oldestKey = key
+      oldestAccess = entry.lastAccess
+    }
+  }
+
+  if (oldestKey) {
+    entries.delete(oldestKey)
+  }
+}
+
+function createRateLimiter({
+  limit,
+  windowMs,
+  maxEntries = HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
+  errorMessage = 'Too many requests. Please wait a few minutes and try again.',
+}: RateLimiterOptions): RequestGuard {
   const entries = new Map<string, RateLimitEntry>()
   let nextPruneAt = 0
 
@@ -117,12 +141,19 @@ function createRateLimiter({ limit, windowMs, errorMessage = 'Too many requests.
     const existing = entries.get(clientId)
 
     if (!existing || existing.resetAt <= now) {
+      if (!existing && entries.size >= maxEntries) {
+        evictLeastRecentlyUsedEntry(entries)
+      }
+
       entries.set(clientId, {
         count: 1,
+        lastAccess: now,
         resetAt: now + windowMs,
       })
       return null
     }
+
+    existing.lastAccess = now
 
     if (existing.count >= limit) {
       const retryAfter = Math.max(1, Math.ceil((existing.resetAt - now) / 1000))
@@ -299,16 +330,19 @@ function withRequestGuard(guard: RequestGuard, handle: RouteHandler): RouteHandl
 
 const iosCertificateRateLimiter = createRateLimiter({
   limit: HEAVY_TOOL_RATE_LIMIT,
+  maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
   windowMs: HEAVY_TOOL_RATE_LIMIT_WINDOW_MS,
 })
 
 const androidKeystoreRateLimiter = createRateLimiter({
   limit: HEAVY_TOOL_RATE_LIMIT,
+  maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
   windowMs: HEAVY_TOOL_RATE_LIMIT_WINDOW_MS,
 })
 
 const iosUdidProfileRateLimiter = createRateLimiter({
   limit: HEAVY_TOOL_RATE_LIMIT,
+  maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
   windowMs: HEAVY_TOOL_RATE_LIMIT_WINDOW_MS,
 })
 

--- a/scripts/validate-agent-skills-digests.mjs
+++ b/scripts/validate-agent-skills-digests.mjs
@@ -5,7 +5,7 @@ import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
 const repoRoot = path.dirname(fileURLToPath(new URL('../package.json', import.meta.url)))
-const skillsDir = path.join(repoRoot, 'apps', 'web', 'public', '.well-known', 'agent-skills')
+const skillsDir = path.resolve(repoRoot, 'apps', 'web', 'public', '.well-known', 'agent-skills')
 const indexPath = path.join(skillsDir, 'index.json')
 
 function normalizeSkillPath(url) {
@@ -13,11 +13,20 @@ function normalizeSkillPath(url) {
     throw new Error(`Unsupported agent skill URL: ${url}`)
   }
 
-  return path.join(repoRoot, 'apps', 'web', 'public', url.slice(1))
+  const relativePath = url.slice('/.well-known/agent-skills/'.length)
+  const resolvedPath = path.resolve(skillsDir, relativePath)
+  const normalizedRelativePath = path.relative(skillsDir, resolvedPath)
+
+  if (normalizedRelativePath.startsWith('..') || path.isAbsolute(normalizedRelativePath)) {
+    throw new Error(`Unsupported agent skill URL: ${url}`)
+  }
+
+  return resolvedPath
 }
 
 function computeDigest(content) {
-  return `sha256:${createHash('sha256').update(content).digest('hex')}`
+  const normalizedContent = content.replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n')
+  return `sha256:${createHash('sha256').update(normalizedContent, 'utf8').digest('hex')}`
 }
 
 async function main() {
@@ -27,7 +36,7 @@ async function main() {
 
   for (const skill of registry.skills ?? []) {
     const skillPath = normalizeSkillPath(skill.url)
-    const skillContent = await readFile(skillPath)
+    const skillContent = await readFile(skillPath, 'utf8')
     const actualDigest = computeDigest(skillContent)
 
     if (skill.digest !== actualDigest) {

--- a/scripts/validate-agent-skills-digests.mjs
+++ b/scripts/validate-agent-skills-digests.mjs
@@ -1,0 +1,53 @@
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.dirname(fileURLToPath(new URL('../package.json', import.meta.url)))
+const skillsDir = path.join(repoRoot, 'apps', 'web', 'public', '.well-known', 'agent-skills')
+const indexPath = path.join(skillsDir, 'index.json')
+
+function normalizeSkillPath(url) {
+  if (!url.startsWith('/.well-known/agent-skills/')) {
+    throw new Error(`Unsupported agent skill URL: ${url}`)
+  }
+
+  return path.join(repoRoot, 'apps', 'web', 'public', url.slice(1))
+}
+
+function computeDigest(content) {
+  return `sha256:${createHash('sha256').update(content).digest('hex')}`
+}
+
+async function main() {
+  const indexContent = await readFile(indexPath, 'utf8')
+  const registry = JSON.parse(indexContent)
+  const mismatches = []
+
+  for (const skill of registry.skills ?? []) {
+    const skillPath = normalizeSkillPath(skill.url)
+    const skillContent = await readFile(skillPath)
+    const actualDigest = computeDigest(skillContent)
+
+    if (skill.digest !== actualDigest) {
+      mismatches.push({
+        name: skill.name,
+        expected: skill.digest,
+        actual: actualDigest,
+      })
+    }
+  }
+
+  if (mismatches.length === 0) {
+    return
+  }
+
+  for (const mismatch of mismatches) {
+    console.error(`Agent skill digest mismatch for ${mismatch.name}: expected ${mismatch.expected}, got ${mismatch.actual}`)
+  }
+
+  process.exitCode = 1
+}
+
+await main()

--- a/scripts/validate-agent-skills-digests.mjs
+++ b/scripts/validate-agent-skills-digests.mjs
@@ -40,14 +40,20 @@ async function main() {
     return
   }
 
-  for (const skill of registry.skills) {
+  for (const [index, skill] of registry.skills.entries()) {
+    if (!skill || typeof skill !== 'object' || typeof skill.url !== 'string' || typeof skill.digest !== 'string') {
+      console.error(`Invalid agent skill entry at index ${index}: expected object with string "url" and "digest".`)
+      process.exitCode = 1
+      continue
+    }
+
     const skillPath = normalizeSkillPath(skill.url)
     const skillContent = await readFile(skillPath, 'utf8')
     const actualDigest = computeDigest(skillContent)
 
     if (skill.digest !== actualDigest) {
       mismatches.push({
-        name: skill.name,
+        name: typeof skill.name === 'string' && skill.name ? skill.name : `skill[${index}]`,
         expected: skill.digest,
         actual: actualDigest,
       })

--- a/scripts/validate-agent-skills-digests.mjs
+++ b/scripts/validate-agent-skills-digests.mjs
@@ -34,7 +34,13 @@ async function main() {
   const registry = JSON.parse(indexContent)
   const mismatches = []
 
-  for (const skill of registry.skills ?? []) {
+  if (!registry || typeof registry !== 'object' || !Array.isArray(registry.skills)) {
+    console.error('Invalid agent skills registry: "skills" must be an array.')
+    process.exitCode = 1
+    return
+  }
+
+  for (const skill of registry.skills) {
     const skillPath = normalizeSkillPath(skill.url)
     const skillContent = await readFile(skillPath, 'utf8')
     const actualDigest = computeDigest(skillContent)


### PR DESCRIPTION
## What changed

- add homepage `Link` headers for API discovery
- add `Content-Signal` directives to `robots.txt`
- publish `/.well-known` AI discovery assets for API catalog, OpenAPI, health status, MCP server card, and agent skills
- register WebMCP navigation tools from the shared layout

## Why

The Capgo landing site was missing the machine-readable discovery surfaces flagged by isitagentready.com, which limited agent discovery for the website tools, docs, and MCP workflow.

## Impact

- agents can discover the Capgo website tools API from standard headers and `/.well-known/api-catalog`
- agents can discover Capgo skill definitions and the documented CLI MCP server
- browsers with WebMCP support get explicit Capgo navigation tools on page load

## Root cause

The landing app exposed human-readable content, but not the complementary discovery metadata and browser-side tool registration that current agent ecosystems expect.

## Validation

- `NODE_OPTIONS=--max-old-space-size=16384 bun run check`
- `cd apps/web && NODE_OPTIONS=--max-old-space-size=16384 bun run build` (fails later on an unrelated existing timeout while rendering `/de/top_capacitor_app`, after emitting the new `_headers`, `robots.txt`, and `/.well-known/*` assets)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI agent skills (CLI MCP, mobile signing tools, public API, site routing) and client-side MCP tool registration for quick navigation.

* **Documentation**
  * Added skill manifests, discovery index, OpenAPI spec, API catalog, MCP server card, service health/status, and updated site headers and robots directive.

* **Bug Fixes / Stability**
  * Per-client rate limiting and improved error handling for tools endpoints.

* **Chores**
  * Added digest validation to checks, CI script hook, and minor layout/formatting tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->