### PR TITLE
docs: remove per-organization SSO flag requirement

### DIFF
--- a/apps/docs/src/content/docs/docs/webapp/enterprise-sso.mdx
+++ b/apps/docs/src/content/docs/docs/webapp/enterprise-sso.mdx
@@ -9,7 +9,7 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 
 <Aside type="caution">
 
-**SSO setup is available on the Enterprise plan only.** Your organization must also have SSO explicitly enabled by Capgo (a per-organization flag). If your org has the SSO flag but is not on Enterprise, the dashboard shows an upgrade prompt instead of the configuration form. If you do not see **SSO configuration** under **Settings → Organization → Security**, contact your Capgo account contact.
+**SSO setup is available on the Enterprise plan only.** If you do not see **SSO configuration** under **Settings → Organization → Security**, ensure your organization is on the Enterprise plan or contact your Capgo account contact.
 
 </Aside>
 
@@ -24,7 +24,6 @@ SSO does not change what users can do. Permissions are controlled by [organizati
 Before starting:
 
 - Enterprise subscription active on the Capgo organization.
-- Capgo has **enabled SSO** for that org.
 - An identity provider that supports **SAML 2.0** and exposes an IdP **metadata URL** (HTTPS).
 - Ability to publish a **DNS TXT record** for the email domain (e.g. `company.com` for users logging in as `user@company.com`).
 - A Capgo organization member with permission to update organization settings.
@@ -38,7 +37,7 @@ Before starting:
 2. Click **Settings** in the left sidebar
 3. Select the **Organization** tab
 4. Select the **Security** tab
-5. Scroll to **SSO configuration**. The form is available only when SSO is enabled for your org and the org is on the Enterprise plan
+5. Scroll to **SSO configuration**. The form is available only when the org is on the Enterprise plan.
 
 </Steps>
 
@@ -127,7 +126,7 @@ Coordinate with your IdP admin and notify all affected users before enabling enf
 
 ## Rollout checklist
 
-- [ ] Enterprise plan confirmed; Capgo has enabled SSO for the org
+- [ ] Enterprise plan confirmed
 - [ ] SAML app created in IdP with ACS URL and Entity ID from Capgo
 - [ ] IdP configured to release a stable email claim
 - [ ] DNS TXT record published and **Verify DNS** succeeded

--- a/apps/docs/src/content/docs/docs/webapp/organization-security.mdx
+++ b/apps/docs/src/content/docs/docs/webapp/organization-security.mdx
@@ -16,7 +16,7 @@ The Organization Security settings allow super admins to configure:
 - **Two-Factor Authentication (2FA) Enforcement** - Require all members to enable 2FA
 - **Password Policy** - Set password complexity requirements
 - **API Key Security** - Enforce secure API keys and expiration policies
-- **SSO (Enterprise only)** - SAML 2.0 single sign-on for your domain. Available on the Enterprise plan when Capgo has enabled SSO for your org. See [SSO setup guide](/docs/webapp/enterprise-sso/).
+- **SSO (Enterprise only)** - SAML 2.0 single sign-on for your domain. Available on the Enterprise plan. See [SSO setup guide](/docs/webapp/enterprise-sso/).
 
 ![Organization Security Settings](/org_security.webp)
 


### PR DESCRIPTION
## Summary

- Supprime les mentions du flag SSO par organisation dans la documentation SSO
- L'accès SSO est désormais conditionné uniquement par le plan Enterprise, sans activation manuelle par Capgo

## Fichiers modifiés

- `apps/docs/src/content/docs/docs/webapp/enterprise-sso.mdx` — avertissement simplifié, prérequis supprimé, texte de localisation et checklist mis à jour
- `apps/docs/src/content/docs/docs/webapp/organization-security.mdx` — mention du flag supprimée

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined Enterprise SSO documentation to clarify that the SSO configuration form is available exclusively for Enterprise-plan organizations.
  * Updated organization security documentation with improved SSO availability descriptions and added links to the SSO setup guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->