### PR TITLE
[codex] Ensure development translation queue

### DIFF
--- a/.github/workflows/deploy-translation.yml
+++ b/.github/workflows/deploy-translation.yml
@@ -41,16 +41,23 @@ jobs:
             ${{ runner.os }}-bun-
       - run: bun install --frozen-lockfile
       - run: bun run ci:verify:translation
-      - name: Ensure translation queue exists
+      - name: Ensure translation queues exist
         run: |
-          set +e
-          output="$(bunx wrangler queues create capgo-translation-refresh 2>&1)"
-          status=$?
-          printf '%s\n' "$output"
-          if [ "$status" -eq 0 ]; then
-            exit 0
-          fi
-          printf '%s\n' "$output" | grep -Eiq 'already exists|already.*capgo-translation-refresh'
+          ensure_queue() {
+            queue="$1"
+            set +e
+            output="$(bunx wrangler queues create "$queue" 2>&1)"
+            status=$?
+            set -e
+            printf '%s\n' "$output"
+            if [ "$status" -eq 0 ]; then
+              return 0
+            fi
+            printf '%s\n' "$output" | grep -Eiq "already exists|already.*${queue}"
+          }
+
+          ensure_queue capgo-translation-refresh
+          ensure_queue capgo-translation-refresh-development
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- address CodeRabbit feedback from #613 by ensuring the development translation queue exists too
- reuse one idempotent queue creation helper for production and development queue names

## Validation
- bun run ci:verify:translation
- bunx prettier --check .github/workflows/deploy-translation.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment infrastructure for translation services by enhancing queue resource management in the GitHub Actions workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->