### PR TITLE
[codex] add web app to Capacitor blog article

### DIFF
--- a/apps/web/src/content/blog/en/how-easy-is-it-to-make-web-app-into-mobile-app-with-capacitor.md
+++ b/apps/web/src/content/blog/en/how-easy-is-it-to-make-web-app-into-mobile-app-with-capacitor.md
@@ -1,0 +1,254 @@
+---
+slug: how-easy-is-it-to-make-web-app-into-mobile-app-with-capacitor
+title: How Easy Is It to Turn a Web App into a Mobile App with Capacitor?
+description: >-
+  A practical answer for first-time founders and web developers who want to turn
+  an existing web app into iOS and Android apps with Capacitor, including app
+  store approval risks, billing rules, testing, and a launch checklist.
+author: Martin Donadieu
+author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
+author_url: 'https://x.com/martindonadieu'
+created_at: 2026-05-01T00:00:00.000Z
+updated_at: 2026-05-01T00:00:00.000Z
+head_image: /capacitor-guide.webp
+head_image_alt: Capacitor web app to mobile app guide
+keywords: Capacitor, web app to mobile app, app store review, Google Play closed testing, iOS app, Android app, mobile app publishing, app wrapper
+tag: Tutorial, Mobile, App Store
+published: true
+locale: en
+next_blog: transform-pwa-to-native-app-with-capacitor
+---
+
+## The Short Answer
+
+A developer on [Reddit asked](https://www.reddit.com/r/capacitor/comments/1sztt6t/how_easy_is_it_to_make_a_web_app_into_app_with/) whether it is simple to take a nearly finished web app, wrap it with Capacitor, and publish it to the App Store and Google Play.
+
+The honest answer is:
+
+**The Capacitor part is usually easy. The app store part is where most first-time developers get surprised.**
+
+If your web app already works well on mobile, has a clean production build, and does not depend on browser-only behavior, you can often get it running inside iOS and Android projects in a few hours. But getting approved requires more than placing a website in a WebView. Your app needs to feel like a real mobile product, handle mobile platform rules, and pass review checks around login, billing, privacy, permissions, and testing.
+
+Capacitor is a strong choice when you already have a working web app and want to avoid rewriting it in Swift, Kotlin, Flutter, or React Native. It gives you native app projects while keeping your existing web stack.
+
+## What Capacitor Actually Does
+
+[Capacitor](https://capacitorjs.com/) packages your built web assets into native iOS and Android projects. Your UI still comes from HTML, CSS, and JavaScript, but it runs inside a native app shell and can call native APIs through plugins.
+
+That means you can keep:
+
+- Your React, Vue, Angular, Svelte, Next.js, Nuxt, or Vite codebase
+- Your existing auth flow and API integration
+- Your design system and components
+- Most of your routing and state management
+- Your web deployment workflow
+
+And you can add:
+
+- Camera, files, geolocation, haptics, and push notifications
+- Native splash screen and app icons
+- Native status bar and keyboard handling
+- App Store and Play Store distribution
+- Live updates for safe web-layer fixes with [Capgo](https://capgo.app/)
+
+This is why Capacitor is often the fastest path from "mobile-friendly web app" to "real mobile app".
+
+## The Basic Conversion Flow
+
+For a typical web app, the first working mobile build looks like this:
+
+```bash
+bun add @capacitor/core
+bun add -D @capacitor/cli
+bunx cap init "My App" com.example.myapp --web-dir dist
+bun add @capacitor/ios @capacitor/android
+bunx cap add ios
+bunx cap add android
+bun run build
+bunx cap sync
+```
+
+Then open the native projects:
+
+```bash
+bunx cap open ios
+bunx cap open android
+```
+
+From there, you run the app in Xcode and Android Studio.
+
+The important setting is `webDir`. It must point to the folder your web framework creates during production build:
+
+| Framework | Common output folder |
+| --- | --- |
+| Vite | `dist` |
+| Angular | `dist/<project-name>` |
+| Create React App | `build` |
+| Next.js static export | `out` |
+| Nuxt static output | `.output/public` or `dist` |
+
+If your app builds static assets and routes correctly inside that folder, Capacitor has a clean starting point.
+
+## When It Is Easy
+
+Converting your web app is usually straightforward when:
+
+- The app is already responsive on small screens.
+- Navigation works without browser-specific assumptions.
+- Login works inside an embedded WebView.
+- You can create a static production build.
+- APIs are hosted separately from the frontend.
+- You are not relying on browser extensions, install prompts, or unsupported Web APIs.
+- Your app already has mobile-friendly touch targets and layout spacing.
+- You can test on real iOS and Android devices.
+
+A recipe app, productivity tool, dashboard, booking app, habit tracker, learning app, or AI chat app is often a good fit.
+
+## When It Gets Tricky
+
+The project becomes more complex when your app needs:
+
+- Heavy background processing
+- Complex Bluetooth, audio, video, or GPS behavior
+- Payment flows for digital goods
+- Offline-first sync with conflict handling
+- Deep native integrations
+- Custom camera or media pipelines
+- High-performance graphics or games
+- Server-rendered pages that cannot be exported or loaded from an API-backed frontend
+
+None of these are impossible with Capacitor. They just require native thinking. You may need plugins, custom Swift or Kotlin code, extra permissions, and more review preparation.
+
+## The App Store Does Not Reject Apps Because They Use Capacitor
+
+Apple and Google do not reject an app simply because it uses Capacitor. They reject apps that feel unfinished, broken, deceptive, unsafe, or too much like a thin copy of a website.
+
+Apple's [App Review Guidelines](https://developer.apple.com/app-store/review/guidelines/) include a "Minimum Functionality" rule. The practical meaning is simple: your app should provide useful app-like functionality, not just open a public website in a wrapper.
+
+For a Capacitor app, that means you should pay attention to:
+
+- Native-feeling navigation
+- Proper safe-area spacing around notches and home indicators
+- Fast startup and loading states
+- A real splash screen and app icon
+- Mobile-appropriate empty states and error states
+- Offline behavior if your product promises it
+- Account deletion if users can create accounts
+- Permission prompts that explain why access is needed
+- No broken links, placeholder screens, or desktop-only UI
+
+If your web app was designed as an app from the beginning, you are already closer than most.
+
+## Billing Is the Biggest Policy Trap
+
+If your app sells physical goods or services consumed outside the app, external payment methods such as Stripe are usually expected.
+
+If your app sells digital content, subscriptions, premium features, credits, or access used inside the app, you must be much more careful. Apple's [in-app purchase rule](https://developer.apple.com/app-store/review/guidelines/#in-app-purchase) generally requires In-App Purchase for digital unlocks, with specific regional and entitlement exceptions. Google has similar Play Billing requirements for many digital purchases.
+
+For example:
+
+- A meal delivery app charging for delivered food can use Stripe.
+- A recipe app selling a premium recipe library inside the app usually needs in-app purchases.
+- A SaaS companion app may be allowed to let existing subscribers log in, but purchase links inside the app need careful review.
+
+Do not submit with payment removed and then add it back later to bypass review. That creates policy risk and can lead to rejection or removal.
+
+If your business model depends on subscriptions, implement the correct store purchase flow from the beginning. For Capacitor, a plugin such as [Capgo Native Purchases](https://capgo.app/docs/plugins/native-purchases/) can help manage iOS and Android purchase integration.
+
+## Google Play Testing Adds Calendar Time
+
+For Android, the build itself may be quick, but publishing can still take time.
+
+Google's [testing requirements for new personal developer accounts](https://support.google.com/googleplay/android-developer/answer/14151465) say that affected accounts must run a closed test with at least 12 opted-in testers for 14 continuous days before applying for production access.
+
+That means your launch plan should include:
+
+- Creating the Play Console app early
+- Uploading an Android App Bundle to closed testing
+- Recruiting testers before you are "done"
+- Asking testers to keep access for the full testing period
+- Collecting and acting on feedback
+- Leaving time for production access review after the 14 days
+
+This is not a Capacitor problem. Native Android apps face the same requirement.
+
+## What About Vibe-Coded Apps?
+
+The app stores do not care whether the first version was written by hand, generated by AI, built in Lovable, created in Bolt, or assembled in Cursor. They care about the submitted app.
+
+AI-generated code can be perfectly valid, but you still need to understand:
+
+- How to build the project locally
+- Where the production output folder is
+- Which dependencies are used
+- What permissions the app requests
+- How login, account deletion, and data export work
+- Whether privacy labels match actual behavior
+- How to fix crashes found by review or testers
+
+If you cannot explain what the app does with user data, reviewers will not treat "AI generated it" as an excuse.
+
+## Mobile Polish Checklist
+
+Before submitting, test your Capacitor app as a mobile app, not as a website.
+
+Use this checklist:
+
+- App launches to useful content, not a blank screen.
+- Splash screen and icon are final.
+- Status bar color matches the UI.
+- Content respects safe areas on iPhone and modern Android devices.
+- Keyboard does not cover important inputs or buttons.
+- Back behavior works correctly on Android.
+- External links open in the right place.
+- Login works for new and returning users.
+- Reviewers have demo credentials if login is required.
+- Account deletion is available if account creation is available.
+- Privacy policy is live and accurate.
+- Permission prompts are only shown when needed.
+- Offline mode is clear if network access is unavailable.
+- Payment flow follows Apple and Google rules.
+- App has been tested on at least one real iPhone and one real Android device.
+
+This is the work that separates a "web wrapper" from an app users can trust.
+
+## A Realistic Timeline
+
+For a simple, well-built web app:
+
+| Task | Typical time |
+| --- | --- |
+| Add Capacitor and run locally | 1-4 hours |
+| Fix mobile layout and safe areas | 0.5-2 days |
+| Add icons, splash, permissions | 0.5-1 day |
+| Test login, routing, and API behavior | 1-2 days |
+| Add store billing, if needed | 2-7+ days |
+| Prepare App Store and Play Store listings | 1-3 days |
+| Google closed testing for affected accounts | 14+ days |
+
+So the right expectation is:
+
+**You can probably get the app running quickly. You should budget at least a week or two for a serious first store submission, and longer if billing or Google closed testing applies.**
+
+## Where Capgo Helps After the First Release
+
+Once your Capacitor app is in production, [Capgo Live Updates](https://capgo.app/) can help ship web-layer fixes without waiting for a full store review each time.
+
+That is useful for:
+
+- UI fixes
+- Copy changes
+- Onboarding improvements
+- Bug fixes in web code
+- Feature flags and staged rollouts
+- Rollbacks when a release has an issue
+
+Live updates do not replace app review for native changes, new native permissions, or major changes to the app's core purpose. But for the normal iteration loop of a web-powered mobile app, they can save a lot of time.
+
+## Final Answer
+
+Yes, it is usually easy to turn a good web app into a mobile app with Capacitor.
+
+But the goal is not just to "wrap" the website. The goal is to ship a mobile app that looks complete, behaves well on iOS and Android, follows billing and privacy rules, and can survive review.
+
+Start by getting a local Capacitor build running. Then spend most of your effort on mobile polish, store compliance, testing, and launch workflow. That is where the real approval work happens.

--- a/apps/web/src/content/blog/en/how-easy-is-it-to-make-web-app-into-mobile-app-with-capacitor.md
+++ b/apps/web/src/content/blog/en/how-easy-is-it-to-make-web-app-into-mobile-app-with-capacitor.md
@@ -143,7 +143,7 @@ If your web app was designed as an app from the beginning, you are already close
 
 If your app sells physical goods or services consumed outside the app, external payment methods such as Stripe are usually expected.
 
-If your app sells digital content, subscriptions, premium features, credits, or access used inside the app, you must be much more careful. Apple's [in-app purchase rule](https://developer.apple.com/app-store/review/guidelines/#in-app-purchase) generally requires In-App Purchase for digital unlocks, with specific regional and entitlement exceptions. Google has similar Play Billing requirements for many digital purchases.
+If your app sells digital content, subscriptions, premium features, credits, or access used inside the app, you must be much more careful. Apple's [in-app purchase rule](https://developer.apple.com/app-store/review/guidelines/#in-app-purchase) generally requires In-App Purchase for digital unlocks, with specific regional and entitlement exceptions. Google has similar [Play Billing requirements](https://support.google.com/googleplay/android-developer/answer/9858738) for many digital purchases.
 
 For example:
 
@@ -159,7 +159,7 @@ If your business model depends on subscriptions, implement the correct store pur
 
 For Android, the build itself may be quick, but publishing can still take time.
 
-Google's [testing requirements for new personal developer accounts](https://support.google.com/googleplay/android-developer/answer/14151465) say that affected accounts must run a closed test with at least 12 opted-in testers for 14 continuous days before applying for production access.
+As of May 1, 2026, Google's [testing requirements for new personal developer accounts](https://support.google.com/googleplay/android-developer/answer/14151465) say that affected accounts must run a closed test with at least 12 opted-in testers for 14 continuous days before applying for production access.
 
 That means your launch plan should include:
 
@@ -224,7 +224,7 @@ For a simple, well-built web app:
 | Test login, routing, and API behavior | 1-2 days |
 | Add store billing, if needed | 2-7+ days |
 | Prepare App Store and Play Store listings | 1-3 days |
-| Google closed testing for affected accounts | 14+ days |
+| Google closed testing for affected accounts | 14+ days under the May 1, 2026 requirement |
 
 So the right expectation is:
 

--- a/apps/web/src/content/blog/en/how-easy-is-it-to-make-web-app-into-mobile-app-with-capacitor.md
+++ b/apps/web/src/content/blog/en/how-easy-is-it-to-make-web-app-into-mobile-app-with-capacitor.md
@@ -224,7 +224,7 @@ For a simple, well-built web app:
 | Test login, routing, and API behavior | 1-2 days |
 | Add store billing, if needed | 2-7+ days |
 | Prepare App Store and Play Store listings | 1-3 days |
-| Google closed testing for affected accounts | 14+ days under the May 1, 2026 requirement |
+| Google closed testing for affected accounts | 14+ days under the May 1, 2026, requirement |
 
 So the right expectation is:
 

--- a/apps/web/src/content/blog/en/how-easy-is-it-to-make-web-app-into-mobile-app-with-capacitor.md
+++ b/apps/web/src/content/blog/en/how-easy-is-it-to-make-web-app-into-mobile-app-with-capacitor.md
@@ -10,7 +10,7 @@ author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2026-05-01T00:00:00.000Z
 updated_at: 2026-05-01T00:00:00.000Z
-head_image: /capacitor-guide.webp
+head_image: /capgo_banner.png
 head_image_alt: Capacitor web app to mobile app guide
 keywords: Capacitor, web app to mobile app, app store review, Google Play closed testing, iOS app, Android app, mobile app publishing, app wrapper
 tag: Tutorial, Mobile, App Store


### PR DESCRIPTION
## Summary
- Add a new English blog article answering how easy it is to turn a web app into an iOS/Android app with Capacitor
- Cover store approval risks, billing policy traps, Google Play closed testing, AI-generated apps, and a mobile polish checklist
- Link to the source Reddit question plus relevant Apple, Google, and Capacitor docs

## Validation
- bunx prettier --write apps/web/src/content/blog/en/how-easy-is-it-to-make-web-app-into-mobile-app-with-capacitor.md
- bun run check

## Notes
- The full check passed with one unrelated existing docs hint in apps/docs/src/components/doc/CopyPage.astro.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added blog article on converting web apps to mobile with Capacitor: explains packaging workflow, framework output folders, factors affecting conversion difficulty, app store compliance and Apple expectations, payment/billing rules and submission cautions, Google Play testing note, mobile polish checklist, realistic time estimates and iteration guidance, plus tips on using live updates to accelerate web-layer fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->