### PR TITLE
[codex] Chunk translation queue jobs

### DIFF
--- a/.github/workflows/deploy-translation.yml
+++ b/.github/workflows/deploy-translation.yml
@@ -61,6 +61,26 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Ensure translation cache buckets exist
+        run: |
+          ensure_bucket() {
+            bucket="$1"
+            set +e
+            output="$(bunx wrangler r2 bucket create "$bucket" 2>&1)"
+            status=$?
+            set -e
+            printf '%s\n' "$output"
+            if [ "$status" -eq 0 ]; then
+              return 0
+            fi
+            printf '%s\n' "$output" | grep -Eiq "already exists|already.*${bucket}"
+          }
+
+          ensure_bucket capgo-translation-cache
+          ensure_bucket capgo-translation-cache-development
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - run: bun run deploy:translation
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -23,6 +23,7 @@ type TranslationJob = {
   cacheVersion: string
   reason: TranslationQueueReason
   sourceHash?: string
+  translatedBatches?: string[][]
 }
 
 type QueueBinding<T> = {
@@ -35,14 +36,6 @@ type QueueMessage<T> = {
 
 type MessageBatch<T> = {
   messages: QueueMessage<T>[]
-}
-
-type PartialTranslationState = {
-  cacheVersion: string
-  sourceHash: string
-  locale: Locale
-  translatedBatches: string[][]
-  updatedAt: number
 }
 
 type SourceHtmlResult = { type: 'response'; response: Response } | { type: 'html'; originResponse: Response; sourceHtml: string }
@@ -86,7 +79,6 @@ const DEFAULT_MODEL = '@cf/moonshotai/kimi-k2.6'
 const FRESH_MS = 24 * 60 * 60 * 1000
 const CACHE_KEEP_SECONDS = 7 * 24 * 60 * 60
 const TRANSLATION_PENDING_SECONDS = 10 * 60
-const TRANSLATION_PARTIAL_SECONDS = 60 * 60
 const TRANSLATION_CACHE_VERSION = '2026-05-01-kimi-k2.6-v1'
 const CLIENT_NO_STORE = 'no-store, max-age=0, must-revalidate'
 const MAX_HTML_BYTES = 1_500_000
@@ -304,14 +296,6 @@ function pendingKeyFor(requestUrl: URL, locale: Locale): Request {
   return new Request(pendingUrl.toString(), { method: 'GET' })
 }
 
-function partialKeyFor(requestUrl: URL, locale: Locale): Request {
-  const partialUrl = new URL(requestUrl)
-  partialUrl.pathname = localizedPath(partialUrl.pathname, locale)
-  partialUrl.search = ''
-  partialUrl.searchParams.set('__capgo_translation_partial', TRANSLATION_CACHE_VERSION)
-  return new Request(partialUrl.toString(), { method: 'GET' })
-}
-
 function withResponseHeaders(response: Response, cacheState: 'MISS' | 'HIT' | 'STALE' | 'BYPASS', isHead = false): Response {
   const headers = new Headers(response.headers)
   headers.set('Cache-Control', CLIENT_NO_STORE)
@@ -350,6 +334,26 @@ function toCachedResponse(response: Response): Response {
   })
 }
 
+function splitLongCoreText(value: string): string[] {
+  const chunks: string[] = []
+  let cursor = 0
+
+  while (cursor < value.length) {
+    let end = Math.min(cursor + MAX_BATCH_CHARS, value.length)
+    if (end < value.length) {
+      let splitIndex = end - 1
+      const minimumSplitIndex = cursor + Math.floor(MAX_BATCH_CHARS * 0.6)
+      while (splitIndex > minimumSplitIndex && !isWhitespace(value[splitIndex])) splitIndex -= 1
+      if (splitIndex > cursor) end = splitIndex + 1
+    }
+
+    chunks.push(value.slice(cursor, end))
+    cursor = end
+  }
+
+  return chunks
+}
+
 function addSegment(parts: HtmlPart[], segments: Segment[], text: string, mode: Segment['mode'], quote?: string): void {
   if (!hasAsciiLetter(text)) {
     parts.push(text)
@@ -365,8 +369,18 @@ function addSegment(parts: HtmlPart[], segments: Segment[], text: string, mode: 
     return
   }
 
-  const segmentIndex = segments.push({ text: core, leading, trailing, mode, quote }) - 1
-  parts.push({ segmentIndex })
+  const chunks = splitLongCoreText(core)
+  for (let index = 0; index < chunks.length; index += 1) {
+    const segmentIndex =
+      segments.push({
+        text: chunks[index],
+        leading: index === 0 ? leading : '',
+        trailing: index === chunks.length - 1 ? trailing : '',
+        mode,
+        quote,
+      }) - 1
+    parts.push({ segmentIndex })
+  }
 }
 
 function tagNameOf(tag: string): string | null {
@@ -800,51 +814,6 @@ function isStringArrayArray(value: unknown): value is string[][] {
   return Array.isArray(value) && value.every((item) => Array.isArray(item) && item.every((nestedItem) => typeof nestedItem === 'string'))
 }
 
-function partialTranslationStateFrom(value: unknown, locale: Locale, sourceHash: string): PartialTranslationState | null {
-  const record = recordOf(value)
-  if (!record) return null
-  if (record.cacheVersion !== TRANSLATION_CACHE_VERSION || record.locale !== locale || record.sourceHash !== sourceHash) return null
-  if (!isStringArrayArray(record.translatedBatches)) return null
-  return {
-    cacheVersion: TRANSLATION_CACHE_VERSION,
-    sourceHash,
-    locale,
-    translatedBatches: record.translatedBatches,
-    updatedAt: typeof record.updatedAt === 'number' ? record.updatedAt : 0,
-  }
-}
-
-async function readPartialTranslationState(requestUrl: URL, locale: Locale, sourceHash: string): Promise<PartialTranslationState | null> {
-  const response = await caches.default.match(partialKeyFor(requestUrl, locale))
-  if (!response) return null
-
-  try {
-    return partialTranslationStateFrom(await response.json(), locale, sourceHash)
-  } catch {
-    return null
-  }
-}
-
-async function writePartialTranslationState(requestUrl: URL, locale: Locale, state: PartialTranslationState): Promise<void> {
-  await caches.default.put(
-    partialKeyFor(requestUrl, locale),
-    new Response(JSON.stringify(state), {
-      headers: {
-        'Content-Type': 'application/json',
-        'Cache-Control': `public, max-age=${TRANSLATION_PARTIAL_SECONDS}`,
-      },
-    }),
-  )
-}
-
-async function deletePartialTranslationState(requestUrl: URL, locale: Locale): Promise<void> {
-  try {
-    await caches.default.delete(partialKeyFor(requestUrl, locale))
-  } catch (error) {
-    console.error('Failed to clear partial translated page state', { pathname: requestUrl.pathname, locale, error: errorMessage(error) })
-  }
-}
-
 function nextMissingBatchIndex(translatedBatches: string[][], batchCount: number): number {
   for (let index = 0; index < batchCount; index += 1) {
     if (!Array.isArray(translatedBatches[index])) return index
@@ -1157,45 +1126,44 @@ function createTranslatedHtmlResponse(originResponse: Response, translatedHtml: 
   })
 }
 
-async function refreshCacheIncrementally(request: Request, env: Env, requestUrl: URL, locale: Locale, cacheKey: Request, expectedSourceHash?: string): Promise<boolean> {
+async function refreshCacheIncrementally(
+  request: Request,
+  env: Env,
+  requestUrl: URL,
+  locale: Locale,
+  cacheKey: Request,
+  expectedSourceHash?: string,
+  existingTranslatedBatches?: string[][],
+): Promise<boolean> {
   const renderRequest = request.method === 'GET' ? request : new Request(request, { method: 'GET' })
   const source = await loadSourceHtml(renderRequest, env, requestUrl, locale)
-  if (source.type === 'response') return true
+  if (source.type === 'response') {
+    if (isRedirect(source.response)) {
+      await caches.default.put(cacheKey, toCachedResponse(source.response.clone()))
+    }
+    return true
+  }
 
   const { parts, segments } = collectSegments(source.sourceHtml)
   if (segments.length === 0) {
     const response = createTranslatedHtmlResponse(source.originResponse, source.sourceHtml, requestUrl, locale)
     const cachedResponse = toCachedResponse(response.clone())
     await caches.default.put(cacheKey, cachedResponse)
-    await deletePartialTranslationState(requestUrl, locale)
     return true
   }
 
   const batches = buildBatches(segments)
   const sourceHash = await sha256Hex(`${TRANSLATION_CACHE_VERSION}:${locale}:${source.sourceHtml}`)
-  if (expectedSourceHash && expectedSourceHash !== sourceHash) {
-    await deletePartialTranslationState(requestUrl, locale)
-  }
-
-  let state = await readPartialTranslationState(requestUrl, locale, sourceHash)
-  state ??= {
-    cacheVersion: TRANSLATION_CACHE_VERSION,
-    sourceHash,
-    locale,
-    translatedBatches: [],
-    updatedAt: Date.now(),
-  }
+  const translatedBatches = expectedSourceHash === sourceHash && existingTranslatedBatches ? existingTranslatedBatches : []
 
   let translatedInThisJob = 0
-  let batchIndex = nextMissingBatchIndex(state.translatedBatches, batches.length)
+  let batchIndex = nextMissingBatchIndex(translatedBatches, batches.length)
 
   while (batchIndex < batches.length && translatedInThisJob < TRANSLATION_BATCHES_PER_QUEUE_JOB) {
     const translatedBatch = await translateBatch(env, LANGUAGE_NAMES[locale], batches[batchIndex])
-    state.translatedBatches[batchIndex] = translatedBatch
-    state.updatedAt = Date.now()
-    await writePartialTranslationState(requestUrl, locale, state)
+    translatedBatches[batchIndex] = translatedBatch
     translatedInThisJob += 1
-    batchIndex = nextMissingBatchIndex(state.translatedBatches, batches.length)
+    batchIndex = nextMissingBatchIndex(translatedBatches, batches.length)
   }
 
   if (batchIndex < batches.length) {
@@ -1205,12 +1173,13 @@ async function refreshCacheIncrementally(request: Request, env: Env, requestUrl:
       cacheVersion: TRANSLATION_CACHE_VERSION,
       reason: 'continue',
       sourceHash,
+      translatedBatches,
     })
     console.log('Translation queue job continued', { pathname: requestUrl.pathname, locale, batchIndex, batchCount: batches.length })
     return false
   }
 
-  const translations = flattenTranslatedBatches(state.translatedBatches, batches.length)
+  const translations = flattenTranslatedBatches(translatedBatches, batches.length)
   if (translations.length !== segments.length) {
     throw new Error(`Partial translation produced ${translations.length} strings for ${segments.length} HTML segments`)
   }
@@ -1221,7 +1190,6 @@ async function refreshCacheIncrementally(request: Request, env: Env, requestUrl:
     const cachedResponse = toCachedResponse(response.clone())
     await caches.default.put(cacheKey, cachedResponse)
   }
-  await deletePartialTranslationState(requestUrl, locale)
   return true
 }
 
@@ -1299,7 +1267,15 @@ async function processTranslationJob(job: TranslationJob, env: Env): Promise<voi
         'Accept-Language': job.locale,
       },
     })
