### PR TITLE
docs: restore social login video on default docs page

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/social-login/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/social-login/index.mdx
@@ -20,9 +20,17 @@ hero:
       variant: minimal
 ---
 
+import YouTubeEmbed from '@/components/YouTubeEmbed.astro';
+
 ## Overview
 
 All social logins in one plugin.
+
+## Video Walkthrough
+
+Watch a quick demo of the plugin setup and login flow in action.
+
+<YouTubeEmbed id="iTINYxvSJrE" title="Capgo Social Login plugin overview" />
 
 ## Core Capabilities
 


### PR DESCRIPTION
## Summary
- add the missing YouTube embed to the default English social login docs page
- align the default locale content with the localized social login intro pages

## Testing
- bunx prettier --write apps/docs/src/content/docs/docs/plugins/social-login/index.mdx
- apps/docs build/check blocked locally by existing `bunx paraglide-js compile` registry 404 in this checkout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a video walkthrough to the social login plugin documentation demonstrating plugin setup and the login flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->