### PR TITLE
[codex] fix translated internal links

### DIFF
--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -59,14 +59,16 @@ const localizedLinksHtml = __translationWorkerTest.rewriteMetadataAndLinks(
   `<!doctype html>
 <html lang="en">
   <head>
-    <link rel="canonical" href="https://capgo.app/blog/post" />
-    <meta property="og:url" content="https://capgo.app/blog/post" />
+    <link rel="canonical" href="https://capgo.app/pricing" />
+    <meta property="og:url" content="https://capgo.app/pricing" />
   </head>
   <body>
     <a href="/pricing">Pricing</a>
+    <a href="/es/pricing">Spanish pricing</a>
     <a href="https://capgo.app/docs/">Docs</a>
+    <a href="https://capgo.app/de/docs/">German docs</a>
     <a href="//capgo.app/plugins">Plugins</a>
-    <a href="features">Features</a>
+    <a href="support-policy">Support policy</a>
     <a href="/#faq">FAQ</a>
     <a href="#local">Local anchor</a>
     <a href="https://github.com/Cap-go/capgo">GitHub</a>
@@ -75,15 +77,17 @@ const localizedLinksHtml = __translationWorkerTest.rewriteMetadataAndLinks(
     <form action="/register"></form>
   </body>
 </html>`,
-  new URL('https://capgo.app/fr/blog/post?ref=nav'),
+  new URL('https://capgo.app/fr/pricing?ref=nav'),
   'fr',
 )
-assert(localizedLinksHtml.includes('hreflang="en" href="https://capgo.app/blog/post"'), 'Link rewrite changed the English hreflang alternate')
-assert(localizedLinksHtml.includes('hreflang="fr" href="https://capgo.app/fr/blog/post"'), 'Link rewrite changed the French hreflang alternate')
+assert(localizedLinksHtml.includes('hreflang="en" href="https://capgo.app/pricing"'), 'Link rewrite changed the English hreflang alternate')
+assert(localizedLinksHtml.includes('hreflang="fr" href="https://capgo.app/fr/pricing"'), 'Link rewrite changed the French hreflang alternate')
 assert(localizedLinksHtml.includes('href="/fr/pricing"'), 'Link rewrite did not localize root-relative internal links')
+assert(localizedLinksHtml.includes('href="/es/pricing"'), 'Link rewrite changed an already localized root-relative link')
+assert(localizedLinksHtml.includes('href="https://capgo.app/de/docs/"'), 'Link rewrite changed an already localized absolute same-site link')
 assert(localizedLinksHtml.includes('href="https://capgo.app/fr/docs/"'), 'Link rewrite did not localize absolute same-site links')
 assert(localizedLinksHtml.includes('href="//capgo.app/fr/plugins"'), 'Link rewrite did not localize protocol-relative same-site links')
-assert(localizedLinksHtml.includes('href="/fr/blog/features"'), 'Link rewrite did not localize relative internal links')
+assert(localizedLinksHtml.includes('href="/fr/support-policy"'), 'Link rewrite did not localize relative internal links')
 assert(localizedLinksHtml.includes('href="/fr/#faq"'), 'Link rewrite did not localize root anchor links')
 assert(localizedLinksHtml.includes('href="#local"'), 'Link rewrite changed same-page anchors')
 assert(localizedLinksHtml.includes('href="https://github.com/Cap-go/capgo"'), 'Link rewrite changed an external URL')

--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -78,6 +78,8 @@ const localizedLinksHtml = __translationWorkerTest.rewriteMetadataAndLinks(
   new URL('https://capgo.app/fr/blog/post?ref=nav'),
   'fr',
 )
+assert(localizedLinksHtml.includes('hreflang="en" href="https://capgo.app/blog/post"'), 'Link rewrite changed the English hreflang alternate')
+assert(localizedLinksHtml.includes('hreflang="fr" href="https://capgo.app/fr/blog/post"'), 'Link rewrite changed the French hreflang alternate')
 assert(localizedLinksHtml.includes('href="/fr/pricing"'), 'Link rewrite did not localize root-relative internal links')
 assert(localizedLinksHtml.includes('href="https://capgo.app/fr/docs/"'), 'Link rewrite did not localize absolute same-site links')
 assert(localizedLinksHtml.includes('href="//capgo.app/fr/plugins"'), 'Link rewrite did not localize protocol-relative same-site links')

