### PR TITLE
fix: redirect cold translation misses

### DIFF
--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -53,10 +53,10 @@ type AttributeMatch = {
 
 const DEFAULT_LOCALE = 'en'
 const ALL_LOCALES = [DEFAULT_LOCALE, ...SUPPORTED_LOCALES] as const
-const DEFAULT_MODEL = '@cf/meta/llama-3.1-8b-instruct'
+const DEFAULT_MODEL = '@cf/moonshotai/kimi-k2.6'
 const FRESH_MS = 24 * 60 * 60 * 1000
 const CACHE_KEEP_SECONDS = 7 * 24 * 60 * 60
-const TRANSLATION_CACHE_VERSION = '2026-05-01-strict-translation-v1'
+const TRANSLATION_CACHE_VERSION = '2026-05-01-kimi-k2.6-v1'
 const CLIENT_NO_STORE = 'no-store, max-age=0, must-revalidate'
 const MAX_HTML_BYTES = 1_500_000
 const MAX_BATCH_CHARS = 6_000
@@ -277,15 +277,12 @@ function withResponseHeaders(response: Response, cacheState: 'MISS' | 'HIT' | 'S
   })
 }
 
-function translationUnavailableResponse(isHead = false): Response {
-  return withResponseHeaders(
-    new Response(isHead ? null : 'Translation temporarily unavailable', {
-      status: 503,
-      headers: { 'Content-Type': 'text/plain; charset=utf-8', 'Retry-After': '60' },
-    }),
-    'BYPASS',
-    isHead,
-  )
+function temporaryEnglishRedirectResponse(requestUrl: URL, isHead = false): Response {
+  const headers = new Headers({
+    Location: localizedPath(requestUrl.pathname, DEFAULT_LOCALE) + requestUrl.search,
+    'X-Capgo-Translation-Fallback': 'temporary-english-redirect',
+  })
+  return withResponseHeaders(new Response(isHead ? null : null, { status: 302, headers }), 'BYPASS', isHead)
 }
 
 function toCachedResponse(response: Response): Response {
@@ -573,6 +570,33 @@ function extractAiText(result: unknown): string {
     const record = result as Record<string, unknown>
     for (const key of ['response', 'text', 'result']) {
       if (typeof record[key] === 'string') return record[key] as string
+    }
+
+    const choices = record.choices
+    if (Array.isArray(choices)) {
+      for (const choice of choices) {
+        if (!choice || typeof choice !== 'object') continue
+        const choiceRecord = choice as Record<string, unknown>
+        if (typeof choiceRecord.text === 'string') return choiceRecord.text
+
+        const message = choiceRecord.message
+        if (message && typeof message === 'object') {
+          const content = (message as Record<string, unknown>).content
+          if (typeof content === 'string') return content
+          if (Array.isArray(content)) {
+            const text = content
+              .map((item) => {
+                if (typeof item === 'string') return item
+                if (item && typeof item === 'object' && typeof (item as Record<string, unknown>).text === 'string') {
+                  return (item as Record<string, unknown>).text as string
+                }
+                return ''
+              })
+              .join('')
+            if (text) return text
+          }
+        }
+      }
     }
   }
   return ''
@@ -1030,8 +1054,12 @@ async function serveTranslated(request: Request, env: Env, ctx: ExecutionContext
     return withResponseHeaders(cachedResponse, isStale ? 'STALE' : 'HIT', isHead)
   }
 
-  const translatedResponse = await refreshCache(request, env, requestUrl, locale, cacheKey)
-  return withResponseHeaders(translatedResponse, 'MISS', isHead)
+  ctx.waitUntil(
+    refreshCache(request, env, requestUrl, locale, cacheKey).catch((error) => {
+      console.error('Failed to create translated page', { pathname: requestUrl.pathname, locale, error })
+    }),
+  )
+  return temporaryEnglishRedirectResponse(requestUrl, isHead)
 }
 
 export default {
@@ -1053,7 +1081,7 @@ export default {
       return await serveTranslated(request, env, ctx, requestUrl, locale)
     } catch (error) {
       console.error('Translation worker failed', { pathname: requestUrl.pathname, locale, error })
-      return translationUnavailableResponse(request.method === 'HEAD')
+      return temporaryEnglishRedirectResponse(requestUrl, request.method === 'HEAD')
     }
   },
 }

--- a/apps/translation-worker/wrangler.jsonc
+++ b/apps/translation-worker/wrangler.jsonc
@@ -9,7 +9,7 @@
     "binding": "AI",
   },
   "vars": {
-    "TRANSLATION_MODEL": "@cf/meta/llama-3.1-8b-instruct",
+    "TRANSLATION_MODEL": "@cf/moonshotai/kimi-k2.6",
   },
   "services": [
     {


### PR DESCRIPTION
## What changed
- Switch the translation worker default model and Wrangler config from Llama to Cloudflare Workers AI Kimi K2.6: `@cf/moonshotai/kimi-k2.6`.
- Parse OpenAI-style `choices[].message.content` responses so Kimi output is accepted.
- Change cold-cache localized requests to immediately issue a temporary redirect to the English path while translation generation continues in the background.
- Keep cached localized pages fast: existing cache is served, stale cache is served while refreshing, and only empty cache redirects.
- Bump the worker cache version for the model/runtime behavior change.

## Validation
- `bun run ci:verify:translation`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unavailable translations now automatically redirect to the default language version instead of showing error messages, enabling a more seamless user experience across different language preferences and regions.

* **Improvements**
  * Translation request response times significantly enhanced through asynchronous background cache refresh operations without blocking.
  * AI translation model and cache versioning updated for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->