### PR TITLE
fix: simplify Kimi response parser

### DIFF
--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -282,7 +282,7 @@ function temporaryEnglishRedirectResponse(requestUrl: URL, isHead = false): Resp
     Location: localizedPath(requestUrl.pathname, DEFAULT_LOCALE) + requestUrl.search,
     'X-Capgo-Translation-Fallback': 'temporary-english-redirect',
   })
-  return withResponseHeaders(new Response(isHead ? null : null, { status: 302, headers }), 'BYPASS', isHead)
+  return withResponseHeaders(new Response(null, { status: 302, headers }), 'BYPASS', isHead)
 }
 
 function toCachedResponse(response: Response): Response {
@@ -564,42 +564,53 @@ function buildBatches(segments: Segment[]): string[][] {
   return batches
 }
 
-function extractAiText(result: unknown): string {
-  if (typeof result === 'string') return result
-  if (result && typeof result === 'object') {
-    const record = result as Record<string, unknown>
-    for (const key of ['response', 'text', 'result']) {
-      if (typeof record[key] === 'string') return record[key] as string
-    }
+function recordOf(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : null
+}
 
-    const choices = record.choices
-    if (Array.isArray(choices)) {
-      for (const choice of choices) {
-        if (!choice || typeof choice !== 'object') continue
-        const choiceRecord = choice as Record<string, unknown>
-        if (typeof choiceRecord.text === 'string') return choiceRecord.text
+function extractContentText(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
 
-        const message = choiceRecord.message
-        if (message && typeof message === 'object') {
-          const content = (message as Record<string, unknown>).content
-          if (typeof content === 'string') return content
-          if (Array.isArray(content)) {
-            const text = content
-              .map((item) => {
-                if (typeof item === 'string') return item
-                if (item && typeof item === 'object' && typeof (item as Record<string, unknown>).text === 'string') {
-                  return (item as Record<string, unknown>).text as string
-                }
-                return ''
-              })
-              .join('')
-            if (text) return text
-          }
-        }
-      }
-    }
+  return content
+    .map((item) => {
+      if (typeof item === 'string') return item
+      const itemRecord = recordOf(item)
+      return typeof itemRecord?.text === 'string' ? itemRecord.text : ''
+    })
+    .join('')
+}
+
+function extractChoiceText(choice: unknown): string {
+  const choiceRecord = recordOf(choice)
+  if (!choiceRecord) return ''
+  if (typeof choiceRecord.text === 'string') return choiceRecord.text
+
+  const message = recordOf(choiceRecord.message)
+  return message ? extractContentText(message.content) : ''
+}
+
+function extractChoicesText(choices: unknown): string {
+  if (!Array.isArray(choices)) return ''
+
+  for (const choice of choices) {
+    const text = extractChoiceText(choice)
+    if (text) return text
   }
   return ''
+}
+
+function extractAiText(result: unknown): string {
+  if (typeof result === 'string') return result
+
+  const record = recordOf(result)
+  if (!record) return ''
+
+  for (const key of ['response', 'text', 'result']) {
+    if (typeof record[key] === 'string') return record[key] as string
+  }
+
+  return extractChoicesText(record.choices)
 }
 
 function stripJsonFence(value: string): string {


### PR DESCRIPTION
## What changed
- Refactor Kimi/OpenAI-style response parsing into small helpers to satisfy Sonar reliability rules.
- Remove the redundant redirect response conditional flagged by Sonar.

## Why
PR #610 was merged before the Sonar fixes were included. This follow-up keeps the merged behavior and fixes the quality gate failure.

## Validation
- `bun run ci:verify:translation`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of AI text extraction with safer parsing of responses, better handling of nested content structures.

* **Refactor**
  * Simplified response body construction logic for cleaner codebase maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->