--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -55,6 +55,40 @@ const rendered = __translationWorkerTest.renderTranslatedHtml(parts, segments, t
 assert(rendered.includes('FR: Ship mobile updates instantly to every user'), 'Renderer did not write translated body text')
 assert(rendered.includes('current < total'), 'Renderer changed skipped script content')
 
+const localizedLinksHtml = __translationWorkerTest.rewriteMetadataAndLinks(
+  `<!doctype html>
+<html lang="en">
+  <head>
+    <link rel="canonical" href="https://capgo.app/blog/post" />
+    <meta property="og:url" content="https://capgo.app/blog/post" />
+  </head>
+  <body>
+    <a href="/pricing">Pricing</a>
+    <a href="https://capgo.app/docs/">Docs</a>
+    <a href="//capgo.app/plugins">Plugins</a>
+    <a href="features">Features</a>
+    <a href="/#faq">FAQ</a>
+    <a href="#local">Local anchor</a>
+    <a href="https://github.com/Cap-go/capgo">GitHub</a>
+    <a href="mailto:hello@capgo.app">Email</a>
+    <a href="/images/logo.png">Logo</a>
+    <form action="/register"></form>
+  </body>
+</html>`,
+  new URL('https://capgo.app/fr/blog/post?ref=nav'),
+  'fr',
+)
+assert(localizedLinksHtml.includes('href="/fr/pricing"'), 'Link rewrite did not localize root-relative internal links')
+assert(localizedLinksHtml.includes('href="https://capgo.app/fr/docs/"'), 'Link rewrite did not localize absolute same-site links')
+assert(localizedLinksHtml.includes('href="//capgo.app/fr/plugins"'), 'Link rewrite did not localize protocol-relative same-site links')
+assert(localizedLinksHtml.includes('href="/fr/blog/features"'), 'Link rewrite did not localize relative internal links')
+assert(localizedLinksHtml.includes('href="/fr/#faq"'), 'Link rewrite did not localize root anchor links')
+assert(localizedLinksHtml.includes('href="#local"'), 'Link rewrite changed same-page anchors')
+assert(localizedLinksHtml.includes('href="https://github.com/Cap-go/capgo"'), 'Link rewrite changed an external URL')
+assert(localizedLinksHtml.includes('href="mailto:hello@capgo.app"'), 'Link rewrite changed a mail link')
+assert(localizedLinksHtml.includes('href="/images/logo.png"'), 'Link rewrite changed an asset URL')
+assert(localizedLinksHtml.includes('action="/fr/register"'), 'Link rewrite did not localize internal form actions')
+
 function coordinatorRequest(body: unknown, path = '/enqueue'): Request {
   return new Request(`https://translation-coordinator${path}`, {
     method: 'POST',

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -327,6 +327,16 @@ function isHttpUrl(value: string): boolean {
   return /^https?:/i.test(value)
 }
 
+function pathnameHasLocalePrefix(pathname: string): boolean {
+  const normalizedPathname = normalizePathname(pathname)
+  return ALL_LOCALES.some((locale) => normalizedPathname === `/${locale}` || normalizedPathname.startsWith(`/${locale}/`))
+}
+
+function hasExplicitLocalePath(value: string, url: URL): boolean {
+  if (!value.startsWith('/') && !value.startsWith('//') && !isHttpUrl(value)) return false
+  return pathnameHasLocalePrefix(url.pathname)
+}
+
 function localizeHref(value: string, locale: Locale, requestUrl: URL): string {
   const trimmed = value.trim()
   if (!trimmed || trimmed.startsWith('#')) return value
@@ -340,6 +350,7 @@ function localizeHref(value: string, locale: Locale, requestUrl: URL): string {
   }
 
   if (url.host !== requestUrl.host) return value
+  if (hasExplicitLocalePath(trimmed, url)) return value
   if (shouldBypassTranslation(url.pathname)) return value
 
   url.pathname = localizedPath(url.pathname, locale)

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -1697,11 +1697,14 @@ function localizeTagUrlAttributes(tag: string, locale: Locale, basePath: string,
   let rewritten = ''
   let lastIndex = 0
   let changed = false
+  const tagName = tagNameOf(tag)
   const targetLanguageLocale = languageSelectorTargetLocale(tag)
+  const isAlternateLink = tagName === 'link' && (readAttributeValue(tag, 'rel') || '').toLowerCase().split(/\s+/).includes('alternate')
 
   for (const attribute of collectQuotedAttributes(tag)) {
     const name = attribute.name.toLowerCase()
     if (name !== 'href' && name !== 'action') continue
+    if (name === 'href' && isAlternateLink) continue
 
     const localized =
       name === 'href' && targetLanguageLocale ? `${localizedPath(basePath, targetLanguageLocale)}${requestUrl.search}` : localizeHref(attribute.value, locale, requestUrl)

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -152,7 +152,7 @@ const CACHE_KEEP_SECONDS = 7 * 24 * 60 * 60
 const TRANSLATION_SOURCE_CHECK_SECONDS = 5 * 60
 const TRANSLATION_PENDING_SECONDS = 10 * 60
 const TRANSLATION_COORDINATOR_PENDING_MS = 15 * 60 * 1000
-const TRANSLATION_CACHE_VERSION = '2026-05-04-llama-3.1-8b-json-body-v5'
+const TRANSLATION_CACHE_VERSION = '2026-05-06-llama-3.1-8b-json-body-v6-localized-links'
 const TRANSLATION_SOURCE_HASH_HEADER = 'X-Capgo-Translation-Source-Hash'
 const CLIENT_NO_STORE = 'no-store, max-age=0, must-revalidate'
 const MAX_HTML_BYTES = 1_500_000
@@ -319,16 +319,32 @@ function shouldBypassTranslation(pathname: string): boolean {
   return false
 }
 
-function shouldLocalizeHref(value: string): boolean {
-  if (!value.startsWith('/') || value.startsWith('//')) return false
-  if (value.startsWith('/#')) return false
-  return !shouldBypassTranslation(value)
+function hasUrlScheme(value: string): boolean {
+  return /^[A-Za-z][A-Za-z0-9+.-]*:/.test(value)
 }
 
-function localizeHref(value: string, locale: Locale): string {
-  if (!shouldLocalizeHref(value)) return value
-  const url = new URL(value, 'https://capgo.app')
+function isHttpUrl(value: string): boolean {
+  return /^https?:/i.test(value)
+}
+
+function localizeHref(value: string, locale: Locale, requestUrl: URL): string {
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.startsWith('#')) return value
+  if (hasUrlScheme(trimmed) && !isHttpUrl(trimmed)) return value
+
+  let url: URL
+  try {
+    url = new URL(trimmed, requestUrl)
+  } catch {
+    return value
+  }
+
+  if (url.host !== requestUrl.host) return value
+  if (shouldBypassTranslation(url.pathname)) return value
+
   url.pathname = localizedPath(url.pathname, locale)
+  if (trimmed.startsWith('//')) return `//${url.host}${url.pathname}${url.search}${url.hash}`
+  if (isHttpUrl(trimmed)) return url.toString()
   return `${url.pathname}${url.search}${url.hash}`
 }
 
@@ -1687,7 +1703,8 @@ function localizeTagUrlAttributes(tag: string, locale: Locale, basePath: string,
     const name = attribute.name.toLowerCase()
     if (name !== 'href' && name !== 'action') continue
 
-    const localized = name === 'href' && targetLanguageLocale ? `${localizedPath(basePath, targetLanguageLocale)}${requestUrl.search}` : localizeHref(attribute.value, locale)
+    const localized =
+      name === 'href' && targetLanguageLocale ? `${localizedPath(basePath, targetLanguageLocale)}${requestUrl.search}` : localizeHref(attribute.value, locale, requestUrl)
     if (localized === attribute.value) continue
 
     rewritten += tag.slice(lastIndex, attribute.valueStart)
@@ -2489,6 +2506,7 @@ export const __translationWorkerTest = {
   buildBatches,
   collectSegments,
   renderTranslatedHtml,
+  rewriteMetadataAndLinks,
 }
 
 export default {


### PR DESCRIPTION
## Summary

Fix translated pages so internal links are rewritten to the active locale path during the translation-worker metadata/link pass.

## Root cause

The previous link rewrite only handled root-relative paths like `/pricing`. Auto-translated HTML could still keep same-site absolute URLs, protocol-relative URLs, and relative links pointing at the default language route.

## Changes

- Localize same-host `href` and `action` values across root-relative, relative, protocol-relative, and same-site `http(s)` forms.
- Leave external links, same-page anchors, non-http schemes, and static/asset paths unchanged.
- Bump the translation cache version so cached translated pages regenerate with corrected links.
- Add parser coverage for internal and non-internal link rewrite behavior.

## Validation

- `bunx prettier --write apps/translation-worker/src/index.ts apps/translation-worker/scripts/verify-parser.ts`
- `bun run ci:verify:translation`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved URL localization for metadata and links, with enhanced handling of root‑relative, absolute, protocol‑relative and relative paths; form actions, anchors, and asset references are now more reliably locale-aware.

* **Tests**
  * Added validation tests that verify metadata and link localization for the French locale across various link types.

* **Chores**
  * Bumped translation cache version and made minor internal alignment improvements to URL handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->