### PR TITLE
[codex] Restore hero headline copy

### DIFF
--- a/apps/shared/copy/messages.ts
+++ b/apps/shared/copy/messages.ts
@@ -1374,7 +1374,7 @@ const messages = {
   instant_updates_for_capacitor_apps: 'Live updates for Capacitor apps',
   instant_updates_for_capacitor_apps_description:
     'When a web-layer bug is live, ship the fix through Capgo instead of waiting days for app store approval. Users get the update in the background while native changes stay in the normal review path.',
-  instant_updates_for_your: 'Ship fixes before app store review ends for your',
+  instant_updates_for_your: 'Ship live updates to your',
   instant_version_switching: 'Instant version switching',
   integrate_identity_provider_mfa: 'Integrate with your identity provider and enforce multi-factor authentication across your organization.',
   integration_and_api: 'Integration & API',


### PR DESCRIPTION
## What changed

- Restored the homepage hero headline copy from `Ship fixes before app store review ends for your` to `Ship live updates to your`.

## Why

- The migration to shared copy introduced weaker App Store wording; this reverts the headline to the previous live-updates message.

## Impact
- Homepage hero copy returns to the prior product positioning without changing layout or behavior.

## Validation

- `bunx prettier --write apps/shared/copy/messages.ts`

- `bun run check`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app messaging to clarify live update capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->