### PR TITLE
[codex] Fix hero Capacitor label translation text

### DIFF
--- a/apps/web/src/components/Hero.astro
+++ b/apps/web/src/components/Hero.astro
@@ -183,7 +183,8 @@ const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. $
         <h1 class="font-pj text-4xl leading-tight font-bold tracking-tight sm:text-5xl sm:leading-tight lg:text-6xl lg:leading-tight xl:text-7xl">
           {m.instant_updates_for_your({}, { locale: Astro.locals.locale })}
           <br />
-          <span class="text-azure-500">&lt;CapacitorJS app/&gt;</span>
+          <span class="hero-capacitor-target text-azure-500" aria-hidden="true"></span>
+          <span class="sr-only">CapacitorJS app</span>
         </h1>
         <p class="font-inter mx-auto mt-6 max-w-3xl text-lg leading-8 text-gray-400 sm:text-xl">
           {m.hero_subtitle_part1({}, { locale: Astro.locals.locale })}
@@ -356,3 +357,9 @@ const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. $
     </div>
   </div>
 </section>
+
+<style>
+  .hero-capacitor-target::before {
+    content: '<CapacitorJS app/>';
+  }
+</style>


### PR DESCRIPTION
## Summary
- Move the visible `<CapacitorJS app/>` hero label into CSS generated content so the translation worker no longer treats the escaped angle-bracket text as translatable page copy.
- Keep an `sr-only` plain-text fallback for accessibility without the problematic angle brackets.

## Validation
- `bunx prettier --write apps/web/src/components/Hero.astro`
- `cd apps/web && bun run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Hero component's headline rendering to use CSS-based styling while maintaining the same visual appearance and accessibility standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->