### PR TITLE
[codex] Add Capgo Build callouts to Fastlane guides

### DIFF
--- a/apps/web/src/content/blog/en/automatic-capacitor-android-build-github-action.md
+++ b/apps/web/src/content/blog/en/automatic-capacitor-android-build-github-action.md
@@ -8,7 +8,7 @@ author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2022-10-27T00:00:00.000Z
-updated_at: 2026-04-08T14:34:13.000Z
+updated_at: 2026-05-05T00:00:00.000Z
 head_image: /fastlane_android.webp
 head_image_alt: Fastlane Google play GitHub action illustration
 keywords: Fastlane, CI/CD, Android, automatic build, automatic release, mobile app updates, Capacitor
@@ -19,6 +19,11 @@ next_blog: automatic-capacitor-ios-build-github-action
 ---
 
 Setting up CI/CD for Capacitor apps can be complex and time-consuming. Here's what you need to know:
+
+## Recommended for New Builds: Use Capgo Build
+
+> **We now recommend using [Capgo Build with the Capgo CLI](/docs/cli/cloud-build/) for native Capacitor builds.**
+> This Fastlane guide is kept for teams maintaining existing GitHub Actions pipelines, but new Android builds should use the Capgo CLI so you do not have to maintain Fastlane, Gradle runners, keystores, and upload scripts yourself.
 
 ## Prerequisites
 

--- a/apps/web/src/content/blog/en/automatic-capacitor-ios-build-github-action-with-match.md
+++ b/apps/web/src/content/blog/en/automatic-capacitor-ios-build-github-action-with-match.md
@@ -8,7 +8,7 @@ author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2022-10-30T00:00:00.000Z
-updated_at: 2026-04-08T14:34:13.000Z
+updated_at: 2026-05-05T00:00:00.000Z
 head_image: /fastlane_ios.webp
 head_image_alt: Fastlane testflight GitHub action illustration
 keywords: Fastlane, CI/CD, iOS, automatic build, automatic release, mobile app updates
@@ -21,6 +21,11 @@ next_blog: automatic-capacitor-android-build-github-action
 # Automatic iOS Builds with GitHub Actions using Match
 
 Setting up CI/CD for Capacitor apps can be complex and time-consuming. Here's what you need to know:
+
+## Recommended for New Builds: Use Capgo Build
+
+> **We now recommend using [Capgo Build with the Capgo CLI](/docs/cli/cloud-build/) for native Capacitor builds.**
+> This Fastlane Match guide is kept for teams maintaining existing GitHub Actions pipelines, but new iOS builds should use the Capgo CLI so you do not have to maintain Fastlane, Match repositories, Xcode runners, certificates, and upload scripts yourself.
 
 ## Prerequisites
 

--- a/apps/web/src/content/blog/en/automatic-capacitor-ios-build-github-action.md
+++ b/apps/web/src/content/blog/en/automatic-capacitor-ios-build-github-action.md
@@ -8,7 +8,7 @@ author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2024-08-04T00:00:00.000Z
-updated_at: 2026-04-08T14:34:13.000Z
+updated_at: 2026-05-05T00:00:00.000Z
 head_image: /fastlane_ios.webp
 head_image_alt: Fastlane testflight GitHub action illustration
 keywords: Fastlane, CI/CD, iOS, automatic build, automatic release, mobile app updates
@@ -19,6 +19,11 @@ next_blog: automatic-capacitor-android-build-github-action
 ---
 
 Setting up CI/CD for Capacitor apps can be complex and time-consuming. Here's what you need to know:
+
+## Recommended for New Builds: Use Capgo Build
+
+> **We now recommend using [Capgo Build with the Capgo CLI](/docs/cli/cloud-build/) for native Capacitor builds.**
+> This Fastlane guide is kept for teams maintaining existing GitHub Actions pipelines, but new iOS builds should use the Capgo CLI so you do not have to maintain Fastlane, Xcode runners, certificates, and upload scripts yourself.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

- Add a visible recommendation to use Capgo Build with the Capgo CLI at the top of the Fastlane GitHub Actions articles.
- Mark the Fastlane setup content as legacy guidance for teams maintaining existing pipelines.
- Update article `updated_at` metadata for the touched posts.

## Impact

Readers starting a new native Capacitor build flow are directed to the current Capgo Build CLI docs before following the older Fastlane setup.

## Validation

- `bunx prettier --write apps/web/src/content/blog/en/automatic-capacitor-ios-build-github-action.md apps/web/src/content/blog/en/automatic-capacitor-android-build-github-action.md apps/web/src/content/blog/en/automatic-capacitor-ios-build-github-action-with-match.md`
- `NODE_OPTIONS=--max-old-space-size=16384 bun run check` in `apps/web`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Capacitor Android and iOS build guides.
  * Added recommendations for new builds to use Capgo CLI instead of Fastlane.
  * Clarified that existing Fastlane guides are for teams maintaining current pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->