### PR TITLE
[codex] sync passkey docs

### DIFF
--- a/apps/docs/src/config/llmsCustomSets.ts
+++ b/apps/docs/src/config/llmsCustomSets.ts
@@ -68,7 +68,7 @@ Plugin Native Purchases|in-app purchases and subscriptions plugin|docs/plugins/n
 Plugin Navigation Bar|Android navigation bar customization plugin|docs/plugins/navigation-bar/**
 Plugin NFC|NFC reading and writing plugin|docs/plugins/nfc/**
 Plugin Pay|Apple Pay and Google Pay integration plugin|docs/plugins/pay/**
-Plugin Passkey|browser-style WebAuthn passkey plugin with native shims and generated platform configuration|docs/plugins/passkey/**
+Plugin Passkey|browser-style WebAuthn passkey plugin that handles native calls and host patching|docs/plugins/passkey/**
 Plugin Privacy Screen|privacy screen plugin for hiding app content in system previews and screenshots|docs/plugins/privacy-screen/**
 Plugin Proximity|native proximity sensor plugin for face, hand, and surface detection|docs/plugins/proximity/**
 Plugin PDF Generator|PDF generation plugin|docs/plugins/pdf-generator/**

--- a/apps/docs/src/content/docs/docs/plugins/passkey/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/passkey/getting-started.mdx
@@ -36,10 +36,12 @@ import { PackageManagers } from 'starlight-package-managers'
    export default config;
    ```
 
-4. **Import the shim once**
+4. **Install the shim during bootstrap**
 
    ```ts
-   import '@capgo/capacitor-passkey/auto';
+   import { CapacitorPasskey } from '@capgo/capacitor-passkey';
+
+   await CapacitorPasskey.autoShimWebAuthn();
    ```
 
 5. **Keep your normal WebAuthn flow**
@@ -61,7 +63,7 @@ The config is read from `plugins.CapacitorPasskey` in `capacitor.config.*`.
 
 - `origin`: primary HTTPS relying-party origin used by the shim and direct API
 - `domains`: extra relying-party hostnames to patch into native config during sync
-- `autoShim`: defaults to `true` when you use `@capgo/capacitor-passkey/auto`
+- `autoShim`: defaults to `true` and controls the native `cap sync` auto-configuration hook
 
 ## What sync patches for you
 

--- a/apps/docs/src/content/docs/docs/plugins/passkey/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/passkey/index.mdx
@@ -27,7 +27,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
     Keep `navigator.credentials.create()` and `navigator.credentials.get()` in your app instead of rewriting your passkey flow around a custom API.
   </Card>
   <Card title="Minimal app changes" icon="pencil">
-    Add plugin config once, import `@capgo/capacitor-passkey/auto`, and keep the rest of your WebAuthn code close to the browser implementation.
+    Add plugin config once, call `CapacitorPasskey.autoShimWebAuthn()` during bootstrap, and keep the rest of your WebAuthn code close to the browser implementation.
   </Card>
   <Card title="Build-time native wiring" icon="setting">
     The plugin patches the generated iOS and Android host projects during sync so you do not need to keep hand-editing those files.

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -48,7 +48,7 @@ const actionDefinitionRows =
 @capgo/capacitor-streamcall|github.com/Cap-go|Integrate video calling and live streaming with Stream SDK for real-time communication|https://github.com/Cap-go/capacitor-streamcall/|Streamcall
 @capgo/capacitor-autofill-save-password|github.com/Cap-go|Prompt users to save passwords to device autofill for seamless login experience|https://github.com/Cap-go/capacitor-autofill-save-password/|Autofill Save Password
 @capgo/capacitor-social-login|github.com/Cap-go|Authenticate users with Google, Facebook, and Apple Sign-In for easy social login|https://github.com/Cap-go/capacitor-social-login/|Social Login
-@capgo/capacitor-passkey|github.com/Cap-go|Use browser-style WebAuthn passkeys in Capacitor with a native shim and generated platform configuration|https://github.com/Cap-go/capacitor-passkey/|Passkey
+@capgo/capacitor-passkey|github.com/Cap-go|Keep browser-style WebAuthn code in Capacitor while native passkey calls and host patching are handled for you|https://github.com/Cap-go/capacitor-passkey/|Passkey
 @capgo/capacitor-jw-player|github.com/Cap-go|Embed JW Player for professional video streaming with ads and analytics support|https://github.com/Cap-go/capacitor-jw-player/|JW Player
 @capgo/capacitor-ricoh360-camera-plugin|github.com/Cap-go|Control Ricoh Theta 360-degree cameras for immersive panoramic photography|https://github.com/Cap-go/capacitor-ricoh360-camera-plugin/|Ricoh360 Camera
 @capgo/capacitor-admob|github.com/Cap-go|Monetize your app with Google AdMob banner, interstitial, and rewarded ads|https://github.com/Cap-go/capacitor-admob/|AdMob

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-passkey.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-passkey.md
@@ -53,7 +53,7 @@ The config is read from `plugins.CapacitorPasskey` in `capacitor.config.*`.
 
 - `origin`: primary HTTPS relying-party origin used by the shim and direct API
 - `domains`: extra relying-party hostnames to patch into native config during sync
-- `autoShim`: defaults to `true` when you use `@capgo/capacitor-passkey/auto`
+- `autoShim`: defaults to `true` and controls the native `cap sync` auto-configuration hook
 
 Run sync again after changing the config:
 
@@ -61,12 +61,14 @@ Run sync again after changing the config:
 bunx cap sync
 ```
 
-## Import the shim once
+## Install the shim during bootstrap
 
-Import the auto entrypoint in your app bootstrap:
+Import the plugin from the standard package entrypoint, then install the shim during app bootstrap:
 
 ```ts
-import '@capgo/capacitor-passkey/auto';
+import { CapacitorPasskey } from '@capgo/capacitor-passkey';
+
+await CapacitorPasskey.autoShimWebAuthn();
 ```
 
 After that, your existing browser-style passkey code can stay the same.

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-passkey.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-passkey.md
@@ -4,7 +4,11 @@ published: true
 ---
 # Using @capgo/capacitor-passkey
 
-`@capgo/capacitor-passkey` lets a Capacitor app keep the same WebAuthn flow you already use on the web:
+Keep your browser-style WebAuthn code in a Capacitor app while the plugin handles native passkey calls and native host patching.
+
+## Browser-style API
+
+`@capgo/capacitor-passkey` keeps the same WebAuthn flow you already use on the web:
 
 ```ts
 await navigator.credentials.create({ publicKey: registrationOptions });
@@ -13,7 +17,7 @@ await navigator.credentials.get({ publicKey: requestOptions });
 
 On native builds, the plugin installs a shim for `navigator.credentials.create()` and `navigator.credentials.get()`, forwards the request to iOS and Android passkey APIs, and returns browser-like credential objects to your app.
 
-## Install the plugin
+## Install and sync native projects
 
 ```bash
 bun add @capgo/capacitor-passkey
@@ -43,16 +47,19 @@ const config: CapacitorConfig = {
 export default config;
 ```
 
+## What the plugin config does
+
+The config is read from `plugins.CapacitorPasskey` in `capacitor.config.*`.
+
+- `origin`: primary HTTPS relying-party origin used by the shim and direct API
+- `domains`: extra relying-party hostnames to patch into native config during sync
+- `autoShim`: defaults to `true` when you use `@capgo/capacitor-passkey/auto`
+
 Run sync again after changing the config:
 
 ```bash
 bunx cap sync
 ```
-
-During sync, the plugin patches the generated native host projects:
-
-- iOS: associated domains entitlements
-- Android: `asset_statements` metadata for Digital Asset Links
 
 ## Import the shim once
 
@@ -76,19 +83,32 @@ const assertion = await navigator.credentials.get({
 });
 ```
 
+## What sync patches for you
+
+During `bunx cap sync`, the plugin updates the generated native host projects:
+
+- iOS: associated domains entitlements and Xcode entitlements wiring when needed
+- Android: `asset_statements` metadata and the generated resource used by the manifest
+
 ## Native setup still needs website trust files
 
-The plugin reduces app-side work, but passkeys still depend on the website trust files for your relying-party domain:
+The plugin reduces app-side work, but passkeys still depend on the website trust files for your relying-party domain. You still need to host:
 
-- iOS needs `/.well-known/apple-app-site-association`
-- Android needs `/.well-known/assetlinks.json`
+- `https://your-domain/.well-known/apple-app-site-association`
+- `https://your-domain/.well-known/assetlinks.json`
 
-The detailed setup is documented here:
+The plugin can patch the generated native projects during sync, but it cannot create or host those website trust files for you.
+
+## Platform guides
 
 - [Getting started](/docs/plugins/passkey/getting-started/)
 - [iOS setup](/docs/plugins/passkey/ios/)
 - [Android setup](/docs/plugins/passkey/android/)
 - [Backend notes](/docs/plugins/passkey/backend/)
+
+## Important iOS note
+
+On iOS 17.4 and newer, the plugin uses the browser-style client-data API so the configured HTTPS origin is reflected in `clientDataJSON`.
 
 ## Important Android caveat
 


### PR DESCRIPTION
## What changed
- synced the public `@capgo/capacitor-passkey` tutorial with the latest passkey docs structure and wording
- updated the passkey summary copy in the web plugin registry and docs LLM set metadata

## Why
The dedicated passkey docs were already current, but the website tutorial and related summary text were still using older phrasing and omitted newer setup details and caveats.

## Impact
- website plugin page now reflects the latest passkey setup guidance
- registry/search copy matches the current plugin positioning

## Validation
- `bun run check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Substantially enhanced Capacitor Passkey plugin docs with clearer setup and bootstrap instructions, including an explicit browser-style API and bootstrap flow
  * Expanded explanation of plugin config options and what native sync/patching performs (iOS entitlements, Android manifest wiring)
  * Clarified trust-file requirements and added important iOS behavior notes; updated plugin description to emphasize native passkey handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->