### PR TITLE
Add hidden AI install panel to plugin docs

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -70,7 +70,7 @@ export default defineConfig({
       markdown: { headingLinks: true },
       customCss: ['./src/css/docs.css'],
       expressiveCode: { themes: ['github-dark'] },
-      editLink: { baseUrl: 'https://github.com/Cap-go/website/edit/main/' },
+      editLink: { baseUrl: 'https://github.com/Cap-go/website/edit/main/apps/docs/' },
       components: {
         Head: './src/components/doc/Head.astro',
         LanguageSelect: './src/components/doc/LanguageSelect.astro',
@@ -88,7 +88,6 @@ export default defineConfig({
     publicDir: PUBLIC_DIR,
     cpuCount: CPU_COUNT,
     optimizeDepsInclude: ['mermaid'],
-    ssrNoExternal: true,
     extraPlugins: [
       viteStaticCopy({
         targets: [

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "dependencies": {
     "@astrojs/cloudflare": "13.1.7",
+    "@astrojs/mdx": "5.0.3",
     "@astrojs/sitemap": "3.7.2",
     "@astrojs/starlight": "0.38.2",
     "@astrojs/starlight-docsearch": "0.7.0",

--- a/apps/docs/src/components/doc/CopyPage.astro
+++ b/apps/docs/src/components/doc/CopyPage.astro
@@ -3,8 +3,13 @@ import type { StarlightRouteData } from '@astrojs/starlight/route-data'
 import * as m from '@/paraglide/messages'
 import { resolveMessageLocale } from '@/services/message-locale'
 
-const { editUrl, id: pageSlug } = Astro.locals.starlightRoute as StarlightRouteData
-const messageLocale = resolveMessageLocale(Astro.locals.starlightRoute.locale, Astro.currentLocale)
+const route = Astro.locals.starlightRoute as StarlightRouteData
+const { editUrl, id: pageSlug } = route
+const messageLocale = resolveMessageLocale(route.locale, Astro.currentLocale)
+const repoSourcePath = route.entry?.filePath ? `apps/docs/${route.entry.filePath}` : ''
+const markdownSourceUrl = repoSourcePath ? `https://raw.githubusercontent.com/Cap-go/website/refs/heads/main/${repoSourcePath}` : ''
+const githubSourceUrl = repoSourcePath ? `https://github.com/Cap-go/website/blob/main/${repoSourcePath}` : ''
+const githubRawUrl = githubSourceUrl ? `${githubSourceUrl}?raw=1` : ''
 
 const translations = {
   copyPage: m.copy_page({}, { locale: messageLocale }),
@@ -25,21 +30,52 @@ const translations = {
 
 <div class="copy-page-container">
   <button class="copy-page-button" aria-label={translations.copyPageOptions} data-page-slug={pageSlug}>
-    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/>
-      <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect>
+      <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path>
     </svg>
     <span>{translations.copyPage}</span>
-    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="chevron">
-      <path d="m6 9 6 6 6-6"/>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="chevron"
+    >
+      <path d="m6 9 6 6 6-6"></path>
     </svg>
   </button>
 
   <div class="copy-page-menu" role="menu" hidden>
     <button class="menu-item copy-markdown" role="menuitem">
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/>
-        <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect>
+        <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path>
       </svg>
       <div>
         <div class="menu-item-title">{translations.copyPage}</div>
@@ -48,81 +84,186 @@ const translations = {
     </button>
 
     <a class="menu-item view-markdown" role="menuitem" target="_blank" rel="noopener noreferrer">
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
         <text x="2" y="18" font-size="20" font-weight="bold" fill="currentColor">M↓</text>
       </svg>
       <div>
         <div class="menu-item-title">{translations.viewAsMarkdown}</div>
         <div class="menu-item-subtitle">{translations.viewPageAsPlainText}</div>
       </div>
-      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="external-icon">
-        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
-        <polyline points="15 3 21 3 21 9"/>
-        <line x1="10" x2="21" y1="14" y2="3"/>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="external-icon"
+      >
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+        <polyline points="15 3 21 3 21 9"></polyline>
+        <line x1="10" x2="21" y1="14" y2="3"></line>
       </svg>
     </a>
 
     <a class="menu-item view-github-raw" role="menuitem" target="_blank" rel="noopener noreferrer" hidden>
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
         <text x="2" y="18" font-size="16" font-weight="bold" fill="currentColor">GH</text>
       </svg>
       <div>
         <div class="menu-item-title">{translations.viewRawOnGithub}</div>
         <div class="menu-item-subtitle">{translations.openRawOnGithub}</div>
       </div>
-      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="external-icon">
-        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
-        <polyline points="15 3 21 3 21 9"/>
-        <line x1="10" x2="21" y1="14" y2="3"/>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="external-icon"
+      >
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+        <polyline points="15 3 21 3 21 9"></polyline>
+        <line x1="10" x2="21" y1="14" y2="3"></line>
       </svg>
     </a>
 
     <button class="menu-item open-chatgpt" role="menuitem">
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <circle cx="12" cy="12" r="10"/>
-        <path d="M12 16v-4"/>
-        <path d="M12 8h.01"/>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <circle cx="12" cy="12" r="10"></circle>
+        <path d="M12 16v-4"></path>
+        <path d="M12 8h.01"></path>
       </svg>
       <div>
         <div class="menu-item-title">{translations.openInChatgpt}</div>
         <div class="menu-item-subtitle">{translations.askQuestionsAboutPage}</div>
       </div>
-      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="external-icon">
-        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
-        <polyline points="15 3 21 3 21 9"/>
-        <line x1="10" x2="21" y1="14" y2="3"/>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="external-icon"
+      >
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+        <polyline points="15 3 21 3 21 9"></polyline>
+        <line x1="10" x2="21" y1="14" y2="3"></line>
       </svg>
     </button>
 
     <button class="menu-item open-claude" role="menuitem">
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M12 2L2 7l10 5 10-5-10-5z"/>
-        <path d="M2 17l10 5 10-5"/>
-        <path d="M2 12l10 5 10-5"/>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M12 2L2 7l10 5 10-5-10-5z"></path>
+        <path d="M2 17l10 5 10-5"></path>
+        <path d="M2 12l10 5 10-5"></path>
       </svg>
       <div>
         <div class="menu-item-title">{translations.openInClaude}</div>
         <div class="menu-item-subtitle">{translations.askQuestionsAboutPage}</div>
       </div>
-      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="external-icon">
-        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
-        <polyline points="15 3 21 3 21 9"/>
-        <line x1="10" x2="21" y1="14" y2="3"/>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="external-icon"
+      >
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+        <polyline points="15 3 21 3 21 9"></polyline>
+        <line x1="10" x2="21" y1="14" y2="3"></line>
       </svg>
     </button>
 
     <button class="menu-item open-perplexity" role="menuitem">
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
       </svg>
       <div>
         <div class="menu-item-title">{translations.openInPerplexity}</div>
         <div class="menu-item-subtitle">{translations.askQuestionsAboutPage}</div>
       </div>
-      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="external-icon">
-        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
-        <polyline points="15 3 21 3 21 9"/>
-        <line x1="10" x2="21" y1="14" y2="3"/>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="external-icon"
+      >
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+        <polyline points="15 3 21 3 21 9"></polyline>
+        <line x1="10" x2="21" y1="14" y2="3"></line>
       </svg>
     </button>
   </div>
@@ -130,7 +271,7 @@ const translations = {
   <span class="copy-page-feedback sr-only" role="status" aria-live="polite" aria-atomic="true"></span>
 </div>
 
-<script is:inline define:vars={{ translations, editUrl: editUrl?.toString() ?? '' }}>
+<script is:inline define:vars={{ translations, editUrl: editUrl?.toString() ?? '', markdownSourceUrl, githubRawUrl }}>
   // Toggle menu visibility
   const buttons = document.querySelectorAll('.copy-page-button')
   buttons.forEach((button) => {
@@ -218,10 +359,14 @@ const translations = {
 
         // Try multiple paths for the markdown file
         const paths = [
-          `/${pageSlug}.md`,  // Built/copied version
-          `/src/content/docs/${pageSlug}.mdx`,  // Dev mode .mdx
-          `/src/content/docs/${pageSlug}.md`,   // Dev mode .md
+          `/${pageSlug}.md`, // Built/copied version
+          `/src/content/docs/${pageSlug}.mdx`, // Dev mode .mdx
+          `/src/content/docs/${pageSlug}.md`, // Dev mode .md
         ]
+
+        if (markdownSourceUrl) {
+          paths.push(markdownSourceUrl)
+        }
 
         let content = ''
         let fetchSuccess = false
@@ -278,23 +423,22 @@ const translations = {
 
   // View as Markdown - set the href to local .md file
   document.querySelectorAll('.view-markdown').forEach((link) => {
+    if (markdownSourceUrl) {
+      link.href = markdownSourceUrl
+      return
+    }
+
     const pageSlug = document.querySelector('.copy-page-button')?.getAttribute('data-page-slug')
     if (pageSlug) {
-      // Link to the local .md file served by vite-plugin-static-copy
       link.href = `/${pageSlug}.md`
     }
   })
 
   // View raw on GitHub
   function getRawGithubUrl() {
-    if (!editUrl) return ''
-    if (editUrl.includes('/edit/')) {
-      return editUrl.replace('/edit/', '/raw/')
-    }
-    if (editUrl.includes('/blob/')) {
-      return editUrl.replace('/blob/', '/raw/')
-    }
-    return editUrl
+    if (githubRawUrl) return githubRawUrl
+    if (markdownSourceUrl) return markdownSourceUrl
+    return ''
   }
 
   document.querySelectorAll('.view-github-raw').forEach((link) => {
@@ -309,10 +453,10 @@ const translations = {
 
   // Get markdown URL - use absolute URL for AI assistants
   function getMarkdownUrl() {
+    if (markdownSourceUrl) return markdownSourceUrl
+
     const pageSlug = document.querySelector('.copy-page-button')?.getAttribute('data-page-slug')
     if (!pageSlug) return window.location.href
-
-    // Return absolute URL to the local .md file
     const baseUrl = window.location.origin
     return `${baseUrl}/${pageSlug}.md`
   }
@@ -382,7 +526,9 @@ const translations = {
     background: var(--sl-color-bg-nav);
     border: 1px solid var(--sl-color-gray-5);
     border-radius: 0.5rem;
-    box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+    box-shadow:
+      0 10px 15px -3px rgb(0 0 0 / 0.1),
+      0 4px 6px -4px rgb(0 0 0 / 0.1);
     padding: 0.5rem;
     z-index: 1000;
   }

--- a/apps/docs/src/components/doc/InstallPromptForAI.astro
+++ b/apps/docs/src/components/doc/InstallPromptForAI.astro
@@ -1,0 +1,293 @@
+---
+import { actions, type Action } from '@/config/plugins'
+import type { StarlightRouteData } from '@astrojs/starlight/route-data'
+
+const route = Astro.locals.starlightRoute as StarlightRouteData | undefined
+const pageId = route?.id ?? ''
+const pageUrl = Astro.url.toString()
+const pageData = (route?.entry?.data as Record<string, unknown> | undefined) ?? {}
+const pageDescription = typeof pageData.description === 'string' ? pageData.description : ''
+const routeMatch = pageId.match(/(?:^|\/)plugins\/([^/]+)(?:\/.*)?\/getting-started$/)
+const pluginSlug = routeMatch?.[1] ?? ''
+
+const addCandidate = (items: string[], value?: string) => {
+  if (value && !items.includes(value)) items.push(value)
+}
+
+const addNormalizedCandidates = (items: string[], value: string) => {
+  addCandidate(items, value)
+
+  if (value.startsWith('capacitor-')) {
+    const withoutPrefix = value.slice('capacitor-'.length)
+    addCandidate(items, withoutPrefix)
+
+    if (withoutPrefix.startsWith('android-')) {
+      addCandidate(items, withoutPrefix.slice('android-'.length))
+    }
+  }
+
+  if (value.endsWith('-plugin')) {
+    addCandidate(items, value.slice(0, -'-plugin'.length))
+  }
+
+  if (value.startsWith('capacitor-') && value.endsWith('-plugin')) {
+    addCandidate(items, value.slice('capacitor-'.length, -'-plugin'.length))
+  }
+}
+
+const getSlugCandidates = (plugin: Pick<Action, 'href' | 'name'>): string[] => {
+  const candidates: string[] = []
+  const name = plugin.name ?? ''
+  const slashIndex = name.indexOf('/')
+  const packageSegment = slashIndex >= 0 ? name.slice(slashIndex + 1) : name
+
+  if (packageSegment.startsWith('capacitor-plus')) {
+    addCandidate(candidates, 'capacitor-plus')
+  }
+
+  if (packageSegment) {
+    addNormalizedCandidates(candidates, packageSegment)
+  }
+
+  const normalizedHref = plugin.href.replace(/\/$/, '')
+  const repoHref = normalizedHref.includes('/tree/') ? normalizedHref.slice(0, normalizedHref.indexOf('/tree/')) : normalizedHref
+  const repoName = repoHref.slice(repoHref.lastIndexOf('/') + 1)
+
+  if (repoName) {
+    addNormalizedCandidates(candidates, repoName)
+  }
+
+  return candidates
+}
+
+const descriptionPackages = Array.from(pageDescription.matchAll(/@[a-z0-9_.-]+\/[a-z0-9_.-]+/gi), (match) => match[0])
+const matchedActions = pluginSlug ? actions.filter((action) => action.name && getSlugCandidates(action).includes(pluginSlug)) : []
+const matchedPackages = matchedActions.flatMap((action) => (action.name ? [action.name] : []))
+const packages = [...new Set([...descriptionPackages, ...matchedPackages])]
+
+const buildPrompt = () => {
+  if (!pluginSlug || packages.length === 0) return null
+
+  if (pluginSlug === 'capacitor-plus') {
+    return [
+      'You are working in a Capacitor project.',
+      'Use `bun` and `bunx` only. Do not use `npm`, `npx`, `pnpm`, or `yarn`.',
+      '',
+      'For a new Capacitor+ setup, use:',
+      '```bash',
+      'bun add @capacitor-plus/core @capacitor-plus/cli',
+      'bun add @capacitor-plus/android    # if the project targets Android',
+      'bun add @capacitor-plus/ios        # if the project targets iOS',
+      'bunx cap init                      # only for a brand new project',
+      'bunx cap add android              # if needed',
+      'bunx cap add ios                  # if needed',
+      '```',
+      '',
+      'For an existing Capacitor app, replace the official packages with Capacitor+ and then run:',
+      '```bash',
+      'bunx cap sync',
+      '```',
+      '',
+      `Continue with the remaining setup from this Capgo docs page: ${pageUrl}`,
+      'Do not skip any platform-specific setup, native file changes, or config steps from that page.',
+    ].join('\n')
+  }
+
+  return [
+    'You are working in a Capacitor project.',
+    'Use `bun` and `bunx` only. Do not use `npm`, `npx`, `pnpm`, or `yarn`.',
+    '',
+    'Install and sync the plugin with:',
+    '```bash',
+    `bun add ${packages.join(' ')}`,
+    'bunx cap sync',
+    '```',
+    '',
+    `Continue with the remaining setup from this Capgo docs page: ${pageUrl}`,
+    'Do not skip any platform-specific setup, native file changes, permissions, or config steps from that page.',
+    'After installation, follow the import and usage examples from the docs page.',
+  ].join('\n')
+}
+
+const promptText = buildPrompt()
+const promptHtml = promptText ? promptText.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;') : ''
+---
+
+{
+  promptText && (
+    <details class="ai-install-panel">
+      <summary>
+        <span>Install Prompt For AI</span>
+        <span class="ai-install-panel__hint">Hidden by default</span>
+      </summary>
+
+      <div class="ai-install-panel__body">
+        <div class="ai-install-panel__actions">
+          <p>Copy this into your coding assistant so it installs the plugin with the right package manager and keeps the remaining setup steps from this page.</p>
+          <button type="button" class="ai-install-panel__copy">
+            Copy for AI
+          </button>
+        </div>
+
+        <pre>
+          <code set:html={promptHtml} />
+        </pre>
+      </div>
+    </details>
+  )
+}
+
+<script is:inline>
+  document.querySelectorAll('.ai-install-panel__copy').forEach((button) => {
+    let resetTimer
+
+    button.addEventListener('click', async () => {
+      const panel = button.closest('.ai-install-panel')
+      const code = panel?.querySelector('pre code')
+      const content = code?.textContent?.trim()
+
+      if (!content) {
+        return
+      }
+
+      const originalText = button.textContent
+
+      const fallbackCopy = (value) => {
+        const textarea = document.createElement('textarea')
+        textarea.value = value
+        textarea.style.position = 'fixed'
+        textarea.style.opacity = '0'
+        document.body.appendChild(textarea)
+        textarea.focus()
+        textarea.select()
+        const legacyCopy = Reflect.get(document, 'execCommand')
+        if (typeof legacyCopy !== 'function' || !legacyCopy.call(document, 'copy')) {
+          throw new Error('Fallback copy method failed')
+        }
+        document.body.removeChild(textarea)
+      }
+
+      try {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(content)
+        } else {
+          fallbackCopy(content)
+        }
+
+        button.textContent = 'Copied'
+      } catch {
+        try {
+          fallbackCopy(content)
+          button.textContent = 'Copied'
+        } catch {
+          button.textContent = 'Copy failed'
+        }
+      }
+
+      if (resetTimer) {
+        window.clearTimeout(resetTimer)
+      }
+
+      resetTimer = window.setTimeout(() => {
+        button.textContent = originalText ?? 'Copy for AI'
+      }, 2000)
+    })
+  })
+</script>
+
+<style>
+  .ai-install-panel {
+    margin-top: 1rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.9rem;
+    background: linear-gradient(180deg, color-mix(in srgb, var(--sl-color-bg-nav) 88%, white 12%), var(--sl-color-bg));
+    overflow: hidden;
+  }
+
+  .ai-install-panel summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.9rem 1rem;
+    cursor: pointer;
+    font-weight: 600;
+    list-style: none;
+  }
+
+  .ai-install-panel summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .ai-install-panel summary::after {
+    content: '+';
+    margin-left: auto;
+    color: var(--sl-color-text-accent);
+    font-size: 1.1rem;
+    line-height: 1;
+  }
+
+  .ai-install-panel[open] summary::after {
+    content: '-';
+  }
+
+  .ai-install-panel__hint {
+    color: var(--sl-color-text-accent);
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
+  .ai-install-panel__body {
+    padding: 0 1rem 1rem;
+  }
+
+  .ai-install-panel__actions {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.85rem;
+  }
+
+  .ai-install-panel__actions p {
+    margin: 0;
+    color: var(--sl-color-text);
+    font-size: 0.95rem;
+  }
+
+  .ai-install-panel__copy {
+    border: 1px solid var(--sl-color-gray-4);
+    border-radius: 999px;
+    padding: 0.5rem 0.9rem;
+    background: var(--sl-color-white);
+    color: var(--sl-color-black);
+    font: inherit;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .ai-install-panel__copy:hover {
+    border-color: var(--sl-color-text-accent);
+  }
+
+  .ai-install-panel pre {
+    margin: 0;
+  }
+
+  @media (max-width: 768px) {
+    .ai-install-panel summary {
+      flex-wrap: wrap;
+    }
+
+    .ai-install-panel__hint {
+      width: 100%;
+    }
+
+    .ai-install-panel__actions {
+      flex-direction: column;
+    }
+  }
+</style>

--- a/apps/docs/src/components/doc/InstallPromptForAI.astro
+++ b/apps/docs/src/components/doc/InstallPromptForAI.astro
@@ -1,14 +1,15 @@
 ---
 import { actions, type Action } from '@/config/plugins'
 import type { StarlightRouteData } from '@astrojs/starlight/route-data'
+import InstallPromptForAIPanel from './InstallPromptForAIPanel.astro'
 
 const route = Astro.locals.starlightRoute as StarlightRouteData | undefined
 const pageId = route?.id ?? ''
-const pageUrl = Astro.url.toString()
 const pageData = (route?.entry?.data as Record<string, unknown> | undefined) ?? {}
 const pageDescription = typeof pageData.description === 'string' ? pageData.description : ''
 const routeMatch = pageId.match(/(?:^|\/)plugins\/([^/]+)(?:\/.*)?\/getting-started$/)
 const pluginSlug = routeMatch?.[1] ?? ''
+const sourceMarkdownUrl = route?.entry?.filePath ? `https://raw.githubusercontent.com/Cap-go/website/refs/heads/main/apps/docs/${route.entry.filePath}` : ''
 
 const addCandidate = (items: string[], value?: string) => {
   if (value && !items.includes(value)) items.push(value)
@@ -64,48 +65,42 @@ const descriptionPackages = Array.from(pageDescription.matchAll(/@[a-z0-9_.-]+\/
 const matchedActions = pluginSlug ? actions.filter((action) => action.name && getSlugCandidates(action).includes(pluginSlug)) : []
 const matchedPackages = matchedActions.flatMap((action) => (action.name ? [action.name] : []))
 const packages = [...new Set([...descriptionPackages, ...matchedPackages])]
+const packageList = packages.map((pkg) => `\`${pkg}\``).join(', ')
 
 const buildPrompt = () => {
-  if (!pluginSlug || packages.length === 0) return null
+  if (!pluginSlug || !sourceMarkdownUrl) return null
+
+  const promptLines = ['Set up this Capacitor plugin in the project.']
 
   if (pluginSlug === 'capacitor-plus') {
     return [
-      'You are working in a Capacitor project.',
-      'Use `bun` and `bunx` only. Do not use `npm`, `npx`, `pnpm`, or `yarn`.',
+      ...promptLines,
       '',
-      'For a new Capacitor+ setup, use:',
-      '```bash',
-      'bun add @capacitor-plus/core @capacitor-plus/cli',
-      'bun add @capacitor-plus/android    # if the project targets Android',
-      'bun add @capacitor-plus/ios        # if the project targets iOS',
-      'bunx cap init                      # only for a brand new project',
-      'bunx cap add android              # if needed',
-      'bunx cap add ios                  # if needed',
-      '```',
+      'Use the package manager already used by the project.',
+      'Install these packages:',
+      '- `@capacitor-plus/core`',
+      '- `@capacitor-plus/cli`',
+      '- `@capacitor-plus/android` if the project targets Android',
+      '- `@capacitor-plus/ios` if the project targets iOS',
       '',
-      'For an existing Capacitor app, replace the official packages with Capacitor+ and then run:',
-      '```bash',
-      'bunx cap sync',
-      '```',
-      '',
-      `Continue with the remaining setup from this Capgo docs page: ${pageUrl}`,
-      'Do not skip any platform-specific setup, native file changes, or config steps from that page.',
+      'Complete the required Capacitor initialization, platform, sync, native setup, and configuration work.',
+      `Read this markdown guide for the full setup steps: ${sourceMarkdownUrl}`,
+      'Use that guide for platform-specific steps, native file edits, permissions, config changes, imports, and usage setup.',
+      'If that guide references other docs pages, read them too.',
     ].join('\n')
   }
 
+  if (packages.length === 0) return null
+
   return [
-    'You are working in a Capacitor project.',
-    'Use `bun` and `bunx` only. Do not use `npm`, `npx`, `pnpm`, or `yarn`.',
+    ...promptLines,
     '',
-    'Install and sync the plugin with:',
-    '```bash',
-    `bun add ${packages.join(' ')}`,
-    'bunx cap sync',
-    '```',
-    '',
-    `Continue with the remaining setup from this Capgo docs page: ${pageUrl}`,
-    'Do not skip any platform-specific setup, native file changes, permissions, or config steps from that page.',
-    'After installation, follow the import and usage examples from the docs page.',
+    'Use the package manager already used by the project.',
+    `Install these package(s): ${packageList}`,
+    'Run the required Capacitor sync/update step after installation.',
+    `Read this markdown guide for the full setup steps: ${sourceMarkdownUrl}`,
+    'Use that guide for platform-specific steps, native file edits, permissions, config changes, imports, and usage setup.',
+    'If that guide references other docs pages, read them too.',
   ].join('\n')
 }
 
@@ -113,181 +108,4 @@ const promptText = buildPrompt()
 const promptHtml = promptText ? promptText.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;') : ''
 ---
 
-{
-  promptText && (
-    <details class="ai-install-panel">
-      <summary>
-        <span>Install Prompt For AI</span>
-        <span class="ai-install-panel__hint">Hidden by default</span>
-      </summary>
-
-      <div class="ai-install-panel__body">
-        <div class="ai-install-panel__actions">
-          <p>Copy this into your coding assistant so it installs the plugin with the right package manager and keeps the remaining setup steps from this page.</p>
-          <button type="button" class="ai-install-panel__copy">
-            Copy for AI
-          </button>
-        </div>
-
-        <pre>
-          <code set:html={promptHtml} />
-        </pre>
-      </div>
-    </details>
-  )
-}
-
-<script is:inline>
-  document.querySelectorAll('.ai-install-panel__copy').forEach((button) => {
-    let resetTimer
-
-    button.addEventListener('click', async () => {
-      const panel = button.closest('.ai-install-panel')
-      const code = panel?.querySelector('pre code')
-      const content = code?.textContent?.trim()
-
-      if (!content) {
-        return
-      }
-
-      const originalText = button.textContent
-
-      const fallbackCopy = (value) => {
-        const textarea = document.createElement('textarea')
-        textarea.value = value
-        textarea.style.position = 'fixed'
-        textarea.style.opacity = '0'
-        document.body.appendChild(textarea)
-        textarea.focus()
-        textarea.select()
-        const legacyCopy = Reflect.get(document, 'execCommand')
-        if (typeof legacyCopy !== 'function' || !legacyCopy.call(document, 'copy')) {
-          throw new Error('Fallback copy method failed')
-        }
-        document.body.removeChild(textarea)
-      }
-
-      try {
-        if (navigator.clipboard?.writeText) {
-          await navigator.clipboard.writeText(content)
-        } else {
-          fallbackCopy(content)
-        }
-
-        button.textContent = 'Copied'
-      } catch {
-        try {
-          fallbackCopy(content)
-          button.textContent = 'Copied'
-        } catch {
-          button.textContent = 'Copy failed'
-        }
-      }
-
-      if (resetTimer) {
-        window.clearTimeout(resetTimer)
-      }
-
-      resetTimer = window.setTimeout(() => {
-        button.textContent = originalText ?? 'Copy for AI'
-      }, 2000)
-    })
-  })
-</script>
-
-<style>
-  .ai-install-panel {
-    margin-top: 1rem;
-    border: 1px solid var(--sl-color-gray-5);
-    border-radius: 0.9rem;
-    background: linear-gradient(180deg, color-mix(in srgb, var(--sl-color-bg-nav) 88%, white 12%), var(--sl-color-bg));
-    overflow: hidden;
-  }
-
-  .ai-install-panel summary {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    padding: 0.9rem 1rem;
-    cursor: pointer;
-    font-weight: 600;
-    list-style: none;
-  }
-
-  .ai-install-panel summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .ai-install-panel summary::after {
-    content: '+';
-    margin-left: auto;
-    color: var(--sl-color-text-accent);
-    font-size: 1.1rem;
-    line-height: 1;
-  }
-
-  .ai-install-panel[open] summary::after {
-    content: '-';
-  }
-
-  .ai-install-panel__hint {
-    color: var(--sl-color-text-accent);
-    font-size: 0.875rem;
-    font-weight: 500;
-  }
-
-  .ai-install-panel__body {
-    padding: 0 1rem 1rem;
-  }
-
-  .ai-install-panel__actions {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 1rem;
-    margin-bottom: 0.85rem;
-  }
-
-  .ai-install-panel__actions p {
-    margin: 0;
-    color: var(--sl-color-text);
-    font-size: 0.95rem;
-  }
-
-  .ai-install-panel__copy {
-    border: 1px solid var(--sl-color-gray-4);
-    border-radius: 999px;
-    padding: 0.5rem 0.9rem;
-    background: var(--sl-color-white);
-    color: var(--sl-color-black);
-    font: inherit;
-    font-size: 0.9rem;
-    font-weight: 600;
-    cursor: pointer;
-    white-space: nowrap;
-    flex-shrink: 0;
-  }
-
-  .ai-install-panel__copy:hover {
-    border-color: var(--sl-color-text-accent);
-  }
-
-  .ai-install-panel pre {
-    margin: 0;
-  }
-
-  @media (max-width: 768px) {
-    .ai-install-panel summary {
-      flex-wrap: wrap;
-    }
-
-    .ai-install-panel__hint {
-      width: 100%;
-    }
-
-    .ai-install-panel__actions {
-      flex-direction: column;
-    }
-  }
-</style>
+<InstallPromptForAIPanel promptHtml={promptHtml} hidden={!promptText} />

--- a/apps/docs/src/components/doc/InstallPromptForAIPanel.astro
+++ b/apps/docs/src/components/doc/InstallPromptForAIPanel.astro
@@ -1,0 +1,414 @@
+---
+const { promptHtml, hidden = false } = Astro.props
+---
+
+<section class="ai-install-panel" data-open="false" hidden={hidden}>
+  <button type="button" class="ai-install-panel__toggle" aria-expanded="false">
+    <span class="ai-install-panel__heading">
+      <span class="ai-install-panel__eyebrow">AI setup prompt</span>
+      <span class="ai-install-panel__title">Prompt to setup with AI</span>
+      <span class="ai-install-panel__subtitle">Install, sync, and follow the full source guide from one copyable prompt.</span>
+    </span>
+    <span class="ai-install-panel__status">Copy-ready</span>
+    <span class="ai-install-panel__chevron" aria-hidden="true">
+      <span class="ai-install-panel__chevron-closed">↓</span>
+      <span class="ai-install-panel__chevron-open">↑</span>
+    </span>
+  </button>
+
+  <div class="ai-install-panel__body" hidden>
+    <div class="ai-install-panel__actions">
+      <div class="ai-install-panel__intro">
+        <p>Copy a setup prompt with the install steps and the full markdown guide for this plugin.</p>
+        <div class="ai-install-panel__chips" aria-hidden="true">
+          <span>Install</span>
+          <span>Sync</span>
+          <span>Source guide</span>
+        </div>
+      </div>
+      <button type="button" class="ai-install-panel__copy"> Copy for AI </button>
+    </div>
+
+    <div class="ai-install-panel__prompt-surface">
+      <div class="ai-install-panel__prompt-meta" aria-hidden="true">
+        <span class="ai-install-panel__prompt-label">Ready to paste</span>
+        <span class="ai-install-panel__prompt-note">Includes install, sync, and the source markdown guide.</span>
+      </div>
+
+      <pre>
+        <code set:html={promptHtml} />
+      </pre>
+    </div>
+  </div>
+</section>
+
+<script>
+  document.querySelectorAll('.ai-install-panel__toggle').forEach((button) => {
+    button.addEventListener('click', () => {
+      const panel = button.closest('.ai-install-panel')
+      const body = panel?.querySelector('.ai-install-panel__body')
+      const isOpen = button.getAttribute('aria-expanded') === 'true'
+      const nextOpen = !isOpen
+
+      button.setAttribute('aria-expanded', String(nextOpen))
+      panel?.setAttribute('data-open', String(nextOpen))
+
+      if (body instanceof HTMLElement) {
+        body.hidden = !nextOpen
+      }
+    })
+  })
+
+  document.querySelectorAll('.ai-install-panel__copy').forEach((button) => {
+    let resetTimer: number | undefined
+
+    button.addEventListener('click', async () => {
+      const panel = button.closest('.ai-install-panel')
+      const code = panel?.querySelector('pre code')
+      const content = code?.textContent?.trim()
+
+      if (!content) {
+        return
+      }
+
+      const originalText = button.textContent
+
+      const fallbackCopy = (value: string) => {
+        const textarea = document.createElement('textarea')
+        textarea.value = value
+        textarea.style.position = 'fixed'
+        textarea.style.opacity = '0'
+        document.body.appendChild(textarea)
+        textarea.focus()
+        textarea.select()
+        const legacyCopy = Reflect.get(document, 'execCommand')
+        if (typeof legacyCopy !== 'function' || !legacyCopy.call(document, 'copy')) {
+          throw new Error('Fallback copy method failed')
+        }
+        document.body.removeChild(textarea)
+      }
+
+      try {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(content)
+        } else {
+          fallbackCopy(content)
+        }
+
+        button.textContent = 'Copied'
+      } catch {
+        try {
+          fallbackCopy(content)
+          button.textContent = 'Copied'
+        } catch {
+          button.textContent = 'Copy failed'
+        }
+      }
+
+      if (resetTimer) {
+        window.clearTimeout(resetTimer)
+      }
+
+      resetTimer = window.setTimeout(() => {
+        button.textContent = originalText ?? 'Copy for AI'
+      }, 2000)
+    })
+  })
+</script>
+
+<style>
+  .ai-install-panel {
+    margin-top: 1rem;
+    position: relative;
+    border: 1px solid color-mix(in srgb, var(--sl-color-gray-5) 86%, var(--sl-color-text-accent) 14%);
+    border-radius: 1rem;
+    background:
+      radial-gradient(circle at top right, color-mix(in srgb, var(--sl-color-text-accent) 16%, transparent) 0, transparent 34%),
+      linear-gradient(180deg, color-mix(in srgb, var(--sl-color-bg-nav) 96%, white 4%), color-mix(in srgb, var(--sl-color-bg) 92%, var(--sl-color-bg-nav) 8%));
+    box-shadow:
+      0 18px 40px color-mix(in srgb, black 10%, transparent),
+      inset 0 1px 0 color-mix(in srgb, white 10%, transparent);
+    overflow: hidden;
+    transition:
+      border-color 0.2s ease,
+      box-shadow 0.2s ease,
+      transform 0.2s ease;
+  }
+
+  .ai-install-panel::before {
+    content: '';
+    position: absolute;
+    inset: 0 0 auto;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--sl-color-text-accent) 65%, white 35%), transparent);
+    pointer-events: none;
+  }
+
+  .ai-install-panel__toggle {
+    width: 100%;
+    border: 0;
+    background: transparent;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 0.85rem;
+    padding: 1rem 1.1rem;
+    cursor: pointer;
+    color: inherit;
+    text-align: left;
+    font: inherit;
+    transition: background 0.2s ease;
+  }
+
+  .ai-install-panel__toggle:hover {
+    background: color-mix(in srgb, var(--sl-color-bg-nav) 88%, white 12%);
+  }
+
+  .ai-install-panel__heading {
+    display: grid;
+    gap: 0.2rem;
+    min-width: 0;
+  }
+
+  .ai-install-panel__eyebrow {
+    color: var(--sl-color-text-accent);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    line-height: 1;
+  }
+
+  .ai-install-panel__title {
+    color: var(--sl-color-white);
+    font-size: 1.02rem;
+    font-weight: 650;
+    line-height: 1.2;
+  }
+
+  .ai-install-panel__subtitle {
+    color: var(--sl-color-gray-3);
+    font-size: 0.86rem;
+    line-height: 1.35;
+  }
+
+  .ai-install-panel__status {
+    border: 1px solid color-mix(in srgb, var(--sl-color-text-accent) 30%, var(--sl-color-gray-4) 70%);
+    border-radius: 999px;
+    padding: 0.32rem 0.62rem;
+    background: color-mix(in srgb, var(--sl-color-text-accent) 12%, transparent);
+    color: var(--sl-color-text-accent);
+    font-size: 0.74rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .ai-install-panel__chevron {
+    width: 2rem;
+    height: 2rem;
+    border: 1px solid color-mix(in srgb, var(--sl-color-text-accent) 24%, var(--sl-color-gray-5) 76%);
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: color-mix(in srgb, var(--sl-color-bg-nav) 82%, white 18%);
+    color: var(--sl-color-text-accent);
+    font-size: 1rem;
+    flex-shrink: 0;
+  }
+
+  .ai-install-panel__chevron-open {
+    display: none;
+  }
+
+  .ai-install-panel[data-open='true'] .ai-install-panel__toggle {
+    border-bottom: 1px solid color-mix(in srgb, var(--sl-color-gray-5) 82%, var(--sl-color-text-accent) 18%);
+  }
+
+  .ai-install-panel[data-open='true'] {
+    border-color: color-mix(in srgb, var(--sl-color-text-accent) 26%, var(--sl-color-gray-5) 74%);
+    box-shadow:
+      0 22px 48px color-mix(in srgb, black 12%, transparent),
+      inset 0 1px 0 color-mix(in srgb, white 10%, transparent);
+  }
+
+  .ai-install-panel[data-open='true'] .ai-install-panel__chevron-closed {
+    display: none;
+  }
+
+  .ai-install-panel[data-open='true'] .ai-install-panel__chevron-open {
+    display: inline;
+  }
+
+  .ai-install-panel__body {
+    padding: 1rem 1.1rem 1.1rem;
+    background:
+      linear-gradient(180deg, color-mix(in srgb, white 78%, var(--sl-color-bg-nav) 22%), color-mix(in srgb, var(--sl-color-bg-nav) 84%, white 16%)),
+      radial-gradient(circle at top left, color-mix(in srgb, var(--sl-color-text-accent) 12%, transparent), transparent 42%);
+  }
+
+  .ai-install-panel__actions {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .ai-install-panel__intro {
+    display: grid;
+    gap: 0.7rem;
+  }
+
+  .ai-install-panel__actions p {
+    margin: 0;
+    color: var(--sl-color-text);
+    font-size: 0.93rem;
+    line-height: 1.5;
+  }
+
+  .ai-install-panel__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+  }
+
+  .ai-install-panel__chips span {
+    border: 1px solid color-mix(in srgb, var(--sl-color-gray-4) 82%, var(--sl-color-text-accent) 18%);
+    border-radius: 999px;
+    padding: 0.3rem 0.58rem;
+    background: color-mix(in srgb, var(--sl-color-bg-nav) 78%, white 22%);
+    color: var(--sl-color-gray-2);
+    font-size: 0.75rem;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  .ai-install-panel__copy {
+    border: 1px solid color-mix(in srgb, var(--sl-color-text-accent) 56%, white 44%);
+    border-radius: 999px;
+    padding: 0.62rem 1rem;
+    background: linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--sl-color-text-accent) 88%, white 12%),
+      color-mix(in srgb, var(--sl-color-text-accent) 68%, var(--sl-color-bg-nav) 32%)
+    );
+    color: var(--sl-color-black);
+    font: inherit;
+    font-size: 0.88rem;
+    font-weight: 700;
+    cursor: pointer;
+    white-space: nowrap;
+    flex-shrink: 0;
+    box-shadow: 0 10px 24px color-mix(in srgb, var(--sl-color-text-accent) 24%, transparent);
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease,
+      filter 0.2s ease;
+  }
+
+  .ai-install-panel__copy:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 14px 28px color-mix(in srgb, var(--sl-color-text-accent) 28%, transparent);
+    filter: brightness(1.02);
+  }
+
+  .ai-install-panel__prompt-surface {
+    position: relative;
+    border: 1px solid color-mix(in srgb, var(--sl-color-text-accent) 18%, #0f172a 82%);
+    border-radius: 1rem;
+    background: radial-gradient(circle at top right, rgba(96, 165, 250, 0.18), transparent 28%), linear-gradient(180deg, #17233b 0%, #101827 54%, #0b1220 100%);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 18px 32px rgba(15, 23, 42, 0.18);
+    overflow: hidden;
+  }
+
+  .ai-install-panel__prompt-surface::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(rgba(148, 163, 184, 0.06) 1px, transparent 1px), linear-gradient(90deg, rgba(148, 163, 184, 0.05) 1px, transparent 1px);
+    background-size:
+      100% 2.5rem,
+      2.5rem 100%;
+    opacity: 0.32;
+    pointer-events: none;
+  }
+
+  .ai-install-panel__prompt-meta {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.8rem 1rem 0;
+  }
+
+  .ai-install-panel__prompt-label {
+    border: 1px solid rgba(147, 197, 253, 0.34);
+    border-radius: 999px;
+    padding: 0.28rem 0.58rem;
+    background: rgba(59, 130, 246, 0.16);
+    color: #dbeafe;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  .ai-install-panel__prompt-note {
+    color: rgba(226, 232, 240, 0.72);
+    font-size: 0.8rem;
+    line-height: 1.4;
+  }
+
+  .ai-install-panel pre {
+    margin: 0;
+    position: relative;
+    z-index: 1;
+    border: 0;
+    padding: 1rem 1rem 1.1rem;
+    background: transparent;
+    overflow-x: auto;
+  }
+
+  .ai-install-panel pre code {
+    display: block;
+    color: #eff6ff;
+    font-size: 0.9rem;
+    line-height: 1.72;
+    text-wrap: pretty;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  @media (max-width: 768px) {
+    .ai-install-panel__toggle {
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: start;
+    }
+
+    .ai-install-panel__status {
+      display: none;
+    }
+
+    .ai-install-panel__actions {
+      flex-direction: column;
+    }
+
+    .ai-install-panel__prompt-meta {
+      align-items: flex-start;
+    }
+
+    .ai-install-panel__copy {
+      width: 100%;
+      justify-content: center;
+    }
+  }
+</style>

--- a/apps/docs/src/components/doc/PageTitle.astro
+++ b/apps/docs/src/components/doc/PageTitle.astro
@@ -1,12 +1,14 @@
 ---
 import Default from '@astrojs/starlight/components/PageTitle.astro'
 import CopyPage from './CopyPage.astro'
+import InstallPromptForAI from './InstallPromptForAI.astro'
 ---
 
 <div class="page-title-wrapper">
   <Default><slot /></Default>
   <CopyPage />
 </div>
+<InstallPromptForAI />
 
 <style>
   .page-title-wrapper {

--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,7 @@
       "name": "@capgo/docs",
       "dependencies": {
         "@astrojs/cloudflare": "13.1.7",
+        "@astrojs/mdx": "5.0.3",
         "@astrojs/sitemap": "3.7.2",
         "@astrojs/starlight": "0.38.2",
         "@astrojs/starlight-docsearch": "0.7.0",


### PR DESCRIPTION
## Summary\n- add a shared collapsed panel that exposes a copyable AI install prompt on plugin getting-started pages\n- resolve plugin packages from docs metadata and plugin registry so the prompt works across localized and nested getting-started routes\n- keep the panel hidden by default and add one-click copy support\n\n## Testing\n- bun run check\n- coverage script confirmed 748 plugin getting-started pages resolve to at least one package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AI-powered setup prompt panel displaying customized installation instructions with copy-to-clipboard functionality
  * Enabled MDX support for enhanced markdown document rendering throughout the documentation site

* **Bug Fixes**
  * Fixed "Edit this page" link redirection to point to the correct documentation directory
  * Improved document viewing and copying operations with better GitHub URL resolution and handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->