### PR TITLE
[codex] add install referrer plugin docs

### DIFF
--- a/apps/docs/src/config/llmsCustomSets.ts
+++ b/apps/docs/src/config/llmsCustomSets.ts
@@ -46,6 +46,7 @@ Plugin iBeacon|iBeacon proximity detection plugin|docs/plugins/ibeacon/**
 Plugin InAppBrowser|in-app browser plugin for opening web content|docs/plugins/inappbrowser/**
 Plugin In App Review|in-app review prompt plugin for app store ratings|docs/plugins/in-app-review/**
 Plugin Incoming Call Kit|native incoming call presentation with iOS CallKit and Android full-screen notifications|docs/plugins/incoming-call-kit/**
+Plugin Install Referrer|install attribution plugin for Google Play Install Referrer and Apple AdServices|docs/plugins/install-referrer/**
 Plugin Intent Launcher|Android intent launcher plugin|docs/plugins/intent-launcher/**
 Plugin Intercom|Intercom customer messaging and support plugin for native in-app chat|docs/plugins/intercom/**
 Plugin Is Root|root/jailbreak detection plugin|docs/plugins/is-root/**

--- a/apps/docs/src/config/sidebar.mjs
+++ b/apps/docs/src/config/sidebar.mjs
@@ -104,6 +104,11 @@ const pluginEntries = [
   ['In App Review', 'in-app-review'],
   ['InAppBrowser', 'inappbrowser'],
   ['Incoming Call Kit', 'incoming-call-kit', [linkItem('iOS', '/docs/plugins/incoming-call-kit/ios'), linkItem('Android', '/docs/plugins/incoming-call-kit/android')]],
+  [
+    'Install Referrer',
+    'install-referrer',
+    [linkItem('iOS attribution', '/docs/plugins/install-referrer/ios'), linkItem('Android referrer', '/docs/plugins/install-referrer/android')],
+  ],
   ['Intent Launcher', 'intent-launcher'],
   ['Intercom', 'intercom'],
   ['Is Root', 'is-root'],

--- a/apps/docs/src/content/docs/docs/plugins/install-referrer/android.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/install-referrer/android.mdx
@@ -1,0 +1,39 @@
+---
+title: Android Referrer
+description: "Android behavior for @capgo/capacitor-install-referrer."
+sidebar:
+  order: 3
+---
+
+## Google Play Install Referrer
+
+On Android, `getReferrer()` connects to the Google Play Install Referrer service and returns data from the Play Store install record.
+
+```typescript
+const result = await InstallReferrer.getReferrer();
+
+console.log(result.referrer);
+console.log(result.clickTimestampSeconds);
+console.log(result.installBeginTimestampSeconds);
+console.log(result.googlePlayInstantParam);
+```
+
+## Returned Fields
+
+| Field | Description |
+| --- | --- |
+| `platform` | Always `android`. |
+| `referrer` | Raw Play install referrer string. |
+| `clickTimestampSeconds` | Client-side referrer click timestamp in seconds. |
+| `installBeginTimestampSeconds` | Client-side install begin timestamp in seconds. |
+| `googlePlayInstantParam` | Whether the user launched the app's instant experience. |
+
+## Requirements
+
+- The app must be installed from Google Play for real install referrer data.
+- The device must have a Play Store version that supports the Install Referrer service.
+- No Android runtime permission is required.
+
+## Error Cases
+
+The plugin rejects when the Play Store service is unavailable, unsupported, disconnected before returning a result, or returns an unexpected response.

--- a/apps/docs/src/content/docs/docs/plugins/install-referrer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/install-referrer/getting-started.mdx
@@ -45,10 +45,12 @@ const result = await InstallReferrer.getReferrer({
   appleAttributionRetryDelayMs: 5000,
 });
 
+// result.appleAttribution is the parsed Apple attribution response.
+// See the iOS attribution page for the Apple-provided payload fields.
 console.log(result.appleAttribution);
 ```
 
-Apple can return `404` while attribution data is still being prepared for a valid token. The retry options control how often the native plugin retries before rejecting.
+Apple can return `404` while attribution data is still being prepared for a valid token. The retry options control how often the native plugin retries before rejecting. See [iOS attribution](/docs/plugins/install-referrer/ios/) for platform details.
 
 ## Compatibility Alias
 

--- a/apps/docs/src/content/docs/docs/plugins/install-referrer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/install-referrer/getting-started.mdx
@@ -1,0 +1,61 @@
+---
+title: Getting Started
+description: "Install @capgo/capacitor-install-referrer and read install attribution data in a Capacitor app."
+sidebar:
+  order: 2
+---
+
+## Install
+
+```bash
+bun add @capgo/capacitor-install-referrer
+bunx cap sync
+```
+
+## Import
+
+```typescript
+import { InstallReferrer } from '@capgo/capacitor-install-referrer';
+```
+
+## Read Attribution Details
+
+```typescript
+const result = await InstallReferrer.getReferrer();
+
+if (result.platform === 'android') {
+  console.log('Install referrer:', result.referrer);
+  console.log('Click timestamp:', result.clickTimestampSeconds);
+  console.log('Install timestamp:', result.installBeginTimestampSeconds);
+}
+
+if (result.platform === 'ios') {
+  console.log('AdServices token:', result.attributionToken);
+}
+```
+
+## Fetch Apple Attribution On iOS
+
+If you want native code to call Apple's attribution endpoint, pass `fetchAppleAttribution`.
+
+```typescript
+const result = await InstallReferrer.getReferrer({
+  fetchAppleAttribution: true,
+  appleAttributionRetryCount: 3,
+  appleAttributionRetryDelayMs: 5000,
+});
+
+console.log(result.appleAttribution);
+```
+
+Apple can return `404` while attribution data is still being prepared for a valid token. The retry options control how often the native plugin retries before rejecting.
+
+## Compatibility Alias
+
+`GetReferrer()` is available for apps migrating from `cap-play-install-referrer`.
+
+```typescript
+const result = await InstallReferrer.GetReferrer();
+```
+
+New code should use `getReferrer()`.

--- a/apps/docs/src/content/docs/docs/plugins/install-referrer/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/install-referrer/index.mdx
@@ -1,0 +1,54 @@
+---
+title: "@capgo/capacitor-install-referrer"
+description: "Install attribution for Capacitor apps using Google Play Install Referrer and Apple AdServices."
+tableOfContents: false
+next: false
+prev: false
+sidebar:
+  order: 1
+  label: "Introduction"
+hero:
+  tagline: "Read Android Play install referrer data and iOS Apple AdServices attribution tokens from Capacitor."
+  actions:
+    - text: Get started
+      link: /docs/plugins/install-referrer/getting-started/
+      icon: right-arrow
+      variant: primary
+    - text: GitHub
+      link: https://github.com/Cap-go/capacitor-install-referrer/
+      icon: external
+      variant: minimal
+---
+
+## Overview
+
+`@capgo/capacitor-install-referrer` exposes install attribution signals through one Capacitor API.
+
+On Android, it reads Google Play Install Referrer details: the raw referrer string, click timestamp, install timestamp, and instant app flag. On iOS, it returns an Apple AdServices attribution token and can optionally call Apple's AdServices attribution endpoint for Apple Search Ads attribution data.
+
+## Core Capabilities
+
+- `getReferrer` - Return native install attribution details for the current platform.
+- `GetReferrer` - Deprecated compatibility alias for apps migrating from `cap-play-install-referrer`.
+- `getPluginVersion` - Return the native plugin implementation version marker.
+- Optional iOS Apple attribution lookup with retry support for delayed AdServices responses.
+
+## Platform Support
+
+| Platform | Support |
+| --- | --- |
+| Android | Google Play Install Referrer API |
+| iOS | Apple AdServices attribution token and optional Apple attribution payload |
+| Web | Unsupported stub |
+
+## Public API
+
+| Method | Description |
+| --- | --- |
+| `getReferrer(options?)` | Return install attribution details for Android or iOS. |
+| `GetReferrer(options?)` | Deprecated compatibility alias for `getReferrer`. |
+| `getPluginVersion()` | Return the native plugin version marker. |
+
+## Source Of Truth
+
+This reference is synced from `src/definitions.ts` in [capacitor-install-referrer](https://github.com/Cap-go/capacitor-install-referrer/).

--- a/apps/docs/src/content/docs/docs/plugins/install-referrer/ios.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/install-referrer/ios.mdx
@@ -1,0 +1,45 @@
+---
+title: iOS Attribution
+description: "iOS behavior for @capgo/capacitor-install-referrer with Apple AdServices."
+sidebar:
+  order: 4
+---
+
+## Apple AdServices
+
+Apple does not provide a generic App Store install referrer equivalent to Google Play Install Referrer. On iOS, this plugin uses Apple AdServices attribution.
+
+By default, `getReferrer()` returns an AdServices attribution token that you can send to your backend or mobile measurement partner.
+
+```typescript
+const result = await InstallReferrer.getReferrer();
+console.log(result.attributionToken);
+```
+
+## Native Apple Attribution Lookup
+
+The plugin can also send the token to Apple's AdServices endpoint from native code.
+
+```typescript
+const result = await InstallReferrer.getReferrer({
+  fetchAppleAttribution: true,
+});
+
+console.log(result.appleAttribution);
+```
+
+Use this mode when the app itself should receive Apple's attribution payload. Keep `fetchAppleAttribution` false when your backend or attribution provider should exchange the token.
+
+## Returned Fields
+
+| Field | Description |
+| --- | --- |
+| `platform` | Always `ios`. |
+| `attributionToken` | Apple AdServices attribution token. |
+| `appleAttribution` | Optional Apple attribution payload when `fetchAppleAttribution` is true. |
+
+## Requirements
+
+- Apple AdServices attribution tokens are available on iOS 14.3 and later.
+- The attribution payload covers Apple Search Ads attribution, not arbitrary App Store referrer URLs.
+- No App Tracking Transparency prompt is required just to request the AdServices attribution token.

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -96,6 +96,7 @@ const actionDefinitionRows =
 @capgo/capacitor-persona|github.com/Cap-go|Launch Persona identity verification inquiries with native iOS and Android SDKs|https://github.com/Cap-go/capacitor-persona/|Persona
 @capgo/capacitor-intune|github.com/Cap-go|Microsoft Intune MAM, app protection policy, app config, and MSAL authentication for Capacitor|https://github.com/Cap-go/capacitor-intune/|Intune
 @capgo/capacitor-incoming-call-kit|github.com/Cap-go|Present native incoming-call UI with iOS CallKit and Android full-screen notifications|https://github.com/Cap-go/capacitor-incoming-call-kit/|Incoming Call Kit
+@capgo/capacitor-install-referrer|github.com/Cap-go|Read Google Play install referrer data and Apple AdServices attribution from Capacitor|https://github.com/Cap-go/capacitor-install-referrer/|Install Referrer
 @capgo/capacitor-android-age-signals|github.com/Cap-go|Google Play Age Signals API wrapper - detect supervised accounts and verified users|https://github.com/Cap-go/capacitor-android-age-signals/|Age Signals
 @capgo/capacitor-barometer|github.com/Cap-go|Access device barometer for atmospheric pressure and altitude readings|https://github.com/Cap-go/capacitor-barometer/|Barometer
 @capgo/capacitor-accelerometer|github.com/Cap-go|Read device accelerometer for motion detection and orientation tracking|https://github.com/Cap-go/capacitor-accelerometer/|Accelerometer
@@ -222,6 +223,7 @@ const pluginIconsByName: Record<string, string> = {
   '@capgo/capacitor-persona': 'UserCircle',
   '@capgo/capacitor-intune': 'ShieldCheck',
   '@capgo/capacitor-incoming-call-kit': 'Phone',
+  '@capgo/capacitor-install-referrer': 'Tag',
   '@capgo/capacitor-android-age-signals': 'UserGroup',
   '@capgo/capacitor-barometer': 'ChartBar',
   '@capgo/capacitor-accelerometer': 'ArrowsPointingOut',

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-install-referrer.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-install-referrer.md
@@ -1,0 +1,59 @@
+---
+locale: en
+---
+# Using @capgo/capacitor-install-referrer
+
+`@capgo/capacitor-install-referrer` reads install attribution signals in Capacitor apps.
+
+Use it when you need Google Play Install Referrer data on Android and Apple AdServices attribution tokens on iOS through one API.
+
+## Install
+
+```bash
+bun add @capgo/capacitor-install-referrer
+bunx cap sync
+```
+
+## What This Plugin Exposes
+
+- `getReferrer` returns install attribution details for Android or iOS.
+- `GetReferrer` is a deprecated compatibility alias for migration from `cap-play-install-referrer`.
+- Android returns the Play referrer string, click timestamp, install timestamp, and instant app flag.
+- iOS returns an AdServices attribution token and can optionally fetch Apple's attribution payload.
+
+## Example Usage
+
+```typescript
+import { InstallReferrer } from '@capgo/capacitor-install-referrer';
+
+const result = await InstallReferrer.getReferrer();
+
+if (result.platform === 'android') {
+  console.log(result.referrer);
+}
+
+if (result.platform === 'ios') {
+  console.log(result.attributionToken);
+}
+```
+
+## Apple Attribution Payload
+
+```typescript
+const result = await InstallReferrer.getReferrer({
+  fetchAppleAttribution: true,
+  appleAttributionRetryCount: 3,
+  appleAttributionRetryDelayMs: 5000,
+});
+
+console.log(result.appleAttribution);
+```
+
+## Platform Notes
+
+Android uses the Google Play Install Referrer service and requires a Play Store install for real referrer data. iOS uses Apple AdServices because Apple does not provide a generic App Store install referrer equivalent.
+
+## Full Reference
+
+- GitHub: https://github.com/Cap-go/capacitor-install-referrer/
+- Docs: /docs/plugins/install-referrer/

--- a/apps/web/src/data/github-stars.json
+++ b/apps/web/src/data/github-stars.json
@@ -75,6 +75,7 @@
   "https://github.com/Cap-go/capacitor-persona/": 2,
   "https://github.com/Cap-go/capacitor-intune/": 1,
   "https://github.com/Cap-go/capacitor-incoming-call-kit/": 2,
+  "https://github.com/Cap-go/capacitor-install-referrer/": 0,
   "https://github.com/Cap-go/capacitor-android-age-signals/": 5,
   "https://github.com/Cap-go/capacitor-barometer/": 5,
   "https://github.com/Cap-go/capacitor-accelerometer/": 5,

--- a/apps/web/src/data/npm-downloads.json
+++ b/apps/web/src/data/npm-downloads.json
@@ -75,6 +75,7 @@
   "@capgo/capacitor-persona": 356,
   "@capgo/capacitor-intune": 268,
   "@capgo/capacitor-incoming-call-kit": 481,
+  "@capgo/capacitor-install-referrer": 0,
   "@capgo/capacitor-android-age-signals": 674,
   "@capgo/capacitor-barometer": 3227,
   "@capgo/capacitor-accelerometer": 2223,


### PR DESCRIPTION
## What

Adds the new `@capgo/capacitor-install-referrer` plugin to the website registry, plugin docs sidebar, LLM docs sets, metadata files, and English tutorial content.

## Why

The plugin is now published in the Cap-go GitHub org and needs website/docs coverage for Android Google Play Install Referrer and iOS Apple AdServices attribution support.

## Validation

- `bunx prettier --write apps/web/src/config/plugins.ts apps/docs/src/config/sidebar.mjs apps/docs/src/config/llmsCustomSets.ts apps/docs/src/content/docs/docs/plugins/install-referrer/index.mdx apps/docs/src/content/docs/docs/plugins/install-referrer/getting-started.mdx apps/docs/src/content/docs/docs/plugins/install-referrer/android.mdx apps/docs/src/content/docs/docs/plugins/install-referrer/ios.mdx apps/web/src/content/plugins-tutorials/en/capacitor-install-referrer.md apps/web/src/data/github-stars.json apps/web/src/data/npm-downloads.json`
- `bun run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for the capacitor-install-referrer plugin, including overview, installation, usage examples, platform-specific pages for Android and iOS attribution, and a tutorials/reference page.

* **Chores**
  * Updated site/plugin registry, sidebar and plugin listings to include Install Referrer; added plugin icon and updated public package metadata (npm/github entries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->