### PR TITLE
Improve Capgo public API AI discovery metadata

### DIFF
--- a/apps/web/public/.well-known/agent-skills/capgo-public-api/SKILL.md
+++ b/apps/web/public/.well-known/agent-skills/capgo-public-api/SKILL.md
@@ -11,11 +11,13 @@ Use this skill when the task requires programmatic work with Capgo Cloud instead
 
 - Product site: https://capgo.app
 - API docs: https://capgo.app/docs/public-api/
+- Agent-ready OpenAPI: https://capgo.app/.well-known/capgo-public-api-openapi.json
 - API base: https://api.capgo.app
+- Status page: https://status.capgo.app/
 
 ## Authentication
 
-Send a Capgo API key in the `authorization` header.
+Send a raw Capgo API key in the `authorization` header. Do not prepend `Bearer` unless the published API docs change.
 
 ```bash
 curl -H "authorization: $CAPGO_API_KEY" https://api.capgo.app/organization/
@@ -27,17 +29,19 @@ Create or rotate API keys in the dashboard:
 
 ## Main resource groups
 
-- `/organization/` and `/organization/members/`
-- `/app/`
-- `/apikey/`
-- `/channel/`
-- `/bundle/`
-- `/device/`
-- `/statistics/...`
+- `/organization/` for organization CRUD and `/organization/members/` for member access control
+- `/app/` and `/app/:app_id` for app listing, creation, updates, and deletion
+- `/apikey/` and `/apikey/:id/` for API key lifecycle management
+- `/channel/` for channel rollout configuration
+- `/bundle/` and `/bundle/metadata` for live-update bundle registration and metadata
+- `/device/` for device overrides and device inventory
+- `/statistics/...` for app, organization, user, and bundle-usage analytics
 
 ## Working rules
 
-- Prefer the published docs for request and response details before guessing fields.
+- Prefer the published docs and OpenAPI document for request and response details before guessing fields.
 - Use least-privilege API keys (`read`, `upload`, `write`, `all`).
-- Handle `429` responses with retry backoff.
+- Handle `401`, `403`, and `429` responses explicitly, with retry backoff for `429`.
+- Standard accounts are limited to 100 requests per minute; enterprise accounts are limited to 1000 requests per minute.
 - Expect JSON success payloads with `data` or `status`, and JSON failures with `error`.
+- Capgo's public API currently uses API-key authentication, not OAuth/OIDC discovery metadata.

--- a/apps/web/public/.well-known/agent-skills/capgo-public-api/SKILL.md
+++ b/apps/web/public/.well-known/agent-skills/capgo-public-api/SKILL.md
@@ -43,5 +43,5 @@ Create or rotate API keys in the dashboard:
 - Use least-privilege API keys (`read`, `upload`, `write`, `all`).
 - Handle `401`, `403`, and `429` responses explicitly, with retry backoff for `429`.
 - Standard accounts are limited to 100 requests per minute; enterprise accounts are limited to 1000 requests per minute.
-- Expect JSON success payloads with `data` or `status`, and JSON failures with `error`.
+- Expect endpoint-specific JSON success shapes. Many responses use `data` or `status`, but `/statistics/...` can return top-level arrays and `bundle_usage` returns an object with `labels` and `datasets`, so rely on the OpenAPI before unwrapping. Errors typically include an `error` field when present.
 - Capgo's public API currently uses API-key authentication, not OAuth/OIDC discovery metadata.

--- a/apps/web/public/.well-known/agent-skills/index.json
+++ b/apps/web/public/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Use Capgo's public API docs and API-key authentication model to manage organizations, apps, channels, devices, bundles, statistics, and API keys.",
       "url": "/.well-known/agent-skills/capgo-public-api/SKILL.md",
-      "digest": "sha256:ceea81e3e0ab1c495bbb2041afa948330aa275f2b0f41b85894ed4a2030e07f5"
+      "digest": "sha256:f416f263f297768ab6559ea258492547b97204e2b3212b401b9a60dbb988c4f2"
     },
     {
       "name": "capgo-mobile-signing-tools",

--- a/apps/web/public/.well-known/agent-skills/index.json
+++ b/apps/web/public/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Use Capgo's public API docs and API-key authentication model to manage organizations, apps, channels, devices, bundles, statistics, and API keys.",
       "url": "/.well-known/agent-skills/capgo-public-api/SKILL.md",
-      "digest": "sha256:a28a7cf3713230bdf6ea8c8f8b48e167f51050cd618ed4d60852fde6086584ef"
+      "digest": "sha256:ceea81e3e0ab1c495bbb2041afa948330aa275f2b0f41b85894ed4a2030e07f5"
     },
     {
       "name": "capgo-mobile-signing-tools",

--- a/apps/web/public/.well-known/api-catalog
+++ b/apps/web/public/.well-known/api-catalog
@@ -1,6 +1,31 @@
 {
   "linkset": [
     {
+      "anchor": "https://api.capgo.app/",
+      "service-desc": [
+        {
+          "href": "https://capgo.app/.well-known/capgo-public-api-openapi.json",
+          "type": "application/openapi+json"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://capgo.app/docs/public-api/",
+          "type": "text/html"
+        },
+        {
+          "href": "https://capgo.app/docs/public-api/api-keys/",
+          "type": "text/html"
+        }
+      ],
+      "status": [
+        {
+          "href": "https://status.capgo.app/",
+          "type": "text/html"
+        }
+      ]
+    },
+    {
       "anchor": "https://capgo.app/api/tools/",
       "service-desc": [
         {

--- a/apps/web/public/.well-known/capgo-public-api-openapi.json
+++ b/apps/web/public/.well-known/capgo-public-api-openapi.json
@@ -1722,6 +1722,7 @@
             "$ref": "#/components/schemas/App"
           }
         },
+        "required": ["data"],
         "additionalProperties": true
       },
       "AppListEnvelope": {

--- a/apps/web/public/.well-known/capgo-public-api-openapi.json
+++ b/apps/web/public/.well-known/capgo-public-api-openapi.json
@@ -1,0 +1,2272 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Capgo Public API",
+    "summary": "REST API for managing Capgo organizations, apps, live update channels, bundles, devices, analytics, and API keys.",
+    "description": "Use this API to automate Capgo Cloud instead of clicking through the dashboard. Authenticate every request by sending a raw Capgo API key in the `authorization` header. Do not prepend `Bearer` unless the published Capgo docs change. Standard accounts are limited to 100 requests per minute and enterprise accounts are limited to 1000 requests per minute. Capgo's public API currently uses API-key authentication rather than OAuth or OIDC discovery metadata.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.capgo.app",
+      "description": "Production"
+    }
+  ],
+  "externalDocs": {
+    "description": "Capgo public API documentation",
+    "url": "https://capgo.app/docs/public-api/"
+  },
+  "security": [
+    {
+      "CapgoApiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "organizations",
+      "description": "Organization CRUD and metadata."
+    },
+    {
+      "name": "members",
+      "description": "Organization member invitations, roles, and removals."
+    },
+    {
+      "name": "apps",
+      "description": "Application inventory and settings."
+    },
+    {
+      "name": "api-keys",
+      "description": "Capgo API key management."
+    },
+    {
+      "name": "channels",
+      "description": "Live update rollout channels."
+    },
+    {
+      "name": "devices",
+      "description": "Device overrides and device inventory."
+    },
+    {
+      "name": "bundles",
+      "description": "Live update bundle registration, metadata, and channel assignment."
+    },
+    {
+      "name": "statistics",
+      "description": "App, organization, user, and bundle usage analytics."
+    }
+  ],
+  "paths": {
+    "/organization/": {
+      "get": {
+        "tags": ["organizations"],
+        "operationId": "getOrganizations",
+        "summary": "List accessible organizations or fetch one organization by `orgId`.",
+        "parameters": [
+          {
+            "name": "orgId",
+            "in": "query",
+            "description": "Optional organization identifier for a single-organization lookup.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Organization data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/OrganizationEnvelope"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OrganizationListEnvelope"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": ["organizations"],
+        "operationId": "createOrganization",
+        "summary": "Create a new organization.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Organization created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "put": {
+        "tags": ["organizations"],
+        "operationId": "updateOrganization",
+        "summary": "Update an organization. Admin access is required.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Organization updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["organizations"],
+        "operationId": "deleteOrganization",
+        "summary": "Delete an organization by query parameter.",
+        "parameters": [
+          {
+            "name": "orgId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Organization deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/organization/members/": {
+      "get": {
+        "tags": ["members"],
+        "operationId": "listOrganizationMembers",
+        "summary": "List members for one organization.",
+        "parameters": [
+          {
+            "name": "orgId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Organization members.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemberListEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": ["members"],
+        "operationId": "upsertOrganizationMember",
+        "summary": "Invite a member or update an existing member role.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemberCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Member invitation or role change accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["members"],
+        "operationId": "deleteOrganizationMember",
+        "summary": "Remove a member from an organization.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemberDelete"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Member removed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/app/": {
+      "get": {
+        "tags": ["apps"],
+        "operationId": "listApps",
+        "summary": "List apps visible to the API key.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageParam"
+          },
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          },
+          {
+            "name": "org_id",
+            "in": "query",
+            "description": "Optional organization filter.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Applications.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppListEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": ["apps"],
+        "operationId": "createApp",
+        "summary": "Create a new Capgo app.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "App created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/app/{appId}": {
+      "get": {
+        "tags": ["apps"],
+        "operationId": "getApp",
+        "summary": "Fetch one app by app identifier.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AppIdPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "One application.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "put": {
+        "tags": ["apps"],
+        "operationId": "updateApp",
+        "summary": "Update one app by app identifier.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AppIdPath"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated application.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["apps"],
+        "operationId": "deleteApp",
+        "summary": "Delete one app by app identifier.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AppIdPath"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "App deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/apikey/": {
+      "get": {
+        "tags": ["api-keys"],
+        "operationId": "listApiKeys",
+        "summary": "List API keys available to the authenticated account.",
+        "responses": {
+          "200": {
+            "description": "API keys.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyListEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": ["api-keys"],
+        "operationId": "createApiKey",
+        "summary": "Create a new API key.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiKeyCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Created API key. The raw secret may only be returned once.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyCreateEnvelope"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/apikey/{id}/": {
+      "delete": {
+        "tags": ["api-keys"],
+        "operationId": "deleteApiKey",
+        "summary": "Delete an API key by numeric identifier.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "API key deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/channel/": {
+      "get": {
+        "tags": ["channels"],
+        "operationId": "listChannels",
+        "summary": "List channels for one app.",
+        "parameters": [
+          {
+            "name": "app_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/PageParam"
+          },
+          {
+            "name": "channel",
+            "in": "query",
+            "description": "Optional channel name filter.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Channels.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChannelListEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": ["channels"],
+        "operationId": "upsertChannel",
+        "summary": "Create or update a channel configuration.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChannelSet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Channel accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["channels"],
+        "operationId": "deleteChannel",
+        "summary": "Delete one channel.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChannelDelete"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Channel deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/device/": {
+      "get": {
+        "tags": ["devices"],
+        "operationId": "getDevices",
+        "summary": "List devices for one app or fetch one device by `device_id`.",
+        "parameters": [
+          {
+            "name": "app_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "device_id",
+            "in": "query",
+            "description": "Optional device identifier for a single-device lookup.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor for paginating device lists.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/LimitParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Device data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/DeviceEnvelope"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DeviceListEnvelope"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": ["devices"],
+        "operationId": "linkDevice",
+        "summary": "Link a device to a channel or bundle override.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeviceLink"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Device override accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["devices"],
+        "operationId": "deleteDeviceOverride",
+        "summary": "Remove a device-specific override so the device falls back to channel defaults.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeviceDelete"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Device override removed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/bundle/": {
+      "get": {
+        "tags": ["bundles"],
+        "operationId": "listBundles",
+        "summary": "List bundles for one app.",
+        "parameters": [
+          {
+            "name": "app_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/PageParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bundles.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BundleListEnvelope"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "tags": ["bundles"],
+        "operationId": "createBundle",
+        "summary": "Register a new bundle using an externally hosted zip URL and checksum.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BundleCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bundle created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "put": {
+        "tags": ["bundles"],
+        "operationId": "setBundleChannel",
+        "summary": "Attach a bundle to a channel.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BundleChannelSet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bundle assigned to channel.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["bundles"],
+        "operationId": "deleteBundle",
+        "summary": "Delete one bundle or all bundles for an app.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BundleDelete"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bundle deletion accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/bundle/metadata": {
+      "post": {
+        "tags": ["bundles"],
+        "operationId": "updateBundleMetadata",
+        "summary": "Update bundle metadata such as release link or comment.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BundleMetadataUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bundle metadata updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/statistics/app/{appId}/": {
+      "get": {
+        "tags": ["statistics"],
+        "operationId": "getAppStatistics",
+        "summary": "Get time-series statistics for one app.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AppIdPath"
+          },
+          {
+            "$ref": "#/components/parameters/FromDateParam"
+          },
+          {
+            "$ref": "#/components/parameters/ToDateParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "App statistics.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/StatisticsPoint"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/statistics/app/{appId}/bundle_usage": {
+      "get": {
+        "tags": ["statistics"],
+        "operationId": "getAppBundleUsage",
+        "summary": "Get bundle usage distribution for one app.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AppIdPath"
+          },
+          {
+            "$ref": "#/components/parameters/FromDateParam"
+          },
+          {
+            "$ref": "#/components/parameters/ToDateParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Bundle usage chart data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BundleUsage"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/statistics/org/{orgId}/": {
+      "get": {
+        "tags": ["statistics"],
+        "operationId": "getOrganizationStatistics",
+        "summary": "Get organization-level time-series statistics.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/OrgIdPath"
+          },
+          {
+            "$ref": "#/components/parameters/FromDateParam"
+          },
+          {
+            "$ref": "#/components/parameters/ToDateParam"
+          },
+          {
+            "name": "breakdown",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "noAccumulate",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Organization statistics.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/StatisticsPoint"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/statistics/user/": {
+      "get": {
+        "tags": ["statistics"],
+        "operationId": "getUserStatistics",
+        "summary": "Get aggregated statistics across organizations visible to the API key.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/FromDateParam"
+          },
+          {
+            "$ref": "#/components/parameters/ToDateParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User-level aggregate statistics.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/StatisticsPoint"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "CapgoApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "authorization",
+        "description": "Send the raw Capgo API key in the `authorization` header. Generate or rotate keys at https://console.capgo.app/dashboard/apikeys/."
+      }
+    },
+    "parameters": {
+      "AppIdPath": {
+        "name": "appId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "OrgIdPath": {
+        "name": "orgId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "PageParam": {
+        "name": "page",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "LimitParam": {
+        "name": "limit",
+        "in": "query",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 50
+        }
+      },
+      "FromDateParam": {
+        "name": "from",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "date"
+        }
+      },
+      "ToDateParam": {
+        "name": "to",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "format": "date"
+        }
+      }
+    },
+    "responses": {
+      "ValidationError": {
+        "description": "The request body or query parameters were invalid.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "The API key is missing, invalid, or expired.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "The API key is valid but lacks the required scope or org access.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "Too many requests. Back off and retry later.",
+        "headers": {
+          "Retry-After": {
+            "schema": {
+              "type": "integer"
+            }
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "InternalError": {
+        "description": "Unexpected Capgo server error.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "StatusResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": ["status"],
+        "additionalProperties": true
+      },
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          }
+        },
+        "required": ["success"],
+        "additionalProperties": true
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": ["error"],
+        "additionalProperties": true
+      },
+      "Organization": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logo": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "management_email": {
+            "type": "string",
+            "format": "email"
+          },
+          "customer_id": {
+            "type": ["string", "null"]
+          }
+        },
+        "required": ["id", "name"]
+      },
+      "OrganizationEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Organization"
+          }
+        },
+        "required": ["data"]
+      },
+      "OrganizationListEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Organization"
+            }
+          }
+        },
+        "required": ["data"]
+      },
+      "OrganizationCreate": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["name"]
+      },
+      "OrganizationUpdate": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "orgId": {
+            "type": "string"
+          },
+          "logo": {
+            "type": "string",
+            "format": "uri"
+          },
+          "name": {
+            "type": "string"
+          },
+          "management_email": {
+            "type": "string",
+            "format": "email"
+          }
+        },
+        "required": ["orgId"]
+      },
+      "Member": {
+        "type": "object",
+        "properties": {
+          "uid": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "image_url": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "role": {
+            "type": "string"
+          }
+        },
+        "required": ["uid", "email", "role"]
+      },
+      "MemberListEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Member"
+            }
+          }
+        },
+        "required": ["data"]
+      },
+      "MemberCreate": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "orgId": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "role": {
+            "type": "string",
+            "enum": ["read", "upload", "write", "admin", "super_admin"]
+          }
+        },
+        "required": ["orgId", "email", "role"]
+      },
+      "MemberDelete": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "orgId": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          }
+        },
+        "required": ["orgId", "email"]
+      },
+      "App": {
+        "type": "object",
+        "properties": {
+          "app_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": ["string", "null"]
+          },
+          "owner_org": {
+            "type": "string"
+          },
+          "default_upload_channel": {
+            "type": "string"
+          },
+          "icon_url": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "last_version": {
+            "type": ["string", "null"]
+          },
+          "retention": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          }
+        },
+        "required": ["app_id"]
+      },
+      "AppEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/App"
+          }
+        },
+        "additionalProperties": true
+      },
+      "AppListEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/App"
+            }
+          }
+        },
+        "required": ["data"]
+      },
+      "AppCreate": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "app_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string",
+            "format": "uri"
+          },
+          "owner_org": {
+            "type": "string"
+          }
+        },
+        "required": ["app_id", "name", "owner_org"]
+      },
+      "AppUpdate": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string",
+            "format": "uri"
+          },
+          "retention": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      },
+      "ApiKey": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "key": {
+            "type": ["string", "null"]
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["read", "write", "upload", "all"]
+          },
+          "name": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "expires_at": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "limited_to_apps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "limited_to_orgs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["id", "mode", "name"]
+      },
+      "ApiKeyListEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiKey"
+            }
+          }
+        },
+        "required": ["data"]
+      },
+      "ApiKeyCreateEnvelope": {
+        "type": "object",
+        "properties": {
+          "apikey": {
+            "$ref": "#/components/schemas/ApiKey"
+          }
+        },
+        "required": ["apikey"]
+      },
+      "ApiKeyCreate": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["read", "write", "upload", "all"]
+          },
+          "limited_to_apps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "limited_to_orgs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "hashed": {
+            "type": "boolean"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": ["name", "mode"]
+      },
+      "ChannelVersion": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["id", "name"]
+      },
+      "Channel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "app_id": {
+            "type": "string"
+          },
+          "version": {
+            "$ref": "#/components/schemas/ChannelVersion"
+          },
+          "public": {
+            "type": "boolean"
+          },
+          "disableAutoUpdateUnderNative": {
+            "type": "boolean"
+          },
+          "disableAutoUpdate": {
+            "type": ["string", "boolean"]
+          },
+          "allow_emulator": {
+            "type": "boolean"
+          },
+          "allow_dev": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": ["id", "name", "app_id"]
+      },
+      "ChannelListEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Channel"
+            }
+          }
+        },
+        "required": ["data"]
+      },
+      "ChannelSet": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "app_id": {
+            "type": "string"
+          },
+          "channel": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "public": {
+            "type": "boolean"
+          },
+          "disableAutoUpdateUnderNative": {
+            "type": "boolean"
+          },
+          "disableAutoUpdate": {
+            "type": "string",
+            "enum": ["major", "minor", "version_number", "none"]
+          },
+          "ios": {
+            "type": "boolean"
+          },
+          "android": {
+            "type": "boolean"
+          },
+          "electron": {
+            "type": "boolean"
+          },
+          "allow_device_self_set": {
+            "type": "boolean"
+          },
+          "allow_emulator": {
+            "type": "boolean"
+          },
+          "allow_dev": {
+            "type": "boolean"
+          }
+        },
+        "required": ["app_id", "channel"]
+      },
+      "ChannelDelete": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "app_id": {
+            "type": "string"
+          },
+          "channel": {
+            "type": "string"
+          }
+        },
+        "required": ["app_id", "channel"]
+      },
+      "Device": {
+        "type": "object",
+        "properties": {
+          "device_id": {
+            "type": "string"
+          },
+          "custom_id": {
+            "type": ["string", "null"]
+          },
+          "version": {
+            "type": ["integer", "null"]
+          },
+          "version_name": {
+            "type": ["string", "null"]
+          },
+          "channel": {
+            "type": ["string", "null"]
+          },
+          "app_id": {
+            "type": "string"
+          },
+          "platform": {
+            "type": "string",
+            "enum": ["ios", "android", "electron"]
+          },
+          "plugin_version": {
+            "type": ["string", "null"]
+          },
+          "os_version": {
+            "type": ["string", "null"]
+          },
+          "version_build": {
+            "type": ["string", "null"]
+          },
+          "is_prod": {
+            "type": "boolean"
+          },
+          "is_emulator": {
+            "type": "boolean"
+          },
+          "key_id": {
+            "type": ["string", "null"]
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": ["device_id", "app_id", "platform"]
+      },
+      "DeviceEnvelope": {
+        "$ref": "#/components/schemas/Device"
+      },
+      "DeviceListEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Device"
+            }
+          },
+          "nextCursor": {
+            "type": "string"
+          },
+          "hasMore": {
+            "type": "boolean"
+          }
+        },
+        "required": ["data"]
+      },
+      "DeviceLink": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "app_id": {
+            "type": "string"
+          },
+          "device_id": {
+            "type": "string"
+          },
+          "version_id": {
+            "type": "string"
+          },
+          "channel": {
+            "type": "string"
+          }
+        },
+        "required": ["app_id", "device_id"]
+      },
+      "DeviceDelete": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "app_id": {
+            "type": "string"
+          },
+          "device_id": {
+            "type": "string"
+          }
+        },
+        "required": ["app_id", "device_id"]
+      },
+      "Bundle": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "app_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "checksum": {
+            "type": ["string", "null"]
+          },
+          "minUpdateVersion": {
+            "type": ["string", "null"]
+          },
+          "storage_provider": {
+            "type": "string"
+          },
+          "external_url": {
+            "type": ["string", "null"],
+            "format": "uri"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          }
+        },
+        "required": ["id", "app_id", "name"]
+      },
+      "BundleListEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Bundle"
+            }
+          }
+        },
+        "required": ["data"]
+      },
+      "BundleCreate": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "app_id": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "external_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "checksum": {
+            "type": "string"
+          }
+        },
+        "required": ["app_id", "version", "external_url", "checksum"]
+      },
+      "BundleDelete": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "app_id": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": ["app_id"]
+      },
+      "BundleMetadataUpdate": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "app_id": {
+            "type": "string"
+          },
+          "version_id": {
+            "type": "integer"
+          },
+          "link": {
+            "type": "string",
+            "format": "uri"
+          },
+          "comment": {
+            "type": "string"
+          }
+        },
+        "required": ["app_id", "version_id"]
+      },
+      "BundleChannelSet": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "app_id": {
+            "type": "string"
+          },
+          "version_id": {
+            "type": "integer"
+          },
+          "channel_id": {
+            "type": "integer"
+          }
+        },
+        "required": ["app_id", "version_id", "channel_id"]
+      },
+      "StatisticsPoint": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "format": "date"
+          },
+          "mau": {
+            "type": "integer"
+          },
+          "storage": {
+            "type": "integer"
+          },
+          "bandwidth": {
+            "type": "integer"
+          }
+        },
+        "required": ["date", "mau", "storage", "bandwidth"]
+      },
+      "BundleUsageDataset": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        },
+        "required": ["label", "data"]
+      },
+      "BundleUsage": {
+        "type": "object",
+        "properties": {
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "datasets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BundleUsageDataset"
+            }
+          }
+        },
+        "required": ["labels", "datasets"]
+      }
+    }
+  }
+}

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,5 +1,6 @@
 /
   Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"
+  Link: </.well-known/capgo-public-api-openapi.json>; rel="service-desc"; type="application/openapi+json"
   Link: </.well-known/capgo-tools-openapi.json>; rel="service-desc"; type="application/openapi+json"
   Link: </docs/public-api/>; rel="service-doc"; type="text/html"
   Link: </tools/>; rel="service-doc"; type="text/html"
@@ -9,22 +10,47 @@
   cache-control: immutable
 
 /.well-known/api-catalog
-  Content-Type: application/linkset+json; charset=utf-8
+  Content-Type: application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"; charset=utf-8
   Access-Control-Allow-Origin: *
   Access-Control-Allow-Methods: GET, HEAD
   Access-Control-Expose-Headers: Link, ETag
+  Cache-Control: public, max-age=3600
+  Link: <https://api.capgo.app/>; rel="item"
+  Link: <https://capgo.app/api/tools/>; rel="item"
+
+/.well-known/capgo-public-api-openapi.json
+  Content-Type: application/openapi+json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, HEAD
+  Access-Control-Expose-Headers: Link, ETag
+  Cache-Control: public, max-age=3600
 
 /.well-known/capgo-tools-openapi.json
   Content-Type: application/openapi+json; charset=utf-8
   Access-Control-Allow-Origin: *
   Access-Control-Allow-Methods: GET, HEAD
   Access-Control-Expose-Headers: Link, ETag
+  Cache-Control: public, max-age=3600
 
 /.well-known/tool-api-status.json
   Content-Type: application/health+json; charset=utf-8
   Access-Control-Allow-Origin: *
   Access-Control-Allow-Methods: GET, HEAD
   Access-Control-Expose-Headers: Link, ETag
+  Cache-Control: public, max-age=3600
+
+/.well-known/agent-skills/index.json
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, HEAD
+  Access-Control-Expose-Headers: Link, ETag
+  Cache-Control: public, max-age=3600
+
+/.well-known/agent-skills/*/SKILL.md
+  Content-Type: text/markdown; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, HEAD
+  Cache-Control: public, max-age=3600
 
 /.well-known/mcp/server-card.json
   Content-Type: application/json; charset=utf-8

--- a/apps/web/public/_redirects
+++ b/apps/web/public/_redirects
@@ -32,6 +32,7 @@
 /ja/blog/capgo-vs-capawesome-comparing-ota-update-plugins/ /ja/capwesome/ 301
 /ko/blog/alternative-to-capawesome/ /ko/capwesome/ 301
 /ko/blog/capgo-vs-capawesome-comparing-ota-update-plugins/ /ko/capwesome/ 301
-/.well-known/* /deepLink/:splat 200
+/.well-known/apple-app-site-association /deepLink/apple-app-site-association 200
+/.well-known/assetlinks.json /deepLink/assetlinks.json 200
 /en/* /:splat 301
 /docs/plugin/* /docs/plugins/updater/:splat 301

--- a/apps/web/src/lib/tools/api.ts
+++ b/apps/web/src/lib/tools/api.ts
@@ -154,7 +154,6 @@ function createRateLimiter({
     }
 
     existing.lastAccess = now
-
     if (existing.count >= limit) {
       const retryAfter = Math.max(1, Math.ceil((existing.resetAt - now) / 1000))
       return webJson({ error: errorMessage }, 429, {
@@ -330,19 +329,28 @@ function withRequestGuard(guard: RequestGuard, handle: RouteHandler): RouteHandl
 
 const iosCertificateRateLimiter = createRateLimiter({
   limit: HEAVY_TOOL_RATE_LIMIT,
+<<<<<<< HEAD
   maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
+=======
+>>>>>>> 907158237 (harden tool discovery endpoints)
   windowMs: HEAVY_TOOL_RATE_LIMIT_WINDOW_MS,
 })
 
 const androidKeystoreRateLimiter = createRateLimiter({
   limit: HEAVY_TOOL_RATE_LIMIT,
+<<<<<<< HEAD
   maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
+=======
+>>>>>>> 907158237 (harden tool discovery endpoints)
   windowMs: HEAVY_TOOL_RATE_LIMIT_WINDOW_MS,
 })
 
 const iosUdidProfileRateLimiter = createRateLimiter({
   limit: HEAVY_TOOL_RATE_LIMIT,
+<<<<<<< HEAD
   maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
+=======
+>>>>>>> 907158237 (harden tool discovery endpoints)
   windowMs: HEAVY_TOOL_RATE_LIMIT_WINDOW_MS,
 })
 

--- a/apps/web/src/lib/tools/api.ts
+++ b/apps/web/src/lib/tools/api.ts
@@ -330,27 +330,39 @@ function withRequestGuard(guard: RequestGuard, handle: RouteHandler): RouteHandl
 const iosCertificateRateLimiter = createRateLimiter({
   limit: HEAVY_TOOL_RATE_LIMIT,
 <<<<<<< HEAD
+<<<<<<< HEAD
   maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
 =======
 >>>>>>> 907158237 (harden tool discovery endpoints)
+=======
+  maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
+>>>>>>> 99ddb21a5 (fix PR review follow-ups)
   windowMs: HEAVY_TOOL_RATE_LIMIT_WINDOW_MS,
 })
 
 const androidKeystoreRateLimiter = createRateLimiter({
   limit: HEAVY_TOOL_RATE_LIMIT,
 <<<<<<< HEAD
+<<<<<<< HEAD
   maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
 =======
 >>>>>>> 907158237 (harden tool discovery endpoints)
+=======
+  maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
+>>>>>>> 99ddb21a5 (fix PR review follow-ups)
   windowMs: HEAVY_TOOL_RATE_LIMIT_WINDOW_MS,
 })
 
 const iosUdidProfileRateLimiter = createRateLimiter({
   limit: HEAVY_TOOL_RATE_LIMIT,
 <<<<<<< HEAD
+<<<<<<< HEAD
   maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
 =======
 >>>>>>> 907158237 (harden tool discovery endpoints)
+=======
+  maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
+>>>>>>> 99ddb21a5 (fix PR review follow-ups)
   windowMs: HEAVY_TOOL_RATE_LIMIT_WINDOW_MS,
 })
 

--- a/apps/web/src/lib/tools/api.ts
+++ b/apps/web/src/lib/tools/api.ts
@@ -329,40 +329,19 @@ function withRequestGuard(guard: RequestGuard, handle: RouteHandler): RouteHandl
 
 const iosCertificateRateLimiter = createRateLimiter({
   limit: HEAVY_TOOL_RATE_LIMIT,
-<<<<<<< HEAD
-<<<<<<< HEAD
   maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
-=======
->>>>>>> 907158237 (harden tool discovery endpoints)
-=======
-  maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
->>>>>>> 99ddb21a5 (fix PR review follow-ups)
   windowMs: HEAVY_TOOL_RATE_LIMIT_WINDOW_MS,
 })
 
 const androidKeystoreRateLimiter = createRateLimiter({
   limit: HEAVY_TOOL_RATE_LIMIT,
-<<<<<<< HEAD
-<<<<<<< HEAD
   maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
-=======
->>>>>>> 907158237 (harden tool discovery endpoints)
-=======
-  maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
->>>>>>> 99ddb21a5 (fix PR review follow-ups)
   windowMs: HEAVY_TOOL_RATE_LIMIT_WINDOW_MS,
 })
 
 const iosUdidProfileRateLimiter = createRateLimiter({
   limit: HEAVY_TOOL_RATE_LIMIT,
-<<<<<<< HEAD
-<<<<<<< HEAD
   maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
-=======
->>>>>>> 907158237 (harden tool discovery endpoints)
-=======
-  maxEntries: HEAVY_TOOL_RATE_LIMIT_MAX_ENTRIES,
->>>>>>> 99ddb21a5 (fix PR review follow-ups)
   windowMs: HEAVY_TOOL_RATE_LIMIT_WINDOW_MS,
 })
 

--- a/scripts/validate-agent-skills-digests.mjs
+++ b/scripts/validate-agent-skills-digests.mjs
@@ -40,6 +40,7 @@ async function main() {
     return
   }
 
+<<<<<<< HEAD
   for (const [index, skill] of registry.skills.entries()) {
     if (!skill || typeof skill !== 'object' || typeof skill.url !== 'string' || typeof skill.digest !== 'string') {
       console.error(`Invalid agent skill entry at index ${index}: expected object with string "url" and "digest".`)

--- a/scripts/validate-agent-skills-digests.mjs
+++ b/scripts/validate-agent-skills-digests.mjs
@@ -40,7 +40,6 @@ async function main() {
     return
   }
 
-<<<<<<< HEAD
   for (const [index, skill] of registry.skills.entries()) {
     if (!skill || typeof skill !== 'object' || typeof skill.url !== 'string' || typeof skill.digest !== 'string') {
       console.error(`Invalid agent skill entry at index ${index}: expected object with string "url" and "digest".`)


### PR DESCRIPTION
## Summary
- fix `.well-known` routing so agent discovery files are not rewritten to deep-link assets
- publish a machine-readable OpenAPI description for `https://api.capgo.app` and list it in `/.well-known/api-catalog`
- tighten agent discovery headers and refresh the public API skill metadata for AI consumers

## Validation
- `bun scripts/validate-agent-skills-digests.mjs`
- `NODE_OPTIONS=--max-old-space-size=16384 bun run check`

## Notes
- OAuth/OIDC discovery metadata is still not added here because the documented Capgo public API uses API keys in the `authorization` header rather than OAuth discovery endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published OpenAPI spec for the Capgo Public API and added it to the API catalog linkset
  * Added agent-consumable skill metadata for discovery

* **Documentation**
  * Clarified API-key authentication (raw key in Authorization header) and concrete rate limits (100/min standard, 1000/min enterprise)
  * Expanded endpoint group descriptions, error handling, and response parsing guidance

* **Chores**
  * Improved well-known headers, caching, and refined redirects for discovery endpoints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->