### PR TITLE
[codex] fix inappbrowser docs MDX syntax

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/inappbrowser/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/inappbrowser/getting-started.mdx
@@ -149,9 +149,9 @@ await InAppBrowser.executeScript({} as { code: string; id?: string });
 
 ### `postMessage`
 
-Sends an event to the webview(inappbrowser). you can listen to this event in the inappbrowser JS with window.addEventListener("messageFromNative", listenerFunc: (event: Record<string, any>) => void)
-detail is the data you want to send to the webview, it's a requirement of Capacitor we cannot send direct objects
-Your object has to be serializable to JSON, so no functions or other non-JSON-serializable types are allowed.
+Sends an event to the webview (`inappbrowser`).
+In the page loaded inside the in-app browser, listen for the `messageFromNative` event on `window`.
+`detail` is the payload sent to the webview. Because it crosses the Capacitor bridge, it must be JSON-serializable.
 When `id` is omitted, broadcasts to all open webviews.
 
 ```typescript

--- a/apps/docs/src/content/docs/docs/plugins/inappbrowser/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/inappbrowser/index.mdx
@@ -46,14 +46,14 @@ Capacitor plugin in app browser.
 | `show` | Show a previously hidden webview. When `id` is omitted, targets the active webview. |
 | `openWebView` | Open url in a new webview with toolbars, and enhanced capabilities, like camera access, file access, listen events, inject javascript, bi directional communication, etc. |
 | `executeScript` | Injects JavaScript code into the InAppBrowser window. When `id` is omitted, executes in all open webviews. |
-| `postMessage` | Sends an event to the webview(inappbrowser). you can listen to this event in the inappbrowser JS with window.addEventListener("messageFromNative", listenerFunc: (event: Record<string, any>) => void) detail is the data you want to send to the webview, it's a requirement of Capacitor we cannot send direct objects Your object has to be serializable to JSON, so no functions or other non-JSON-serializable types are allowed. When `id` is omitted, broadcasts to all open webviews. |
+| `postMessage` | Sends an event to the webview (`inappbrowser`). In the page loaded inside the in-app browser, listen for the `messageFromNative` event on `window`. `detail` is the payload sent to the webview, and it must be JSON-serializable. When `id` is omitted, broadcasts to all open webviews. |
 | `takeScreenshot` | Captures the current webview viewport as a PNG screenshot. When `id` is omitted, targets the active webview. |
 | `setUrl` | Sets the URL of the webview. When `id` is omitted, targets the active webview. |
 | `addListener` | Listen for url change, only for openWebView. |
 | `addListener` | See the source definitions for current behavior. |
 | `addListener` | Listen for close click only for openWebView. |
 | `addListener` | Will be triggered when user clicks on confirm button when disclaimer is required, works with openWebView shareDisclaimer and closeModal. |
-| `addListener` | Will be triggered when event is sent from webview(inappbrowser), to send an event to the main app use window.mobileApp.postMessage({ "detail": { "message": "myMessage" } }) detail is the data you want to send to the main app, it's a requirement of Capacitor we cannot send direct objects Your object has to be serializable to JSON, no functions or other non-JSON-serializable types are allowed. |
+| `addListener` | Triggered when the webview (`inappbrowser`) sends an event to the main app. From the in-app browser page, call `window.mobileApp.postMessage(...)` with a JSON-serializable `detail` payload. |
 | `addListener` | Will be triggered whenever a screenshot is captured from the plugin API, the native screenshot button, or the injected JavaScript bridge. |
 | `addListener` | Will be triggered when page is loaded. |
 | `addListener` | Will be triggered when page load error. |


### PR DESCRIPTION
## Summary
- replace MDX-unsafe inline TypeScript syntax in the inappbrowser getting-started doc
- align the inappbrowser index table copy with parser-safe wording
- simplify the message listener examples to plain English while preserving the API behavior

## Validation
- NODE_OPTIONS=--max-old-space-size=16384 bun run build:docs
- NODE_OPTIONS=--max-old-space-size=16384 bun run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified in-app browser messaging: specifies that the `detail` payload must be JSON-serializable (functions and non-serializable types are not allowed) and refines wording around broadcasting when no `id` is provided; overall clearer guidance for using `postMessage` and related listeners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->