### PR TITLE
[codex] Fix stale translated hero label

### DIFF
--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -146,7 +146,7 @@ const FRESH_MS = 24 * 60 * 60 * 1000
 const CACHE_KEEP_SECONDS = 7 * 24 * 60 * 60
 const TRANSLATION_PENDING_SECONDS = 10 * 60
 const TRANSLATION_COORDINATOR_PENDING_MS = 15 * 60 * 1000
-const TRANSLATION_CACHE_VERSION = '2026-05-02-llama-3.1-8b-json-body-v4'
+const TRANSLATION_CACHE_VERSION = '2026-05-04-llama-3.1-8b-json-body-v5'
 const CLIENT_NO_STORE = 'no-store, max-age=0, must-revalidate'
 const MAX_HTML_BYTES = 1_500_000
 const MAX_BATCH_CHARS = 1_500

--- a/apps/web/src/components/Hero.astro
+++ b/apps/web/src/components/Hero.astro
@@ -183,8 +183,7 @@ const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. $
         <h1 class="font-pj text-4xl leading-tight font-bold tracking-tight sm:text-5xl sm:leading-tight lg:text-6xl lg:leading-tight xl:text-7xl">
           {m.instant_updates_for_your({}, { locale: Astro.locals.locale })}
           <br />
-          <span class="hero-capacitor-target text-azure-500" aria-hidden="true"></span>
-          <span class="sr-only">CapacitorJS app</span>
+          <span class="text-azure-500">CapacitorJS app</span>
         </h1>
         <p class="font-inter mx-auto mt-6 max-w-3xl text-lg leading-8 text-gray-400 sm:text-xl">
           {m.hero_subtitle_part1({}, { locale: Astro.locals.locale })}
@@ -357,9 +356,3 @@ const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. $
     </div>
   </div>
 </section>
-
-<style>
-  .hero-capacitor-target::before {
-    content: '<CapacitorJS app/>';
-  }
-</style>


### PR DESCRIPTION
## Summary
- replace the hero angle-bracket label workaround with plain visible text
- bump the translation worker cache namespace so stale translated HTML is regenerated

## Root cause
Production was still serving an old translated-page cache for /id/ (`x-capgo-translation-cache: STALE`) that contained the previous hero markup. The source-only fix could not invalidate that stored HTML.

## Validation
- bunx prettier --write apps/web/src/components/Hero.astro apps/translation-worker/src/index.ts
- apps/web: bun run check
- bun run ci:verify:translation
- apps/web: bun run build
- apps/translation-worker: bunx wrangler deploy --dry-run
- verified built index has no hero-capacitor-target, no &lt;CapacitorJS app/&gt;, and no literal <CapacitorJS app/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated translation cache configuration to a new cache version for more consistent translated content delivery.
  * Simplified the hero headline markup so the "CapacitorJS app" text is rendered directly, improving accessibility and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->