### PR TITLE
[codex] add xcode 26 requirement blog article

### DIFF
--- a/apps/web/src/content/blog/en/xcode-26-requirement-for-capacitor-apps.md
+++ b/apps/web/src/content/blog/en/xcode-26-requirement-for-capacitor-apps.md
@@ -16,7 +16,7 @@ locale: en
 next_blog: ''
 ---
 
-As of April 28, 2026, Apple requires every app and app update uploaded to App Store Connect to be built with Xcode 26 and the iOS 26 SDK, or the matching SDKs for iPadOS, tvOS, visionOS, and watchOS. If you ship a Capacitor app, this is the deadline that matters.
+Starting April 28, 2026, Apple requires every app and app update uploaded to App Store Connect to be built with Xcode 26 or later, using the iOS 26 SDK or the matching 26 SDKs for iPadOS, tvOS, visionOS, and watchOS. If you ship a Capacitor app, this is the deadline that matters.
 
 The good news: for most teams, this is a build environment change, not a full app migration. And if you already use [Capgo Build](/native-build/), your iOS build system is already on Xcode 26.
 
@@ -24,21 +24,21 @@ The good news: for most teams, this is a build environment change, not a full ap
 
 Apple published the requirement in its [Upcoming Requirements](https://developer.apple.com/news/upcoming-requirements/) page and repeats it on the [App Store submission](https://developer.apple.com/ios/submit/) page.
 
-Starting on **April 28, 2026**, uploads built with the older baseline are no longer accepted. Existing apps already live on the App Store keep working, but the next binary you submit must come from the new toolchain.
+Starting on **April 28, 2026**, App Store Connect no longer accepts uploads built with Xcode earlier than 26 or without the required 26 SDKs. Existing apps already live on the App Store keep working, but the next binary you submit must come from the new toolchain.
 
 ## What It Means for Capacitor Teams
 
 For most Capacitor apps, this is mainly about how you build the app, not about replacing Capacitor or rewriting your project.
 
-- If you build locally on a Mac, you need Xcode 26 installed and selected.
-- If you use your own CI pipeline, your macOS runner image needs Xcode 26.
+- If you build locally on a Mac, you need Xcode 26 or later installed and selected.
+- If you use your own CI pipeline, your macOS runner image needs Xcode 26 or later.
 - If you have native dependencies or older plugins, rebuild once on the new SDK and test a fresh archive before your next release.
 
 The failure mode here is simple: everything may still work in development, but App Store Connect will block the upload if the build came from an older Xcode line.
 
 ## Capgo Build Is Already on Xcode 26
 
-If you build with [Capgo Build](/native-build/), you do not need to scramble to update your build environment for this Apple deadline. Our current iOS build system is already running on Xcode 26.
+If you build with [Capgo Build](/native-build/), you do not need to scramble to update your build environment for this Apple deadline. Our current iOS build system is already running on Xcode 26 or later.
 
 That means teams using Capgo Build are already aligned with Apple's April 28, 2026 submission requirement. No local Mac refresh, no runner image hunt, and no last-minute Xcode upgrade just to keep shipping.
 
@@ -46,8 +46,8 @@ That means teams using Capgo Build are already aligned with Apple's April 28, 20
 
 You still need to make changes if any of these apply:
 
-- You build and archive iOS apps locally and have not moved to Xcode 26 yet.
-- Your self-managed CI pipeline is pinned to an older Xcode image.
+- You build and archive iOS apps locally and have not moved to Xcode 26 or later yet.
+- Your self-managed CI pipeline is pinned to an older Xcode image than Xcode 26.
 - One of your native SDKs or plugins has trouble when rebuilt with the iOS 26 SDK.
 
 If that is your setup, update the toolchain first, then run a clean build and a TestFlight submission before planning a production release.
@@ -56,4 +56,4 @@ If that is your setup, update the toolchain first, then run a clean build and a 
 
 This is Apple’s normal yearly toolchain cutoff, but the enforcement date is real: **since April 28, 2026**, older Xcode builds are no longer enough for App Store uploads.
 
-If you use Capgo Build, you are already on Xcode 26. If you build elsewhere, now is the time to update your environment before your next iOS release window.
+If you use Capgo Build, you are already on Xcode 26 or later. If you build elsewhere, now is the time to update your environment before your next iOS release window.

--- a/apps/web/src/content/blog/en/xcode-26-requirement-for-capacitor-apps.md
+++ b/apps/web/src/content/blog/en/xcode-26-requirement-for-capacitor-apps.md
@@ -30,15 +30,17 @@ Starting on **April 28, 2026**, App Store Connect no longer accepts uploads buil
 
 For most Capacitor apps, this is mainly about how you build the app, not about replacing Capacitor or rewriting your project.
 
-- If you build locally on a Mac, you need Xcode 26 or later installed and selected.
-- If you use your own CI pipeline, your macOS runner image needs Xcode 26 or later.
-- If you have native dependencies or older plugins, rebuild once on the new SDK and test a fresh archive before your next release.
+Ensure every build path uses Xcode 26 or later:
+
+- Local Mac builds: install and select Xcode 26 or later.
+- Self-managed CI: use a macOS runner image with Xcode 26 or later.
+- Native dependencies and older plugins: rebuild on the new SDK and test a fresh archive before your next release.
 
 The failure mode here is simple: everything may still work in development, but App Store Connect will block the upload if the build came from an older Xcode line.
 
 ## Capgo Build Is Already on Xcode 26
 
-If you build with [Capgo Build](/native-build/), you do not need to scramble to update your build environment for this Apple deadline. Our current iOS build system is already running on Xcode 26 or later.
+If you build with [Capgo Build](/native-build/), you do not need to scramble to update your build environment for this Apple deadline. As of April 29, 2026, our current iOS build system is already running on Xcode 26 or later through [Capgo Build](/native-build/).
 
 That means teams using Capgo Build are already aligned with Apple's April 28, 2026 submission requirement. No local Mac refresh, no runner image hunt, and no last-minute Xcode upgrade just to keep shipping.
 
@@ -56,4 +58,4 @@ If that is your setup, update the toolchain first, then run a clean build and a 
 
 This is Apple’s normal yearly toolchain cutoff, but the enforcement date is real: **since April 28, 2026**, older Xcode builds are no longer enough for App Store uploads.
 
-If you use Capgo Build, you are already on Xcode 26 or later. If you build elsewhere, now is the time to update your environment before your next iOS release window.
+If you use Capgo Build, you are already on Xcode 26 or later. If you build elsewhere, update your environment to Xcode 26 or later before your next iOS release.

--- a/apps/web/src/content/blog/en/xcode-26-requirement-for-capacitor-apps.md
+++ b/apps/web/src/content/blog/en/xcode-26-requirement-for-capacitor-apps.md
@@ -1,0 +1,59 @@
+---
+slug: xcode-26-requirement-for-capacitor-apps
+title: "Apple's Xcode 26 Requirement for Capacitor Apps"
+description: Apple now requires Xcode 26 and the iOS 26 SDK for App Store Connect submissions. Here is what changed for Capacitor teams and why Capgo Build users are already covered.
+author: Martin Donadieu
+author_image_url: https://avatars.githubusercontent.com/u/4084527?v=4
+author_url: https://github.com/riderx
+created_at: 2026-04-29T09:30:00.000Z
+updated_at: 2026-04-29T09:30:00.000Z
+head_image: /build_list.webp
+head_image_alt: Capgo native build list
+keywords: Apple, Xcode 26, iOS 26 SDK, Capacitor, App Store Connect, Capgo Build, cloud builds
+tag: Development, Mobile, Cloud
+published: true
+locale: en
+next_blog: ''
+---
+
+As of April 28, 2026, Apple requires every app and app update uploaded to App Store Connect to be built with Xcode 26 and the iOS 26 SDK, or the matching SDKs for iPadOS, tvOS, visionOS, and watchOS. If you ship a Capacitor app, this is the deadline that matters.
+
+The good news: for most teams, this is a build environment change, not a full app migration. And if you already use [Capgo Build](/native-build/), your iOS build system is already on Xcode 26.
+
+## What Apple Changed
+
+Apple published the requirement in its [Upcoming Requirements](https://developer.apple.com/news/upcoming-requirements/) page and repeats it on the [App Store submission](https://developer.apple.com/ios/submit/) page.
+
+Starting on **April 28, 2026**, uploads built with the older baseline are no longer accepted. Existing apps already live on the App Store keep working, but the next binary you submit must come from the new toolchain.
+
+## What It Means for Capacitor Teams
+
+For most Capacitor apps, this is mainly about how you build the app, not about replacing Capacitor or rewriting your project.
+
+- If you build locally on a Mac, you need Xcode 26 installed and selected.
+- If you use your own CI pipeline, your macOS runner image needs Xcode 26.
+- If you have native dependencies or older plugins, rebuild once on the new SDK and test a fresh archive before your next release.
+
+The failure mode here is simple: everything may still work in development, but App Store Connect will block the upload if the build came from an older Xcode line.
+
+## Capgo Build Is Already on Xcode 26
+
+If you build with [Capgo Build](/native-build/), you do not need to scramble to update your build environment for this Apple deadline. Our current iOS build system is already running on Xcode 26.
+
+That means teams using Capgo Build are already aligned with Apple's April 28, 2026 submission requirement. No local Mac refresh, no runner image hunt, and no last-minute Xcode upgrade just to keep shipping.
+
+## When You Still Need to Act
+
+You still need to make changes if any of these apply:
+
+- You build and archive iOS apps locally and have not moved to Xcode 26 yet.
+- Your self-managed CI pipeline is pinned to an older Xcode image.
+- One of your native SDKs or plugins has trouble when rebuilt with the iOS 26 SDK.
+
+If that is your setup, update the toolchain first, then run a clean build and a TestFlight submission before planning a production release.
+
+## Final Take
+
+This is Apple’s normal yearly toolchain cutoff, but the enforcement date is real: **since April 28, 2026**, older Xcode builds are no longer enough for App Store uploads.
+
+If you use Capgo Build, you are already on Xcode 26. If you build elsewhere, now is the time to update your environment before your next iOS release window.


### PR DESCRIPTION
## Summary
- add a new English blog post about Apple’s April 28, 2026 Xcode 26 / iOS 26 SDK submission requirement
- explain what the requirement changes for Capacitor teams
- state that Capgo Build is already on Xcode 26

## Why
Apple now requires App Store Connect submissions to be built with Xcode 26. We need a site article covering the requirement in Capgo’s voice without referencing Capawesome.

## Validation
- `bun run ci:verify:web`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added blog post outlining Apple's Xcode 26 and iOS 26 SDK requirements for App Store Connect submissions effective April 28, 2026, with guidance for developers on updating local builds, CI/CD pipelines, and native dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->