### PR TITLE
[codex] fix proximity docs icon build

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/proximity/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/proximity/index.mdx
@@ -10,7 +10,7 @@ sidebar:
 hero:
   tagline: Enable native proximity monitoring so your app can react when the device is held to the ear, covered by a hand, or placed face down.
   image:
-    file: /icons/plugins/proximity.svg
+    file: ~public/icons/plugins/proximity.svg
   actions:
     - text: Get started
       link: /docs/plugins/proximity/getting-started/

--- a/apps/web/public/icons/plugins/proximity.svg
+++ b/apps/web/public/icons/plugins/proximity.svg
@@ -1,0 +1,8 @@
+<svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="56" height="56" rx="12" fill="#0F766E" />
+  <rect x="16" y="10" width="18" height="36" rx="5" fill="white" fill-opacity="0.18" stroke="white" stroke-width="2" />
+  <rect x="20" y="15" width="10" height="21" rx="2" fill="white" />
+  <circle cx="25" cy="41" r="2" fill="white" />
+  <path d="M39 18C42.3137 20.6667 44 24 44 28C44 32 42.3137 35.3333 39 38" stroke="white" stroke-width="2.5" stroke-linecap="round" />
+  <path d="M35 22C37 23.6667 38 25.6667 38 28C38 30.3333 37 32.3333 35 34" stroke="white" stroke-width="2.5" stroke-linecap="round" />
+</svg>


### PR DESCRIPTION
## What changed
- added the missing `proximity.svg` source asset under `apps/web/public/icons/plugins/` so the docs asset sync can copy it
- switched the proximity docs hero image reference to the standard `~public/icons/plugins/...` format Astro expects

## Why
The docs build deletes and rebuilds `apps/docs/public` from `apps/web/public`. The proximity icon only existed in docs public, and the docs frontmatter used `/icons/...` instead of the supported `~public/...` form, so the build could not resolve the image.

## Validation
- `bun run build:docs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated the proximity plugin documentation page to ensure the plugin icon displays correctly in the header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->