### PR TITLE
Add WebView Crash plugin docs and landing entry

### DIFF
--- a/apps/docs/src/config/llmsCustomSets.ts
+++ b/apps/docs/src/config/llmsCustomSets.ts
@@ -100,6 +100,7 @@ Plugin Volume Buttons|volume button event detection plugin|docs/plugins/volume-b
 Plugin Watch|Apple Watch and Wear OS integration plugin|docs/plugins/watch/**
 Plugin WeChat|WeChat integration plugin|docs/plugins/wechat/**
 Plugin Webview Guardian|webview security and protection plugin|docs/plugins/webview-guardian/**
+Plugin Webview Crash|recovered WebView crash detection plugin|docs/plugins/webview-crash/**
 Plugin Webview Version Checker|Android WebView version validation plugin|docs/plugins/webview-version-checker/**
 Plugin WiFi|WiFi network information plugin|docs/plugins/wifi/**
 Plugin Widget Kit|WidgetKit and Live Activities template plugin|docs/plugins/widget-kit/**

--- a/apps/docs/src/config/llmsCustomSets.ts
+++ b/apps/docs/src/config/llmsCustomSets.ts
@@ -100,7 +100,7 @@ Plugin Volume Buttons|volume button event detection plugin|docs/plugins/volume-b
 Plugin Watch|Apple Watch and Wear OS integration plugin|docs/plugins/watch/**
 Plugin WeChat|WeChat integration plugin|docs/plugins/wechat/**
 Plugin Webview Guardian|webview security and protection plugin|docs/plugins/webview-guardian/**
-Plugin Webview Crash|recovered WebView crash detection plugin|docs/plugins/webview-crash/**
+Plugin WebView Crash|recovered WebView crash detection plugin|docs/plugins/webview-crash/**
 Plugin Webview Version Checker|Android WebView version validation plugin|docs/plugins/webview-version-checker/**
 Plugin WiFi|WiFi network information plugin|docs/plugins/wifi/**
 Plugin Widget Kit|WidgetKit and Live Activities template plugin|docs/plugins/widget-kit/**

--- a/apps/docs/src/config/sidebar.mjs
+++ b/apps/docs/src/config/sidebar.mjs
@@ -217,6 +217,7 @@ const pluginEntries = [
   ['Volume Buttons', 'volume-buttons'],
   ['Watch', 'watch'],
   ['WebView Guardian', 'webview-guardian'],
+  ['WebView Crash', 'webview-crash'],
   ['WeChat', 'wechat'],
   [
     'WebView Version Checker',

--- a/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
@@ -33,6 +33,7 @@ await WebViewCrash.addListener('webViewRestoredAfterCrash', async (info) => {
 });
 
 const pending = await WebViewCrash.getPendingCrashInfo();
+// Note: the listener callback may have already cleared the pending marker.
 if (pending.value) {
   console.log('Pending crash marker', pending.value);
 }

--- a/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
@@ -1,0 +1,156 @@
+---
+title: Getting Started
+description: "Install @capgo/capacitor-webview-crash and handle recovered WebView crashes in your Capacitor app startup flow."
+sidebar:
+  order: 2
+---
+
+## Install
+
+```bash
+bun add @capgo/capacitor-webview-crash
+bunx cap sync
+```
+
+## Import
+
+```typescript
+import { WebViewCrash } from '@capgo/capacitor-webview-crash';
+```
+
+## Recommended recovery flow
+
+Attach the listener as early as possible in your app startup so the recovered runtime can react before users continue navigating:
+
+```typescript
+import { WebViewCrash } from '@capgo/capacitor-webview-crash';
+
+await WebViewCrash.addListener('webViewRestoredAfterCrash', async (info) => {
+  console.log('Recovered after a WebView crash', info);
+
+  // Rehydrate critical state, reopen the correct screen, or prompt the user to retry.
+  await WebViewCrash.clearPendingCrashInfo();
+});
+
+const pending = await WebViewCrash.getPendingCrashInfo();
+if (pending.value) {
+  console.log('Pending crash marker', pending.value);
+}
+```
+
+## API overview
+
+### `getPendingCrashInfo`
+
+Returns the stored native crash marker, or `null` when nothing is pending.
+
+```typescript
+const pending = await WebViewCrash.getPendingCrashInfo();
+if (pending.value) {
+  console.log(pending.value.platform, pending.value.reason);
+}
+```
+
+### `clearPendingCrashInfo`
+
+Clears the stored crash marker after your recovery handling is finished.
+
+```typescript
+await WebViewCrash.clearPendingCrashInfo();
+```
+
+### `simulateCrashRecovery`
+
+Creates a fake crash marker so QA and local debugging can exercise the recovery path without crashing a real WebView.
+
+```typescript
+const simulated = await WebViewCrash.simulateCrashRecovery();
+console.log(simulated.value);
+```
+
+## Platform notes
+
+- Android stores crash metadata from `onRenderProcessGone`, including `didCrash` and `rendererPriorityAtExit` when the platform provides them.
+- iOS stores crash metadata from `webViewWebContentProcessDidTerminate` and adds the current application state when available.
+- Web does not detect real renderer crashes. The web implementation only simulates the behavior with local storage.
+
+## Type reference
+
+### `PendingCrashInfoResult`
+
+```typescript
+export interface PendingCrashInfoResult {
+  /**
+   * Stored crash metadata, or `null` when no marker is pending.
+   */
+  value: WebViewCrashInfo | null;
+}
+```
+
+### `WebViewCrashInfo`
+
+```typescript
+export interface WebViewCrashInfo {
+  /**
+   * Platform that detected and stored the crash marker.
+   */
+  platform: WebViewCrashPlatform;
+
+  /**
+   * Unix timestamp in milliseconds for when the crash marker was written.
+   */
+  timestamp: number;
+
+  /**
+   * ISO-8601 version of `timestamp`.
+   */
+  timestampISO: string;
+
+  /**
+   * Platform-specific reason for the crash marker.
+   */
+  reason: WebViewCrashReason;
+
+  /**
+   * Last known WebView URL when the crash marker was written.
+   */
+  url?: string;
+
+  /**
+   * Android-only hint from `RenderProcessGoneDetail.didCrash()`.
+   */
+  didCrash?: boolean;
+
+  /**
+   * Android-only renderer priority reported at exit.
+   */
+  rendererPriorityAtExit?: number;
+
+  /**
+   * iOS-only application state captured when the WebView process died.
+   */
+  appState?: WebViewCrashAppState;
+}
+```
+
+### `WebViewCrashPlatform`
+
+```typescript
+export type WebViewCrashPlatform = 'android' | 'ios' | 'web';
+```
+
+### `WebViewCrashReason`
+
+```typescript
+export type WebViewCrashReason = 'renderProcessGone' | 'webContentProcessDidTerminate' | 'simulated';
+```
+
+### `WebViewCrashAppState`
+
+```typescript
+export type WebViewCrashAppState = 'active' | 'inactive' | 'background' | 'unknown';
+```
+
+## Source Of Truth
+
+This page is generated from the plugin's `src/definitions.ts`. Re-run the sync when the public API changes upstream.

--- a/apps/docs/src/content/docs/docs/plugins/webview-crash/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-crash/index.mdx
@@ -1,0 +1,53 @@
+---
+title: "@capgo/capacitor-webview-crash"
+description: "Capacitor plugin for detecting recovered WebView crashes and exposing the pending crash marker to the next JavaScript runtime."
+tableOfContents: false
+next: false
+prev: false
+sidebar:
+  order: 1
+  label: "Introduction"
+hero:
+  tagline: "Detect recovered WebView crashes and handle lost in-memory state after the WebView restarts."
+  actions:
+    - text: Get started
+      link: /docs/plugins/webview-crash/getting-started/
+      icon: right-arrow
+      variant: primary
+    - text: GitHub
+      link: https://github.com/Cap-go/capacitor-webview-crash/
+      icon: external
+      variant: minimal
+---
+
+## Overview
+
+This plugin stores a native crash marker when the previous Capacitor WebView process dies, then exposes that marker to the next JavaScript runtime after the app recovers.
+
+## Core Capabilities
+
+- `getPendingCrashInfo` - Returns the stored native crash marker, or `null` when nothing is pending.
+- `clearPendingCrashInfo` - Clears the stored crash marker after your app has restored its state.
+- `simulateCrashRecovery` - Creates a fake crash marker so recovery flows can be tested locally.
+- `addListener` - Fires `webViewRestoredAfterCrash` when a listener attaches and a crash marker is still pending.
+
+## Public API
+
+| Method | Description |
+| --- | --- |
+| `getPendingCrashInfo` | Returns the stored native crash marker, or `null` when nothing is pending. |
+| `clearPendingCrashInfo` | Clears the stored crash marker after your app has restored its state. |
+| `simulateCrashRecovery` | Creates a fake crash marker so recovery flows can be tested locally. |
+| `addListener` | Fires `webViewRestoredAfterCrash` when a listener attaches and a crash marker is still pending. |
+| `removeAllListeners` | Removes all plugin listeners. |
+
+## Notes
+
+- This plugin detects recovery after a WebView crash. It does not prevent the underlying crash.
+- The recovered JavaScript runtime is new, so any in-memory state from the previous WebView is already gone when this API fires.
+- On Android, extra fields such as `didCrash` and `rendererPriorityAtExit` may be available.
+- On iOS, the plugin records `appState` when the terminated WebView process is observed.
+
+## Source Of Truth
+
+This reference is synced from `src/definitions.ts` in [capacitor-webview-crash](https://github.com/Cap-go/capacitor-webview-crash/).

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -113,6 +113,7 @@ const actionDefinitionRows =
 @capgo/capacitor-wifi|github.com/Cap-go|Manage WiFi connectivity for your Capacitor app|https://github.com/Cap-go/capacitor-wifi/|WiFi
 @capgo/capacitor-screen-orientation|github.com/Cap-go|Screen orientation plugin with support for bypassing orientation lock|https://github.com/Cap-go/capacitor-screen-orientation/|Screen Orientation
 @capgo/capacitor-webview-guardian|github.com/Cap-go|Detect when the WebView was killed in the background and relaunch it on foreground|https://github.com/Cap-go/capacitor-webview-guardian/|WebView Guardian
+@capgo/capacitor-webview-crash|github.com/Cap-go|Detect recovered WebView crashes and tell the next JavaScript runtime what happened|https://github.com/Cap-go/capacitor-webview-crash/|WebView Crash
 @capgo/capacitor-webview-version-checker|github.com/Cap-go|Capacitor plugin for checking Android WebView version freshness and guiding users to native update flows|https://github.com/Cap-go/capacitor-webview-version-checker/|WebView Version Checker
 @capgo/capacitor-firebase-analytics|github.com/Cap-go|Capacitor plugin for Firebase Analytics|https://github.com/Cap-go/capacitor-firebase/tree/main/packages/analytics|Firebase Analytics
 @capgo/capacitor-firebase-app|github.com/Cap-go|Capacitor plugin for Firebase App|https://github.com/Cap-go/capacitor-firebase/tree/main/packages/app|Firebase App
@@ -238,6 +239,7 @@ const pluginIconsByName: Record<string, string> = {
   '@capgo/capacitor-wifi': 'Wifi',
   '@capgo/capacitor-screen-orientation': 'DevicePhoneMobile',
   '@capgo/capacitor-webview-guardian': 'ShieldExclamation',
+  '@capgo/capacitor-webview-crash': 'ShieldExclamation',
   '@capgo/capacitor-webview-version-checker': 'ShieldExclamation',
   '@capgo/capacitor-firebase-analytics': 'ChartBar',
   '@capgo/capacitor-firebase-app': 'Fire',

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-webview-crash.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-webview-crash.md
@@ -30,6 +30,7 @@ await WebViewCrash.addListener('webViewRestoredAfterCrash', async (info) => {
 });
 
 const pending = await WebViewCrash.getPendingCrashInfo();
+// Note: the listener callback may have already cleared the pending marker.
 if (pending.value) {
   console.log('Pending crash marker', pending.value);
 }

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-webview-crash.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-webview-crash.md
@@ -1,0 +1,41 @@
+---
+locale: en
+---
+# Using @capgo/capacitor-webview-crash
+
+Detect recovered WebView crashes and tell the next JavaScript runtime what happened.
+
+## Install
+
+```bash
+bun add @capgo/capacitor-webview-crash
+bunx cap sync
+```
+
+## What This Plugin Exposes
+
+- `getPendingCrashInfo` - Returns the stored native crash marker, or `null` when nothing is pending.
+- `clearPendingCrashInfo` - Clears the stored crash marker after your app has restored its state.
+- `simulateCrashRecovery` - Creates a fake crash marker so recovery flows can be tested locally.
+- `webViewRestoredAfterCrash` - Listener event fired when a crash marker is still pending in the recovered runtime.
+
+## Example Usage
+
+```typescript
+import { WebViewCrash } from '@capgo/capacitor-webview-crash';
+
+await WebViewCrash.addListener('webViewRestoredAfterCrash', async (info) => {
+  console.log('Recovered after a WebView crash', info);
+  await WebViewCrash.clearPendingCrashInfo();
+});
+
+const pending = await WebViewCrash.getPendingCrashInfo();
+if (pending.value) {
+  console.log('Pending crash marker', pending.value);
+}
+```
+
+## Full Reference
+
+- GitHub: https://github.com/Cap-go/capacitor-webview-crash/
+- Docs: /docs/plugins/webview-crash/


### PR DESCRIPTION
## Summary
- add the WebView Crash plugin to the website plugin registry
- add docs pages for the new plugin under `/docs/plugins/webview-crash/`
- add the landing/tutorial content and sidebar/LLM registrations

## Validation
- bun run check
- PERSONAL_ACCESS_TOKEN="$(gh auth token)" bun run ci:verify:docs
- PERSONAL_ACCESS_TOKEN="$(gh auth token)" bun run ci:verify:web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Capacitor WebView Crash plugin to the site’s plugins list and actions, including an icon and link.

* **Documentation**
  * Added full docs and a tutorial for the Capacitor WebView Crash plugin: installation, API (getPendingCrashInfo, clearPendingCrashInfo, simulateCrashRecovery), event listener usage, platform notes, and code examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->