-    completed = await refreshCacheIncrementally(renderRequest, env, requestUrl, job.locale, cacheKey, job.sourceHash)
+    completed = await refreshCacheIncrementally(
+      renderRequest,
+      env,
+      requestUrl,
+      job.locale,
+      cacheKey,
+      job.sourceHash,
+      isStringArrayArray(job.translatedBatches) ? job.translatedBatches : undefined,
+    )
   } finally {
     if (completed) {
       try {

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -23,7 +23,6 @@ type TranslationJob = {
   cacheVersion: string
   reason: TranslationQueueReason
   sourceHash?: string
-  translatedBatches?: string[][]
 }
 
 type QueueBinding<T> = {
@@ -38,6 +37,16 @@ type MessageBatch<T> = {
   messages: QueueMessage<T>[]
 }
 
+type R2ObjectBody = {
+  text(): Promise<string>
+}
+
+type R2BucketBinding = {
+  get(key: string): Promise<R2ObjectBody | null>
+  put(key: string, value: string): Promise<unknown>
+  delete(key: string): Promise<void>
+}
+
 type SourceHtmlResult = { type: 'response'; response: Response } | { type: 'html'; originResponse: Response; sourceHtml: string }
 
 interface Env {
@@ -45,6 +54,7 @@ interface Env {
   WEB: WorkerService
   DOCS: WorkerService
   TRANSLATION_QUEUE: QueueBinding<TranslationJob>
+  TRANSLATION_STORE: R2BucketBinding
   TRANSLATION_MODEL?: string
 }
 
@@ -63,6 +73,23 @@ type Segment = {
 }
 
 type HtmlPart = string | { segmentIndex: number }
+type PartialTranslationState = {
+  cacheVersion: string
+  locale: Locale
+  sourceHash: string
+  batchCount: number
+  translatedBatches: string[][]
+  updatedAt: number
+}
+type StoredTranslatedResponse = {
+  cacheVersion: string
+  locale: Locale
+  translatedAt: number
+  status: number
+  statusText: string
+  headers: [string, string][]
+  body: string
+}
 type AttributeMatch = {
   name: string
   quote: string
@@ -294,6 +321,19 @@ function pendingKeyFor(requestUrl: URL, locale: Locale): Request {
   pendingUrl.search = ''
   pendingUrl.searchParams.set('__capgo_translation_pending', TRANSLATION_CACHE_VERSION)
   return new Request(pendingUrl.toString(), { method: 'GET' })
+}
+
+function canonicalTranslationStoreUrl(requestUrl: URL, locale: Locale): string {
+  const storeUrl = new URL(requestUrl)
+  storeUrl.pathname = localizedPath(storeUrl.pathname, locale)
+  storeUrl.search = ''
+  storeUrl.hash = ''
+  return storeUrl.toString()
+}
+
+async function translationStoreKey(kind: 'pages' | 'state', requestUrl: URL, locale: Locale): Promise<string> {
+  const urlHash = await sha256Hex(canonicalTranslationStoreUrl(requestUrl, locale))
+  return `${kind}/${TRANSLATION_CACHE_VERSION}/${locale}/${urlHash}.json`
 }
 
 function withResponseHeaders(response: Response, cacheState: 'MISS' | 'HIT' | 'STALE' | 'BYPASS', isHead = false): Response {
@@ -814,6 +854,118 @@ function isStringArrayArray(value: unknown): value is string[][] {
   return Array.isArray(value) && value.every((item) => Array.isArray(item) && item.every((nestedItem) => typeof nestedItem === 'string'))
 }
 
+function isStringPairArray(value: unknown): value is [string, string][] {
+  return Array.isArray(value) && value.every((item) => Array.isArray(item) && item.length === 2 && typeof item[0] === 'string' && typeof item[1] === 'string')
+}
+
+function parseStoredJson(value: string): Record<string, unknown> | null {
+  try {
+    return recordOf(JSON.parse(value))
+  } catch {
+    return null
+  }
+}
+
+function partialTranslationStateFrom(value: unknown, locale: Locale, sourceHash: string, batchCount: number): PartialTranslationState | null {
+  const record = recordOf(value)
+  if (!record) return null
+  if (record.cacheVersion !== TRANSLATION_CACHE_VERSION || record.locale !== locale || record.sourceHash !== sourceHash) return null
+  if (record.batchCount !== batchCount || !isStringArrayArray(record.translatedBatches)) return null
+  if (record.translatedBatches.length > batchCount) return null
+  if (typeof record.updatedAt !== 'number' || Date.now() - record.updatedAt > CACHE_KEEP_SECONDS * 1000) return null
+  return {
+    cacheVersion: TRANSLATION_CACHE_VERSION,
+    locale,
+    sourceHash,
+    batchCount,
+    translatedBatches: record.translatedBatches,
+    updatedAt: record.updatedAt,
+  }
+}
+
+function storedTranslatedResponseFrom(value: unknown, locale: Locale): StoredTranslatedResponse | null {
+  const record = recordOf(value)
+  if (!record) return null
+  if (record.cacheVersion !== TRANSLATION_CACHE_VERSION || record.locale !== locale) return null
+  if (typeof record.translatedAt !== 'number' || typeof record.status !== 'number' || typeof record.statusText !== 'string') return null
+  if (!isStringPairArray(record.headers) || typeof record.body !== 'string') return null
+  return {
+    cacheVersion: TRANSLATION_CACHE_VERSION,
+    locale,
+    translatedAt: record.translatedAt,
+    status: record.status,
+    statusText: record.statusText,
+    headers: record.headers,
+    body: record.body,
+  }
+}
+
+async function readPartialTranslationState(env: Env, requestUrl: URL, locale: Locale, sourceHash: string, batchCount: number): Promise<PartialTranslationState | null> {
+  const key = await translationStoreKey('state', requestUrl, locale)
+  const object = await env.TRANSLATION_STORE.get(key)
+  if (!object) return null
+  return partialTranslationStateFrom(parseStoredJson(await object.text()), locale, sourceHash, batchCount)
+}
+
+async function writePartialTranslationState(env: Env, requestUrl: URL, locale: Locale, state: PartialTranslationState): Promise<void> {
+  const key = await translationStoreKey('state', requestUrl, locale)
+  await env.TRANSLATION_STORE.put(key, JSON.stringify(state))
+}
+
+async function deletePartialTranslationState(env: Env, requestUrl: URL, locale: Locale): Promise<void> {
+  const key = await translationStoreKey('state', requestUrl, locale)
+  await env.TRANSLATION_STORE.delete(key)
+}
+
+async function deletePartialTranslationStateSafely(env: Env, requestUrl: URL, locale: Locale): Promise<void> {
+  try {
+    await deletePartialTranslationState(env, requestUrl, locale)
+  } catch (error) {
+    console.error('Failed to delete partial translation state', { pathname: requestUrl.pathname, locale, error: errorMessage(error) })
+  }
+}
+
+async function readStoredTranslatedResponse(env: Env, requestUrl: URL, locale: Locale): Promise<Response | null> {
+  const key = await translationStoreKey('pages', requestUrl, locale)
+  const object = await env.TRANSLATION_STORE.get(key)
+  if (!object) return null
+
+  const stored = storedTranslatedResponseFrom(parseStoredJson(await object.text()), locale)
+  if (!stored) return null
+
+  const headers = new Headers(stored.headers)
+  headers.set('X-Capgo-Translated-At', stored.translatedAt.toString())
+  headers.delete('Content-Length')
+  return new Response(stored.body, {
+    status: stored.status,
+    statusText: stored.statusText,
+    headers,
+  })
+}
+
+async function writeStoredTranslatedResponse(env: Env, requestUrl: URL, locale: Locale, response: Response): Promise<void> {
+  const key = await translationStoreKey('pages', requestUrl, locale)
+  const headers: [string, string][] = []
+  response.headers.forEach((value, name) => {
+    if (name.toLowerCase() !== 'content-length') headers.push([name, value])
+  })
+  const stored: StoredTranslatedResponse = {
+    cacheVersion: TRANSLATION_CACHE_VERSION,
+    locale,
+    translatedAt: readTranslatedAt(response) || Date.now(),
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+    body: await response.text(),
+  }
+  await env.TRANSLATION_STORE.put(key, JSON.stringify(stored))
+}
+
+async function cacheTranslatedResponse(env: Env, requestUrl: URL, locale: Locale, cacheKey: Request, response: Response): Promise<void> {
+  await writeStoredTranslatedResponse(env, requestUrl, locale, response.clone())
+  await caches.default.put(cacheKey, response)
+}
+
 function nextMissingBatchIndex(translatedBatches: string[][], batchCount: number): number {
   for (let index = 0; index < batchCount; index += 1) {
     if (!Array.isArray(translatedBatches[index])) return index
@@ -1126,21 +1278,15 @@ function createTranslatedHtmlResponse(originResponse: Response, translatedHtml: 
   })
 }
 
-async function refreshCacheIncrementally(
-  request: Request,
-  env: Env,
-  requestUrl: URL,
-  locale: Locale,
-  cacheKey: Request,
-  expectedSourceHash?: string,
-  existingTranslatedBatches?: string[][],
-): Promise<boolean> {
+async function refreshCacheIncrementally(request: Request, env: Env, requestUrl: URL, locale: Locale, cacheKey: Request, expectedSourceHash?: string): Promise<boolean> {
   const renderRequest = request.method === 'GET' ? request : new Request(request, { method: 'GET' })
   const source = await loadSourceHtml(renderRequest, env, requestUrl, locale)
   if (source.type === 'response') {
     if (isRedirect(source.response)) {
-      await caches.default.put(cacheKey, toCachedResponse(source.response.clone()))
+      const cachedResponse = toCachedResponse(source.response.clone())
+      await cacheTranslatedResponse(env, requestUrl, locale, cacheKey, cachedResponse)
     }
+    await deletePartialTranslationStateSafely(env, requestUrl, locale)
     return true
   }
 
@@ -1148,13 +1294,18 @@ async function refreshCacheIncrementally(
   if (segments.length === 0) {
     const response = createTranslatedHtmlResponse(source.originResponse, source.sourceHtml, requestUrl, locale)
     const cachedResponse = toCachedResponse(response.clone())
-    await caches.default.put(cacheKey, cachedResponse)
+    await cacheTranslatedResponse(env, requestUrl, locale, cacheKey, cachedResponse)
+    await deletePartialTranslationStateSafely(env, requestUrl, locale)
     return true
   }
 
   const batches = buildBatches(segments)
   const sourceHash = await sha256Hex(`${TRANSLATION_CACHE_VERSION}:${locale}:${source.sourceHtml}`)
-  const translatedBatches = expectedSourceHash === sourceHash && existingTranslatedBatches ? existingTranslatedBatches : []
+  const state = await readPartialTranslationState(env, requestUrl, locale, sourceHash, batches.length)
+  if (expectedSourceHash && expectedSourceHash !== sourceHash) {
+    console.log('Translation source changed during continuation', { pathname: requestUrl.pathname, locale })
+  }
+  const translatedBatches = state?.translatedBatches ?? []
 
   let translatedInThisJob = 0
   let batchIndex = nextMissingBatchIndex(translatedBatches, batches.length)
@@ -1167,13 +1318,20 @@ async function refreshCacheIncrementally(
   }
 
   if (batchIndex < batches.length) {
+    await writePartialTranslationState(env, requestUrl, locale, {
+      cacheVersion: TRANSLATION_CACHE_VERSION,
+      locale,
+      sourceHash,
+      batchCount: batches.length,
+      translatedBatches,
+      updatedAt: Date.now(),
+    })
     await env.TRANSLATION_QUEUE.send({
       url: requestUrl.toString(),
       locale,
       cacheVersion: TRANSLATION_CACHE_VERSION,
       reason: 'continue',
       sourceHash,
-      translatedBatches,
     })
     console.log('Translation queue job continued', { pathname: requestUrl.pathname, locale, batchIndex, batchCount: batches.length })
     return false
@@ -1188,8 +1346,9 @@ async function refreshCacheIncrementally(
   const response = createTranslatedHtmlResponse(source.originResponse, translatedHtml, requestUrl, locale)
   if (response.ok && isHtmlResponse(response)) {
     const cachedResponse = toCachedResponse(response.clone())
-    await caches.default.put(cacheKey, cachedResponse)
+    await cacheTranslatedResponse(env, requestUrl, locale, cacheKey, cachedResponse)
   }
+  await deletePartialTranslationStateSafely(env, requestUrl, locale)
   return true
 }
 
@@ -1255,6 +1414,18 @@ async function processTranslationJob(job: TranslationJob, env: Env): Promise<voi
     if (cachedResponse) {
       const translatedAt = readTranslatedAt(cachedResponse)
       if (Date.now() - translatedAt <= FRESH_MS) {
+        await deletePartialTranslationStateSafely(env, requestUrl, job.locale)
+        completed = true
+        return
+      }
+    }
+
+    const storedResponse = await readStoredTranslatedResponse(env, requestUrl, job.locale)
+    if (storedResponse) {
+      const translatedAt = readTranslatedAt(storedResponse)
+      if (Date.now() - translatedAt <= FRESH_MS) {
+        await caches.default.put(cacheKey, storedResponse.clone())
+        await deletePartialTranslationStateSafely(env, requestUrl, job.locale)
         completed = true
         return
       }
@@ -1267,15 +1438,7 @@ async function processTranslationJob(job: TranslationJob, env: Env): Promise<voi
         'Accept-Language': job.locale,
       },
     })
-    completed = await refreshCacheIncrementally(
-      renderRequest,
-      env,
-      requestUrl,
-      job.locale,
-      cacheKey,
-      job.sourceHash,
-      isStringArrayArray(job.translatedBatches) ? job.translatedBatches : undefined,
-    )
+    completed = await refreshCacheIncrementally(renderRequest, env, requestUrl, job.locale, cacheKey, job.sourceHash)
   } finally {
     if (completed) {
       try {
@@ -1299,6 +1462,17 @@ async function serveTranslated(request: Request, env: Env, requestUrl: URL, loca
       await enqueueTranslationSafely(env, requestUrl, locale, 'stale')
     }
     return withResponseHeaders(cachedResponse, isStale ? 'STALE' : 'HIT', isHead)
+  }
+
+  const storedResponse = await readStoredTranslatedResponse(env, requestUrl, locale)
+  if (storedResponse) {
+    const translatedAt = readTranslatedAt(storedResponse)
+    const isStale = Date.now() - translatedAt > FRESH_MS
+    await caches.default.put(cacheKey, storedResponse.clone())
+    if (isStale) {
+      await enqueueTranslationSafely(env, requestUrl, locale, 'stale')
+    }
+    return withResponseHeaders(storedResponse, isStale ? 'STALE' : 'HIT', isHead)
   }
 
   await enqueueTranslationSafely(env, requestUrl, locale, 'miss')

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -88,6 +88,7 @@ type StoredTranslatedResponse = {
   status: number
   statusText: string
   headers: [string, string][]
+  bodyEncoding: 'text' | 'base64'
   body: string
 }
 type AttributeMatch = {
@@ -159,6 +160,29 @@ const STATIC_PREFIXES = [
   '/status.json',
   '/sponsors.json',
 ]
+const IGNORED_TRANSLATION_QUERY_KEYS = new Set([
+  '_branch_match_id',
+  '_branch_referrer',
+  '_gl',
+  '_hsenc',
+  '_hsmi',
+  'fbclid',
+  'gad_source',
+  'gbraid',
+  'gclid',
+  'igshid',
+  'mc_cid',
+  'mc_eid',
+  'msclkid',
+  'ref',
+  'ref_src',
+  'session',
+  'session_id',
+  'sessionid',
+  'twclid',
+  'wbraid',
+  'yclid',
+])
 
 function escapeHtmlText(value: string): string {
   return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
@@ -311,10 +335,38 @@ function readTranslatedAt(response: Response): number {
   return Number.isFinite(timestamp) ? timestamp : 0
 }
 
+function shouldIgnoreTranslationQueryParam(name: string): boolean {
+  const normalizedName = name.toLowerCase()
+  return normalizedName.startsWith('utm_') || IGNORED_TRANSLATION_QUERY_KEYS.has(normalizedName)
+}
+
+function normalizedTranslationSearchParams(requestUrl: URL): URLSearchParams {
+  const entries: [string, string][] = []
+  requestUrl.searchParams.forEach((value, name) => {
+    if (!shouldIgnoreTranslationQueryParam(name)) entries.push([name, value])
+  })
+
+  entries.sort(([leftName, leftValue], [rightName, rightValue]) => leftName.localeCompare(rightName) || leftValue.localeCompare(rightValue))
+
+  const params = new URLSearchParams()
+  for (const [name, value] of entries) {
+    params.append(name, value)
+  }
+  return params
+}
+
+function applyNormalizedTranslationSearch(targetUrl: URL, requestUrl: URL): void {
+  targetUrl.search = ''
+  const params = normalizedTranslationSearchParams(requestUrl)
+  params.forEach((value, name) => {
+    targetUrl.searchParams.append(name, value)
+  })
+}
+
 function cacheKeyFor(requestUrl: URL, locale: Locale): Request {
   const cacheUrl = new URL(requestUrl)
   cacheUrl.pathname = localizedPath(cacheUrl.pathname, locale)
-  cacheUrl.search = ''
+  applyNormalizedTranslationSearch(cacheUrl, requestUrl)
   cacheUrl.searchParams.set('__capgo_translation_cache', TRANSLATION_CACHE_VERSION)
   return new Request(cacheUrl.toString(), { method: 'GET' })
 }
@@ -322,7 +374,7 @@ function cacheKeyFor(requestUrl: URL, locale: Locale): Request {
 function pendingKeyFor(requestUrl: URL, locale: Locale): Request {
   const pendingUrl = new URL(requestUrl)
   pendingUrl.pathname = localizedPath(pendingUrl.pathname, locale)
-  pendingUrl.search = ''
+  applyNormalizedTranslationSearch(pendingUrl, requestUrl)
   pendingUrl.searchParams.set('__capgo_translation_pending', TRANSLATION_CACHE_VERSION)
   return new Request(pendingUrl.toString(), { method: 'GET' })
 }
@@ -350,7 +402,7 @@ async function putTranslationPendingMarkerSafely(requestUrl: URL, locale: Locale
 function canonicalTranslationStoreUrl(requestUrl: URL, locale: Locale): string {
   const storeUrl = new URL(requestUrl)
   storeUrl.pathname = localizedPath(storeUrl.pathname, locale)
-  storeUrl.search = ''
+  applyNormalizedTranslationSearch(storeUrl, requestUrl)
   storeUrl.hash = ''
   return storeUrl.toString()
 }
@@ -913,6 +965,7 @@ function storedTranslatedResponseFrom(value: unknown, locale: Locale): StoredTra
   if (record.cacheVersion !== TRANSLATION_CACHE_VERSION || record.locale !== locale) return null
   if (typeof record.translatedAt !== 'number' || typeof record.status !== 'number' || typeof record.statusText !== 'string') return null
   if (!isStringPairArray(record.headers) || typeof record.body !== 'string') return null
+  const bodyEncoding = record.bodyEncoding === 'base64' ? 'base64' : 'text'
   return {
     cacheVersion: TRANSLATION_CACHE_VERSION,
     locale,
@@ -920,8 +973,42 @@ function storedTranslatedResponseFrom(value: unknown, locale: Locale): StoredTra
     status: record.status,
     statusText: record.statusText,
     headers: record.headers,
+    bodyEncoding,
     body: record.body,
   }
+}
+
+function bytesToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  for (let index = 0; index < bytes.length; index += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + 0x8000))
+  }
+  return btoa(binary)
+}
+
+function base64ToBytes(value: string): ArrayBuffer {
+  const binary = atob(value)
+  const bytes = new Uint8Array(binary.length)
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index)
+  }
+  return bytes.buffer
+}
+
+function isTextLikeContentType(value: string | null): boolean {
+  const contentType = value?.toLowerCase() ?? ''
+  if (contentType.startsWith('text/')) return true
+  if (contentType.includes('charset=')) return true
+  if (contentType.includes('+json') || contentType.includes('+xml')) return true
+  return (
+    contentType.includes('application/json') ||
+    contentType.includes('application/javascript') ||
+    contentType.includes('application/ld+json') ||
+    contentType.includes('application/xml') ||
+    contentType.includes('application/xhtml+xml') ||
+    contentType.includes('image/svg+xml')
+  )
 }
 
 async function readPartialTranslationState(env: Env, requestUrl: URL, locale: Locale, sourceHash: string, batchCount: number): Promise<PartialTranslationState | null> {
@@ -960,7 +1047,8 @@ async function readStoredTranslatedResponse(env: Env, requestUrl: URL, locale: L
   const headers = new Headers(stored.headers)
   headers.set('X-Capgo-Translated-At', stored.translatedAt.toString())
   headers.delete('Content-Length')
-  return new Response(stored.body, {
+  const body = stored.bodyEncoding === 'base64' ? base64ToBytes(stored.body) : stored.body
+  return new Response(body, {
     status: stored.status,
     statusText: stored.statusText,
     headers,
@@ -980,8 +1068,10 @@ async function writeStoredTranslatedResponse(env: Env, requestUrl: URL, locale: 
     status: response.status,
     statusText: response.statusText,
     headers,
-    body: await response.text(),
+    bodyEncoding: isTextLikeContentType(response.headers.get('Content-Type')) ? 'text' : 'base64',
+    body: '',
   }
+  stored.body = stored.bodyEncoding === 'text' ? await response.text() : bytesToBase64(await response.arrayBuffer())
   await env.TRANSLATION_STORE.put(key, JSON.stringify(stored))
 }
 

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -286,6 +286,10 @@ function isRedirect(response: Response): boolean {
   return response.status >= 300 && response.status < 400 && response.headers.has('Location')
 }
 
+function isStableTerminalResponse(response: Response): boolean {
+  return isRedirect(response) || response.ok || response.status === 404 || response.status === 410
+}
+
 function localizeRedirect(response: Response, requestUrl: URL, locale: Locale): Response {
   const headers = new Headers(response.headers)
   const location = headers.get('Location')
@@ -321,6 +325,26 @@ function pendingKeyFor(requestUrl: URL, locale: Locale): Request {
   pendingUrl.search = ''
   pendingUrl.searchParams.set('__capgo_translation_pending', TRANSLATION_CACHE_VERSION)
   return new Request(pendingUrl.toString(), { method: 'GET' })
+}
+
+async function putTranslationPendingMarker(requestUrl: URL, locale: Locale, reason: TranslationQueueReason): Promise<void> {
+  await caches.default.put(
+    pendingKeyFor(requestUrl, locale),
+    new Response(reason, {
+      headers: {
+        'Cache-Control': `public, max-age=${TRANSLATION_PENDING_SECONDS}`,
+        'X-Capgo-Translation-Pending': reason,
+      },
+    }),
+  )
+}
+
+async function putTranslationPendingMarkerSafely(requestUrl: URL, locale: Locale, reason: TranslationQueueReason): Promise<void> {
+  try {
+    await putTranslationPendingMarker(requestUrl, locale, reason)
+  } catch (error) {
+    console.error('Failed to refresh translated page pending marker', { pathname: requestUrl.pathname, locale, reason, error: errorMessage(error) })
+  }
 }
 
 function canonicalTranslationStoreUrl(requestUrl: URL, locale: Locale): string {
@@ -966,6 +990,14 @@ async function cacheTranslatedResponse(env: Env, requestUrl: URL, locale: Locale
   await caches.default.put(cacheKey, response)
 }
 
+async function repopulateTranslatedPageCacheSafely(cacheKey: Request, response: Response, requestUrl: URL, locale: Locale): Promise<void> {
+  try {
+    await caches.default.put(cacheKey, response)
+  } catch (error) {
+    console.error('Failed to repopulate translated page cache from R2', { pathname: requestUrl.pathname, locale, error: errorMessage(error) })
+  }
+}
+
 function nextMissingBatchIndex(translatedBatches: string[][], batchCount: number): number {
   for (let index = 0; index < batchCount; index += 1) {
     if (!Array.isArray(translatedBatches[index])) return index
@@ -1282,12 +1314,15 @@ async function refreshCacheIncrementally(request: Request, env: Env, requestUrl:
   const renderRequest = request.method === 'GET' ? request : new Request(request, { method: 'GET' })
   const source = await loadSourceHtml(renderRequest, env, requestUrl, locale)
   if (source.type === 'response') {
-    if (isRedirect(source.response)) {
+    if (isStableTerminalResponse(source.response)) {
       const cachedResponse = toCachedResponse(source.response.clone())
       await cacheTranslatedResponse(env, requestUrl, locale, cacheKey, cachedResponse)
+      await deletePartialTranslationStateSafely(env, requestUrl, locale)
+      return true
     }
-    await deletePartialTranslationStateSafely(env, requestUrl, locale)
-    return true
+
+    console.error('Translation source returned transient terminal response', { pathname: requestUrl.pathname, locale, status: source.response.status })
+    return false
   }
 
   const { parts, segments } = collectSegments(source.sourceHtml)
@@ -1326,6 +1361,7 @@ async function refreshCacheIncrementally(request: Request, env: Env, requestUrl:
       translatedBatches,
       updatedAt: Date.now(),
     })
+    await putTranslationPendingMarkerSafely(requestUrl, locale, 'continue')
     await env.TRANSLATION_QUEUE.send({
       url: requestUrl.toString(),
       locale,
@@ -1359,15 +1395,7 @@ async function enqueueTranslation(env: Env, requestUrl: URL, locale: Locale, rea
   try {
     if (await caches.default.match(pendingKey)) return
 
-    await caches.default.put(
-      pendingKey,
-      new Response(reason, {
-        headers: {
-          'Cache-Control': `public, max-age=${TRANSLATION_PENDING_SECONDS}`,
-          'X-Capgo-Translation-Pending': reason,
-        },
-      }),
-    )
+    await putTranslationPendingMarker(requestUrl, locale, reason)
     markedPending = true
   } catch (error) {
     console.error('Failed to mark translated page as pending', { pathname: requestUrl.pathname, locale, reason, error: errorMessage(error) })
@@ -1424,7 +1452,7 @@ async function processTranslationJob(job: TranslationJob, env: Env): Promise<voi
     if (storedResponse) {
       const translatedAt = readTranslatedAt(storedResponse)
       if (Date.now() - translatedAt <= FRESH_MS) {
-        await caches.default.put(cacheKey, storedResponse.clone())
+        await repopulateTranslatedPageCacheSafely(cacheKey, storedResponse.clone(), requestUrl, job.locale)
         await deletePartialTranslationStateSafely(env, requestUrl, job.locale)
         completed = true
         return
@@ -1468,7 +1496,7 @@ async function serveTranslated(request: Request, env: Env, requestUrl: URL, loca
   if (storedResponse) {
     const translatedAt = readTranslatedAt(storedResponse)
     const isStale = Date.now() - translatedAt > FRESH_MS
-    await caches.default.put(cacheKey, storedResponse.clone())
+    await repopulateTranslatedPageCacheSafely(cacheKey, storedResponse.clone(), requestUrl, locale)
     if (isStale) {
       await enqueueTranslationSafely(env, requestUrl, locale, 'stale')
     }

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -15,13 +15,14 @@ type WorkerService = {
   fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>
 }
 
-type TranslationQueueReason = 'miss' | 'stale'
+type TranslationQueueReason = 'miss' | 'stale' | 'continue'
 
 type TranslationJob = {
   url: string
   locale: Locale
   cacheVersion: string
   reason: TranslationQueueReason
+  sourceHash?: string
 }
 
 type QueueBinding<T> = {
@@ -35,6 +36,16 @@ type QueueMessage<T> = {
 type MessageBatch<T> = {
   messages: QueueMessage<T>[]
 }
+
+type PartialTranslationState = {
+  cacheVersion: string
+  sourceHash: string
+  locale: Locale
+  translatedBatches: string[][]
+  updatedAt: number
+}
+
+type SourceHtmlResult = { type: 'response'; response: Response } | { type: 'html'; originResponse: Response; sourceHtml: string }
 
 interface Env {
   AI: AiBinding
@@ -75,10 +86,13 @@ const DEFAULT_MODEL = '@cf/moonshotai/kimi-k2.6'
 const FRESH_MS = 24 * 60 * 60 * 1000
 const CACHE_KEEP_SECONDS = 7 * 24 * 60 * 60
 const TRANSLATION_PENDING_SECONDS = 10 * 60
+const TRANSLATION_PARTIAL_SECONDS = 60 * 60
 const TRANSLATION_CACHE_VERSION = '2026-05-01-kimi-k2.6-v1'
 const CLIENT_NO_STORE = 'no-store, max-age=0, must-revalidate'
 const MAX_HTML_BYTES = 1_500_000
-const MAX_BATCH_CHARS = 6_000
+const MAX_BATCH_CHARS = 1_500
+const MAX_BATCH_ITEMS = 32
+const TRANSLATION_BATCHES_PER_QUEUE_JOB = 1
 
 const LANGUAGE_NAMES: Record<Locale, string> = {
   de: 'German',
@@ -288,6 +302,14 @@ function pendingKeyFor(requestUrl: URL, locale: Locale): Request {
   pendingUrl.search = ''
   pendingUrl.searchParams.set('__capgo_translation_pending', TRANSLATION_CACHE_VERSION)
   return new Request(pendingUrl.toString(), { method: 'GET' })
+}
+
+function partialKeyFor(requestUrl: URL, locale: Locale): Request {
+  const partialUrl = new URL(requestUrl)
+  partialUrl.pathname = localizedPath(partialUrl.pathname, locale)
+  partialUrl.search = ''
+  partialUrl.searchParams.set('__capgo_translation_partial', TRANSLATION_CACHE_VERSION)
+  return new Request(partialUrl.toString(), { method: 'GET' })
 }
 
 function withResponseHeaders(response: Response, cacheState: 'MISS' | 'HIT' | 'STALE' | 'BYPASS', isHead = false): Response {
@@ -582,7 +604,7 @@ function buildBatches(segments: Segment[]): string[][] {
 
   for (const segment of segments) {
     const nextLength = currentLength + segment.text.length
-    if (currentBatch.length > 0 && nextLength > MAX_BATCH_CHARS) {
+    if (currentBatch.length > 0 && (nextLength > MAX_BATCH_CHARS || currentBatch.length >= MAX_BATCH_ITEMS)) {
       batches.push(currentBatch)
       currentBatch = []
       currentLength = 0
@@ -642,6 +664,16 @@ function extractAiText(result: unknown): string {
   }
 
   return extractChoicesText(record.choices)
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return `${error.name}: ${error.message}${error.stack ? `\n${error.stack}` : ''}`
+  if (typeof error === 'string') return error
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
+  }
 }
 
 function stripJsonFence(value: string): string {
@@ -745,15 +777,6 @@ async function translateBatch(env: Env, targetLanguage: string, batch: string[])
   return translated
 }
 
-async function translateSegments(env: Env, locale: Locale, segments: Segment[]): Promise<string[]> {
-  const translations: string[] = []
-  for (const batch of buildBatches(segments)) {
-    const translatedBatch = await translateBatch(env, LANGUAGE_NAMES[locale], batch)
-    translations.push(...translatedBatch)
-  }
-  return translations
-}
-
 function renderTranslatedHtml(parts: HtmlPart[], segments: Segment[], translations: string[]): string {
   return parts
     .map((part) => {
@@ -770,15 +793,75 @@ function renderTranslatedHtml(parts: HtmlPart[], segments: Segment[], translatio
     .join('')
 }
 
-async function translateHtml(env: Env, locale: Locale, html: string): Promise<string> {
-  const { parts, segments } = collectSegments(html)
-  if (segments.length === 0) return html
+function isStringArrayArray(value: unknown): value is string[][] {
+  return Array.isArray(value) && value.every((item) => Array.isArray(item) && item.every((nestedItem) => typeof nestedItem === 'string'))
+}
 
-  const translations = await translateSegments(env, locale, segments)
-  if (translations.length !== segments.length) {
-    throw new Error(`Translation produced ${translations.length} strings for ${segments.length} HTML segments`)
+function partialTranslationStateFrom(value: unknown, locale: Locale, sourceHash: string): PartialTranslationState | null {
+  const record = recordOf(value)
+  if (!record) return null
+  if (record.cacheVersion !== TRANSLATION_CACHE_VERSION || record.locale !== locale || record.sourceHash !== sourceHash) return null
+  if (!isStringArrayArray(record.translatedBatches)) return null
+  return {
+    cacheVersion: TRANSLATION_CACHE_VERSION,
+    sourceHash,
+    locale,
+    translatedBatches: record.translatedBatches,
+    updatedAt: typeof record.updatedAt === 'number' ? record.updatedAt : 0,
   }
-  return renderTranslatedHtml(parts, segments, translations)
+}
+
+async function readPartialTranslationState(requestUrl: URL, locale: Locale, sourceHash: string): Promise<PartialTranslationState | null> {
+  const response = await caches.default.match(partialKeyFor(requestUrl, locale))
+  if (!response) return null
+
+  try {
+    return partialTranslationStateFrom(await response.json(), locale, sourceHash)
+  } catch {
+    return null
+  }
+}
+
+async function writePartialTranslationState(requestUrl: URL, locale: Locale, state: PartialTranslationState): Promise<void> {
+  await caches.default.put(
+    partialKeyFor(requestUrl, locale),
+    new Response(JSON.stringify(state), {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': `public, max-age=${TRANSLATION_PARTIAL_SECONDS}`,
+      },
+    }),
+  )
+}
+
+async function deletePartialTranslationState(requestUrl: URL, locale: Locale): Promise<void> {
+  try {
+    await caches.default.delete(partialKeyFor(requestUrl, locale))
+  } catch (error) {
+    console.error('Failed to clear partial translated page state', { pathname: requestUrl.pathname, locale, error: errorMessage(error) })
+  }
+}
+
+function nextMissingBatchIndex(translatedBatches: string[][], batchCount: number): number {
+  for (let index = 0; index < batchCount; index += 1) {
+    if (!Array.isArray(translatedBatches[index])) return index
+  }
+  return batchCount
+}
+
+function flattenTranslatedBatches(translatedBatches: string[][], batchCount: number): string[] {
+  const translations: string[] = []
+  for (let index = 0; index < batchCount; index += 1) {
+    const batch = translatedBatches[index]
+    if (!Array.isArray(batch)) throw new Error(`Missing translated batch ${index}`)
+    translations.push(...batch)
+  }
+  return translations
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value))
+  return [...new Uint8Array(digest)].map((item) => item.toString(16).padStart(2, '0')).join('')
 }
 
 function setLinkRel(html: string, rel: string, tag: string): string {
@@ -1041,10 +1124,10 @@ function rewriteMetadataAndLinks(html: string, requestUrl: URL, locale: Locale):
   return rewritten
 }
 
-async function buildTranslatedResponse(request: Request, env: Env, requestUrl: URL, locale: Locale): Promise<Response> {
+async function loadSourceHtml(request: Request, env: Env, requestUrl: URL, locale: Locale): Promise<SourceHtmlResult> {
   const originResponse = await fetchEnglishOrigin(request, env, requestUrl)
-  if (isRedirect(originResponse)) return localizeRedirect(originResponse, requestUrl, locale)
-  if (!isHtmlResponse(originResponse) || !originResponse.ok) return originResponse
+  if (isRedirect(originResponse)) return { type: 'response', response: localizeRedirect(originResponse, requestUrl, locale) }
+  if (!isHtmlResponse(originResponse) || !originResponse.ok) return { type: 'response', response: originResponse }
 
   const contentLength = Number.parseInt(originResponse.headers.get('Content-Length') || '0', 10)
   if (Number.isFinite(contentLength) && contentLength > MAX_HTML_BYTES) {
@@ -1056,7 +1139,10 @@ async function buildTranslatedResponse(request: Request, env: Env, requestUrl: U
     throw new Error(`Source HTML is too large to translate after download: ${sourceHtml.length} characters`)
   }
 
-  const translatedHtml = await translateHtml(env, locale, sourceHtml)
+  return { type: 'html', originResponse, sourceHtml }
+}
+
+function createTranslatedHtmlResponse(originResponse: Response, translatedHtml: string, requestUrl: URL, locale: Locale): Response {
   const localizedHtml = rewriteMetadataAndLinks(translatedHtml, requestUrl, locale)
   const headers = new Headers(originResponse.headers)
   headers.set('Content-Type', 'text/html; charset=utf-8')
@@ -1068,14 +1154,74 @@ async function buildTranslatedResponse(request: Request, env: Env, requestUrl: U
   })
 }
 
-async function refreshCache(request: Request, env: Env, requestUrl: URL, locale: Locale, cacheKey: Request): Promise<Response> {
+async function refreshCacheIncrementally(request: Request, env: Env, requestUrl: URL, locale: Locale, cacheKey: Request, expectedSourceHash?: string): Promise<boolean> {
   const renderRequest = request.method === 'GET' ? request : new Request(request, { method: 'GET' })
-  const response = await buildTranslatedResponse(renderRequest, env, requestUrl, locale)
+  const source = await loadSourceHtml(renderRequest, env, requestUrl, locale)
+  if (source.type === 'response') return true
+
+  const { parts, segments } = collectSegments(source.sourceHtml)
+  if (segments.length === 0) {
+    const response = createTranslatedHtmlResponse(source.originResponse, source.sourceHtml, requestUrl, locale)
+    const cachedResponse = toCachedResponse(response.clone())
+    await caches.default.put(cacheKey, cachedResponse)
+    await deletePartialTranslationState(requestUrl, locale)
+    return true
+  }
+
+  const batches = buildBatches(segments)
+  const sourceHash = await sha256Hex(`${TRANSLATION_CACHE_VERSION}:${locale}:${source.sourceHtml}`)
+  if (expectedSourceHash && expectedSourceHash !== sourceHash) {
+    await deletePartialTranslationState(requestUrl, locale)
+  }
+
+  let state = await readPartialTranslationState(requestUrl, locale, sourceHash)
+  if (!state) {
+    state = {
+      cacheVersion: TRANSLATION_CACHE_VERSION,
+      sourceHash,
+      locale,
+      translatedBatches: [],
+      updatedAt: Date.now(),
+    }
+  }
+
+  let translatedInThisJob = 0
+  let batchIndex = nextMissingBatchIndex(state.translatedBatches, batches.length)
+
+  while (batchIndex < batches.length && translatedInThisJob < TRANSLATION_BATCHES_PER_QUEUE_JOB) {
+    const translatedBatch = await translateBatch(env, LANGUAGE_NAMES[locale], batches[batchIndex])
+    state.translatedBatches[batchIndex] = translatedBatch
+    state.updatedAt = Date.now()
+    await writePartialTranslationState(requestUrl, locale, state)
+    translatedInThisJob += 1
+    batchIndex = nextMissingBatchIndex(state.translatedBatches, batches.length)
+  }
+
+  if (batchIndex < batches.length) {
+    await env.TRANSLATION_QUEUE.send({
+      url: requestUrl.toString(),
+      locale,
+      cacheVersion: TRANSLATION_CACHE_VERSION,
+      reason: 'continue',
+      sourceHash,
+    })
+    console.log('Translation queue job continued', { pathname: requestUrl.pathname, locale, batchIndex, batchCount: batches.length })
+    return false
+  }
+
+  const translations = flattenTranslatedBatches(state.translatedBatches, batches.length)
+  if (translations.length !== segments.length) {
+    throw new Error(`Partial translation produced ${translations.length} strings for ${segments.length} HTML segments`)
+  }
+
+  const translatedHtml = renderTranslatedHtml(parts, segments, translations)
+  const response = createTranslatedHtmlResponse(source.originResponse, translatedHtml, requestUrl, locale)
   if (response.ok && isHtmlResponse(response)) {
     const cachedResponse = toCachedResponse(response.clone())
     await caches.default.put(cacheKey, cachedResponse)
   }
-  return response
+  await deletePartialTranslationState(requestUrl, locale)
+  return true
 }
 
 async function enqueueTranslation(env: Env, requestUrl: URL, locale: Locale, reason: TranslationQueueReason): Promise<void> {
@@ -1096,7 +1242,7 @@ async function enqueueTranslation(env: Env, requestUrl: URL, locale: Locale, rea
     )
     markedPending = true
   } catch (error) {
-    console.error('Failed to mark translated page as pending', { pathname: requestUrl.pathname, locale, reason, error })
+    console.error('Failed to mark translated page as pending', { pathname: requestUrl.pathname, locale, reason, error: errorMessage(error) })
   }
 
   try {
@@ -1111,7 +1257,7 @@ async function enqueueTranslation(env: Env, requestUrl: URL, locale: Locale, rea
       try {
         await caches.default.delete(pendingKey)
       } catch (deleteError) {
-        console.error('Failed to clear translated page pending marker after enqueue failure', { pathname: requestUrl.pathname, locale, reason, error: deleteError })
+        console.error('Failed to clear translated page pending marker after enqueue failure', { pathname: requestUrl.pathname, locale, reason, error: errorMessage(deleteError) })
       }
     }
     throw error
@@ -1122,7 +1268,7 @@ async function enqueueTranslationSafely(env: Env, requestUrl: URL, locale: Local
   try {
     await enqueueTranslation(env, requestUrl, locale, reason)
   } catch (error) {
-    console.error('Failed to enqueue translated page', { pathname: requestUrl.pathname, locale, reason, error })
+    console.error('Failed to enqueue translated page', { pathname: requestUrl.pathname, locale, reason, error: errorMessage(error) })
   }
 }
 
@@ -1152,14 +1298,13 @@ async function processTranslationJob(job: TranslationJob, env: Env): Promise<voi
         'Accept-Language': job.locale,
       },
     })
-    await refreshCache(renderRequest, env, requestUrl, job.locale, cacheKey)
-    completed = true
+    completed = await refreshCacheIncrementally(renderRequest, env, requestUrl, job.locale, cacheKey, job.sourceHash)
   } finally {
     if (completed) {
       try {
         await caches.default.delete(pendingKey)
       } catch (error) {
-        console.error('Failed to clear translated page pending marker', { pathname: requestUrl.pathname, locale: job.locale, error })
+        console.error('Failed to clear translated page pending marker', { pathname: requestUrl.pathname, locale: job.locale, error: errorMessage(error) })
       }
     }
   }
@@ -1201,7 +1346,7 @@ export default {
     try {
       return await serveTranslated(request, env, requestUrl, locale)
     } catch (error) {
-      console.error('Translation worker failed', { pathname: requestUrl.pathname, locale, error })
+      console.error('Translation worker failed', { pathname: requestUrl.pathname, locale, error: errorMessage(error) })
       return temporaryEnglishRedirectResponse(requestUrl, request.method === 'HEAD')
     }
   },
@@ -1210,7 +1355,7 @@ export default {
       try {
         await processTranslationJob(message.body, env)
       } catch (error) {
-        console.error('Failed to process translated page queue job', { job: message.body, error })
+        console.error('Failed to process translated page queue job', { job: message.body, error: errorMessage(error) })
         throw error
       }
     }

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -667,7 +667,10 @@ function extractAiText(result: unknown): string {
 }
 
 function errorMessage(error: unknown): string {
-  if (error instanceof Error) return `${error.name}: ${error.message}${error.stack ? `\n${error.stack}` : ''}`
+  if (error instanceof Error) {
+    const base = `${error.name}: ${error.message}`
+    return error.stack ? `${base}\n${error.stack}` : base
+  }
   if (typeof error === 'string') return error
   try {
     return JSON.stringify(error)
@@ -1175,14 +1178,12 @@ async function refreshCacheIncrementally(request: Request, env: Env, requestUrl:
   }
 
   let state = await readPartialTranslationState(requestUrl, locale, sourceHash)
-  if (!state) {
-    state = {
-      cacheVersion: TRANSLATION_CACHE_VERSION,
-      sourceHash,
-      locale,
-      translatedBatches: [],
-      updatedAt: Date.now(),
-    }
+  state ??= {
+    cacheVersion: TRANSLATION_CACHE_VERSION,
+    sourceHash,
+    locale,
+    translatedBatches: [],
+    updatedAt: Date.now(),
   }
 
   let translatedInThisJob = 0

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -1321,8 +1321,7 @@ async function refreshCacheIncrementally(request: Request, env: Env, requestUrl:
       return true
     }
 
-    console.error('Translation source returned transient terminal response', { pathname: requestUrl.pathname, locale, status: source.response.status })
-    return false
+    throw new Error(`Translation source returned transient response: ${source.response.status} ${source.response.statusText}`)
   }
 
   const { parts, segments } = collectSegments(source.sourceHtml)

--- a/apps/translation-worker/wrangler.jsonc
+++ b/apps/translation-worker/wrangler.jsonc
@@ -5,6 +5,9 @@
   "compatibility_date": "2026-05-01",
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": false,
+  "limits": {
+    "cpu_ms": 300000,
+  },
   "ai": {
     "binding": "AI",
   },
@@ -63,6 +66,9 @@
   ],
   "env": {
     "development": {
+      "limits": {
+        "cpu_ms": 300000,
+      },
       "queues": {
         "producers": [
           {

--- a/apps/translation-worker/wrangler.jsonc
+++ b/apps/translation-worker/wrangler.jsonc
@@ -11,6 +11,12 @@
   "ai": {
     "binding": "AI",
   },
+  "r2_buckets": [
+    {
+      "binding": "TRANSLATION_STORE",
+      "bucket_name": "capgo-translation-cache",
+    },
+  ],
   "vars": {
     "TRANSLATION_MODEL": "@cf/moonshotai/kimi-k2.6",
   },
@@ -69,6 +75,18 @@
       "limits": {
         "cpu_ms": 300000,
       },
+      "ai": {
+        "binding": "AI",
+      },
+      "vars": {
+        "TRANSLATION_MODEL": "@cf/moonshotai/kimi-k2.6",
+      },
+      "r2_buckets": [
+        {
+          "binding": "TRANSLATION_STORE",
+          "bucket_name": "capgo-translation-cache-development",
+        },
+      ],
       "queues": {
         "producers": [
           {


### PR DESCRIPTION
## Summary
- split translation queue processing into small persisted batches so slow model calls do not make the whole page job fail before cache write
- store partial translation progress in the server-side cache and enqueue continuation jobs until the full localized page is cached
- add queue CPU headroom and clearer serialized error logging for future Cloudflare logs

## Root cause
The live /id/ page was redirecting to English because the Indonesian translation cache was empty. The queue consumer was failing after ~108s wall time while translating the full page in one invocation, so it never wrote the cached localized HTML. The logged CPU time was only 69ms, so increasing CPU alone would not fix it.

## Validation
- bun run ci:verify:translation
- bunx prettier --check apps/translation-worker/src/index.ts apps/translation-worker/wrangler.jsonc
- cd apps/translation-worker && bunx wrangler deploy --dry-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incremental/resumable HTML translation that persists intermediate batches and continues across background jobs until a final translated page is produced.

* **Refactor**
  * Safer, more efficient batch processing: smaller batches, one-batch-per-job progression, validation of partial state, fresher-serving logic (prefer stored results and repopulate cache), and standardized error logging.

* **Chores**
  * Added persistent translation storage bindings, increased worker execution limits, and CI steps to ensure translation storage buckets exist for deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->