### PR TITLE
docs: improve Widget Kit guide

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/widget-kit/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/widget-kit/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: "Install @capgo/capacitor-widget-kit and start using its current Capacitor API."
+description: "Install @capgo/capacitor-widget-kit, create SVG frame/timer widgets, or sync full-native widgets with the app."
 sidebar:
   order: 2
 ---
@@ -18,297 +18,250 @@ bunx cap sync
 import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
 ```
 
-## API Overview
+## iOS Setup
 
-### `areActivitiesSupported`
+For Live Activities and WidgetKit extensions, configure the native app first:
 
-Check whether the native template activity bridge can run on the current device.
+- Use iOS 17+ for interactive Live Activity buttons when possible.
+- Add `NSSupportsLiveActivities` to the app `Info.plist` when using ActivityKit.
+- Add the same App Group to the app target and the widget extension target.
+- Set `CapgoWidgetKitAppGroup` in both `Info.plist` files to the shared App Group identifier.
 
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.areActivitiesSupported();
+```xml
+<key>CapgoWidgetKitAppGroup</key>
+<string>group.app.capgo.widgetkit.exampleapp.widgetkit</string>
 ```
 
-### `startTemplateActivity`
-
-Persist a generic SVG template activity and start the matching native Live Activity bridge.
+## Check Support
 
 ```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
+const { supported, reason } = await CapgoWidgetKit.areActivitiesSupported();
 
-await CapgoWidgetKit.startTemplateActivity({} as StartTemplateActivityOptions);
-```
-
-### `updateTemplateActivity`
-
-Replace part or all of the stored activity definition/state.
-
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.updateTemplateActivity({} as UpdateTemplateActivityOptions);
-```
-
-### `endTemplateActivity`
-
-End a running activity while optionally persisting one last state snapshot.
-
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.endTemplateActivity({} as EndTemplateActivityOptions);
-```
-
-### `performTemplateAction`
-
-Execute one declarative action and record the resulting event.
-
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.performTemplateAction({} as PerformTemplateActionOptions);
-```
-
-### `getTemplateActivity`
-
-Read one activity back from the shared store.
-
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.getTemplateActivity({} as GetTemplateActivityOptions);
-```
-
-### `listTemplateActivities`
-
-List every activity currently known by the plugin.
-
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.listTemplateActivities();
-```
-
-### `listTemplateEvents`
-
-List stored action events so the app can react to widget interactions later.
-
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.listTemplateEvents();
-```
-
-### `acknowledgeTemplateEvents`
-
-Mark previously processed events as acknowledged.
-
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.acknowledgeTemplateEvents({} as AcknowledgeTemplateEventsOptions);
-```
-
-## Type Reference
-
-### `ActivitiesSupportedResult`
-Result of a Live Activities capability check.
-```typescript
-export interface ActivitiesSupportedResult {
-  /**
-   * Whether the current device and runtime can run the native template activity bridge.
-   */
-  supported: boolean;
-
-  /**
-   * Human-readable reason when support is unavailable.
-   */
-  reason?: string;
+if (!supported) {
+  console.log('WidgetKit bridge unavailable:', reason);
 }
 ```
 
-### `StartTemplateActivityOptions`
-Options for starting a generic SVG template activity.
+## Option 1: SVG Template Activity
+
+Use this mode when the widget can render resolved SVG. The plugin stores state, resolves placeholders, applies tap actions, switches SVG frames, and keeps timer state consistent.
+
 ```typescript
-export interface StartTemplateActivityOptions {
-  /**
-   * Optional explicit activity identifier. When omitted, the native runtime creates one.
-   */
-  activityId?: string;
-
-  /**
-   * Generic SVG template definition.
-   */
-  definition: SvgTemplateDefinition;
-
-  /**
-   * Initial JSON state exposed under `state.*`.
-   */
-  state: SvgTemplateState;
-
-  /**
-   * Optional deep link used when the widget body is tapped.
-   */
-  openUrl?: string;
-}
+const { activity } = await CapgoWidgetKit.startTemplateActivity({
+  activityId: 'workout-session-1',
+  openUrl: 'myapp://workout/session-1',
+  state: {
+    title: 'Chest Day',
+    frame: 'summary',
+    restDurationMs: 90000,
+  },
+  definition: {
+    id: 'workout-card',
+    timers: [
+      {
+        id: 'rest',
+        durationPath: 'state.restDurationMs',
+      },
+    ],
+    actions: [
+      {
+        id: 'next-frame',
+        eventName: 'widget.frame.changed',
+        frameMutations: [
+          {
+            op: 'next',
+            path: 'frame',
+            surface: 'lockScreen',
+          },
+        ],
+      },
+      {
+        id: 'toggle-rest',
+        eventName: 'widget.timer.toggled',
+        timerMutations: [
+          {
+            op: 'toggle',
+            timerId: 'rest',
+          },
+        ],
+      },
+    ],
+    layouts: {
+      lockScreen: {
+        width: 100,
+        height: 40,
+        frameIdPath: 'state.frame',
+        frames: [
+          {
+            id: 'summary',
+            hotspots: [{ id: 'switch', actionId: 'next-frame', x: 0, y: 0, width: 100, height: 40 }],
+            svg: `<svg viewBox="0 0 100 40"><text x="6" y="22">{{state.title}}</text></svg>`,
+          },
+          {
+            id: 'timer',
+            hotspots: [{ id: 'pause-play', actionId: 'toggle-rest', x: 0, y: 0, width: 100, height: 40 }],
+            svg: `<svg viewBox="0 0 100 40"><text x="6" y="22">{{timers.rest.remainingText}}</text></svg>`,
+          },
+        ],
+      },
+    },
+  },
+});
 ```
 
-### `StartTemplateActivityResult`
-Result when starting a generic template activity.
+### Run Actions From The App
+
+Native widgets can trigger the same actions through their hotspot/action wiring. The app can also run them directly:
+
 ```typescript
-export interface StartTemplateActivityResult {
-  /**
-   * Stored activity snapshot.
-   */
-  activity: SvgTemplateActivityRecord;
-}
+await CapgoWidgetKit.performTemplateAction({
+  activityId: activity.activityId,
+  actionId: 'toggle-rest',
+  sourceId: 'app-pause-play-button',
+});
 ```
 
-### `UpdateTemplateActivityOptions`
-Options for updating an existing template activity.
+### Process Widget Events
+
+Actions emit events so the app can process widget interactions after launch or resume:
+
 ```typescript
-export interface UpdateTemplateActivityOptions {
-  /**
-   * Activity identifier returned by `startTemplateActivity`.
-   */
-  activityId: string;
+const { events } = await CapgoWidgetKit.listTemplateEvents({
+  activityId: activity.activityId,
+  unacknowledgedOnly: true,
+});
 
-  /**
-   * Optional replacement definition.
-   */
-  definition?: SvgTemplateDefinition;
-
-  /**
-   * Optional replacement state.
-   */
-  state?: SvgTemplateState;
-
-  /**
-   * Optional replacement deep link.
-   */
-  openUrl?: string;
+for (const event of events) {
+  console.log('Widget event:', event.eventName, event.state, event.timers);
 }
+
+await CapgoWidgetKit.acknowledgeTemplateEvents({
+  activityId: activity.activityId,
+});
 ```
 
-### `TemplateActivityResult`
-Result when reading or updating a single activity.
+### Update Or End The Activity
+
 ```typescript
-export interface TemplateActivityResult {
-  /**
-   * Stored activity snapshot, or `null` when not found.
-   */
-  activity: SvgTemplateActivityRecord | null;
-}
+await CapgoWidgetKit.updateTemplateActivity({
+  activityId: activity.activityId,
+  state: {
+    title: 'Back Day',
+    frame: 'summary',
+    restDurationMs: 120000,
+  },
+});
+
+await CapgoWidgetKit.endTemplateActivity({
+  activityId: activity.activityId,
+  state: { title: 'Workout complete', frame: 'summary' },
+});
 ```
 
-### `EndTemplateActivityOptions`
-Options for ending a template activity.
-```typescript
-export interface EndTemplateActivityOptions {
-  /**
-   * Activity identifier returned by `startTemplateActivity`.
-   */
-  activityId: string;
+## Frame Mutations
 
-  /**
-   * Optional final state persisted before ending.
-   */
-  state?: SvgTemplateState;
-}
+Frame mutations write the active frame id into state. A layout can then read it with `frameIdPath`.
+
+| Operation | Behavior |
+| --- | --- |
+| `set` | Set a specific frame id. Plain strings are treated as literal frame ids; `{{...}}` templates are resolved first. |
+| `next` | Move to the next frame from `frameIds` or the frames declared on `surface`. |
+| `previous` | Move to the previous frame. |
+| `toggle` | Toggle between the first two available frames, or between the current frame and `frameId`. |
+
+Invalid frame ids are ignored when the mutation has a known selectable frame list, so state stays aligned with the rendered surface.
+
+## Timer Mutations
+
+Timer mutations target a named timer from `definition.timers`.
+
+| Operation | Behavior |
+| --- | --- |
+| `start` / `restart` | Start from zero using the current duration. |
+| `pause` | Store elapsed time and clear `startedAt`. |
+| `resume` | Resume only paused timers. Stopped timers stay stopped until an explicit start or restart. |
+| `toggle` | Pause a running timer or resume a paused timer. |
+| `reset` | Clear elapsed time and return to idle. |
+| `stop` | Clear runtime progress and mark the timer stopped. |
+| `setDuration` | Recompute status after a duration change. |
+
+Timer bindings are available to SVG as `{{timers.<id>.remainingText}}`, `{{timers.<id>.elapsedMs}}`, `{{timers.<id>.status}}`, and related fields.
+
+## Option 2: Full-Native Widget Session
+
+Use this mode when the widget UI is built in native code. The plugin gives the app and widget a shared session record and a message queue.
+
+```typescript
+const { session } = await CapgoWidgetKit.startWidgetSession({
+  widgetId: 'native-session-1',
+  kind: 'workout-controls',
+  state: { isRunning: true, selectedSetId: 'set-1' },
+  metadata: { accent: '#00d69c' },
+});
+
+await CapgoWidgetKit.updateWidgetSession({
+  widgetId: session.widgetId,
+  merge: true,
+  state: { isRunning: false },
+});
+
+const { sessions } = await CapgoWidgetKit.listWidgetSessions();
+console.log('Known widget sessions:', sessions);
 ```
 
-### `PerformTemplateActionOptions`
-Options for executing a declarative action.
+## Async Widget Messages
+
+Messages cover work that needs a later response, such as a widget asking the app to sync data.
+
 ```typescript
-export interface PerformTemplateActionOptions {
-  /**
-   * Activity identifier returned by `startTemplateActivity`.
-   */
-  activityId: string;
+const { message } = await CapgoWidgetKit.sendWidgetMessage({
+  widgetId: session.widgetId,
+  direction: 'widgetToApp',
+  name: 'syncWorkoutSet',
+  payload: { setId: 'set-1' },
+  expectsResponse: true,
+});
 
-  /**
-   * Action identifier declared in the template definition.
-   */
-  actionId: string;
+await CapgoWidgetKit.acknowledgeWidgetMessages({
+  messageIds: [message.messageId],
+});
 
-  /**
-   * Optional source identifier, typically the hotspot id that triggered the action.
-   */
-  sourceId?: string;
-
-  /**
-   * Optional payload stored with the emitted event and exposed to declarative patches under `{{action.payload.*}}`.
-   */
-  payload?: JsonObject;
-}
+await CapgoWidgetKit.completeWidgetMessage({
+  messageId: message.messageId,
+  response: { synced: true },
+});
 ```
 
-### `PerformTemplateActionResult`
-Result after executing an action.
-```typescript
-export interface PerformTemplateActionResult {
-  /**
-   * Updated activity snapshot.
-   */
-  activity: SvgTemplateActivityRecord;
+To fail the job, pass `error` instead of `response`:
 
-  /**
-   * Action event emitted by the runtime.
-   */
-  event: SvgTemplateActionEvent;
-}
+```typescript
+await CapgoWidgetKit.completeWidgetMessage({
+  messageId: message.messageId,
+  error: 'Network unavailable',
+});
 ```
 
-### `GetTemplateActivityOptions`
-Options for reading one stored activity.
+`completeWidgetMessage` is idempotent. If the message is already completed or failed, repeated calls return the existing message snapshot.
+
+## Stop A Native Session
+
 ```typescript
-export interface GetTemplateActivityOptions {
-  /**
-   * Activity identifier to load.
-   */
-  activityId: string;
-}
+await CapgoWidgetKit.stopWidgetSession({
+  widgetId: session.widgetId,
+  state: { isRunning: false },
+});
 ```
 
-### `ListTemplateActivitiesResult`
-Result when listing stored activities.
-```typescript
-export interface ListTemplateActivitiesResult {
-  /**
-   * Stored activity snapshots.
-   */
-  activities: SvgTemplateActivityRecord[];
-}
-```
+## API Groups
 
-### `ListTemplateEventsOptions`
-Options when listing action events.
-```typescript
-export interface ListTemplateEventsOptions {
-  /**
-   * Optional activity filter.
-   */
-  activityId?: string;
-
-  /**
-   * When true, only unacknowledged events are returned.
-   */
-  unacknowledgedOnly?: boolean;
-}
-```
-
-### `ListTemplateEventsResult`
-Result when listing action events.
-```typescript
-export interface ListTemplateEventsResult {
-  /**
-   * Matching action events.
-   */
-  events: SvgTemplateActionEvent[];
-}
-```
+| Group | APIs |
+| --- | --- |
+| Capability | `areActivitiesSupported`, `getPluginVersion` |
+| SVG activity lifecycle | `startTemplateActivity`, `updateTemplateActivity`, `endTemplateActivity`, `getTemplateActivity`, `listTemplateActivities` |
+| SVG actions and events | `performTemplateAction`, `listTemplateEvents`, `acknowledgeTemplateEvents` |
+| Native widget sessions | `startWidgetSession`, `updateWidgetSession`, `stopWidgetSession`, `getWidgetSession`, `listWidgetSessions` |
+| Native widget messages | `sendWidgetMessage`, `listWidgetMessages`, `acknowledgeWidgetMessages`, `completeWidgetMessage` |
 
 ## Source Of Truth
 
-This page is generated from the plugin's `src/definitions.ts`. Re-run the sync when the public API changes upstream.
+The full type reference lives in the plugin repository at [`src/definitions.ts`](https://github.com/Cap-go/capacitor-widget-kit/blob/main/src/definitions.ts).

--- a/apps/docs/src/content/docs/docs/plugins/widget-kit/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/widget-kit/index.mdx
@@ -1,14 +1,14 @@
 ---
 title: "@capgo/capacitor-widget-kit"
-description: "Capacitor plugin for generic iOS WidgetKit and Live Activities using SVG templates, declarative actions, and shared App Group persistence."
-tableOfContents: false
+description: "Build iOS WidgetKit and Live Activity surfaces from Capacitor with SVG frame templates, timers, action hotspots, and a full-native widget bridge."
+tableOfContents: true
 next: false
 prev: false
 sidebar:
   order: 1
   label: "Introduction"
 hero:
-  tagline: "Capacitor bridge for an iOS-first WidgetKit / Live Activities plugin."
+  tagline: "WidgetKit and Live Activities for Capacitor apps, with SVG-driven templates or full-native widget state sync."
   actions:
     - text: Get started
       link: /docs/plugins/widget-kit/getting-started/
@@ -22,30 +22,81 @@ hero:
 
 ## Overview
 
-Capacitor bridge for an iOS-first WidgetKit / Live Activities plugin.
+`@capgo/capacitor-widget-kit` gives a Capacitor app two ways to drive widgets and Live Activities:
 
-## Core Capabilities
+- SVG template activities: define WidgetKit surfaces as SVG, switch named frames from taps, run pause/play timers, mutate JSON state, and collect action events in the app.
+- Full-native widget sessions: keep the widget UI fully in Swift/Kotlin/Java while Capacitor owns shared JSON state and app-to-widget or widget-to-app messages.
 
-- `areActivitiesSupported` - Check whether the native template activity bridge can run on the current device.
-- `startTemplateActivity` - Persist a generic SVG template activity and start the matching native Live Activity bridge.
-- `updateTemplateActivity` - Replace part or all of the stored activity definition/state.
-- `endTemplateActivity` - End a running activity while optionally persisting one last state snapshot.
+Use SVG templates when your widget can be rendered from resolved SVG strings. Use full-native sessions when the widget needs a custom native UI but still has to start, stop, sync state, or ask the app to complete async work.
+
+## Choose A Mode
+
+| Mode | Best for | Main APIs |
+| --- | --- | --- |
+| SVG template activity | Live Activities or widget surfaces that render from SVG output | `startTemplateActivity`, `performTemplateAction`, `listTemplateEvents` |
+| Full-native widget session | Native-rendered widgets that need shared state and async jobs | `startWidgetSession`, `updateWidgetSession`, `sendWidgetMessage` |
+
+Both modes can live in the same app. For example, a workout app can use an SVG Live Activity for fast frame/timer controls and a full-native widget session for a home-screen widget with a richer native layout.
+
+## SVG Template Capabilities
+
+SVG templates include the pieces needed for interactive widget surfaces:
+
+- `frames` hold named SVG variants such as `summary`, `timer`, or `details`.
+- `frameMutations` switch, toggle, or step through frames after a hotspot action.
+- `timerMutations` start, pause, resume, toggle, reset, stop, or change timer duration.
+- `patches` update JSON state using literal values, templates, timestamps, increments, toggles, or unset operations.
+- `hotspots` map tap areas to action identifiers.
+- `listTemplateEvents` lets the app process widget-originated actions later.
+
+The runtime resolves placeholders like `{{state.title}}`, `{{timers.rest.remainingText}}`, and `{{meta.template.kind}}` before the native bridge returns a surface for rendering.
+
+## Full-Native Bridge Capabilities
+
+Full-native sessions are for widgets that render their own UI natively:
+
+- `startWidgetSession` creates shared state and metadata for native widget code.
+- `updateWidgetSession` merges or replaces state and marks the session active again.
+- `stopWidgetSession` records a final state and marks the session stopped.
+- `sendWidgetMessage` queues app-to-widget or widget-to-app work.
+- `acknowledgeWidgetMessages` marks messages as received.
+- `completeWidgetMessage` stores a response or failure for async jobs.
+
+Messages are idempotent after completion: retrying a completed or failed message returns the existing result instead of overwriting it.
 
 ## Public API
 
 | Method | Description |
 | --- | --- |
 | `areActivitiesSupported` | Check whether the native template activity bridge can run on the current device. |
-| `startTemplateActivity` | Persist a generic SVG template activity and start the matching native Live Activity bridge. |
-| `updateTemplateActivity` | Replace part or all of the stored activity definition/state. |
-| `endTemplateActivity` | End a running activity while optionally persisting one last state snapshot. |
-| `performTemplateAction` | Execute one declarative action and record the resulting event. |
-| `getTemplateActivity` | Read one activity back from the shared store. |
-| `listTemplateActivities` | List every activity currently known by the plugin. |
-| `listTemplateEvents` | List stored action events so the app can react to widget interactions later. |
-| `acknowledgeTemplateEvents` | Mark previously processed events as acknowledged. |
+| `startTemplateActivity` | Persist an SVG template activity and start the native Live Activity bridge. |
+| `updateTemplateActivity` | Replace the activity definition, state, or open URL. |
+| `endTemplateActivity` | End a running activity and optionally persist one last state snapshot. |
+| `performTemplateAction` | Execute declarative patches, frame mutations, timer mutations, and event logging. |
+| `getTemplateActivity` | Read one stored template activity. |
+| `listTemplateActivities` | List every stored template activity. |
+| `listTemplateEvents` | Read action events emitted by template actions. |
+| `acknowledgeTemplateEvents` | Mark template events as processed. |
+| `startWidgetSession` | Start a full-native widget session backed by shared JSON state. |
+| `updateWidgetSession` | Merge or replace a full-native widget session state. |
+| `stopWidgetSession` | Stop a full-native widget session and optionally persist final state. |
+| `getWidgetSession` | Read one full-native widget session. |
+| `listWidgetSessions` | List every full-native widget session. |
+| `sendWidgetMessage` | Queue a message between the app and native widget code. |
+| `listWidgetMessages` | List queued bridge messages. |
+| `acknowledgeWidgetMessages` | Mark bridge messages as acknowledged. |
+| `completeWidgetMessage` | Complete or fail an async bridge message. |
 | `getPluginVersion` | Return the platform implementation version marker. |
+
+## Native Pieces
+
+The plugin also ships native helpers for widget targets:
+
+- `CapgoTemplateWidgetBridge` resolves an SVG template surface into `svg`, `frameId`, `hotspots`, and metadata.
+- `CapgoTemplateActionIntent` connects interactive iOS widget buttons to template actions.
+- `CapgoNativeWidgetBridge` loads full-native sessions and messages from native widget code.
+- Android template helpers provide matching action receiver and widget bridge behavior.
 
 ## Source Of Truth
 
-This reference is synced from `src/definitions.ts` in [capacitor-widget-kit](https://github.com/Cap-go/capacitor-widget-kit/).
+The API reference is synced from [`src/definitions.ts`](https://github.com/Cap-go/capacitor-widget-kit/blob/main/src/definitions.ts) in the plugin repository.

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -141,7 +141,7 @@ const actionDefinitionRows =
 @capgo/capacitor-in-app-review|github.com/Cap-go|Prompt users to submit app store ratings and reviews without leaving your app using native iOS and Android APIs|https://github.com/Cap-go/capacitor-in-app-review/|In App Review
 @capgo/capacitor-file-picker|github.com/Cap-go|Pick files, images, videos, and directories with full native support for iOS and Android including HEIC conversion|https://github.com/Cap-go/capacitor-file-picker/|File Picker
 @capgo/capacitor-watch|github.com/Cap-go|Apple Watch communication with bidirectional messaging between iPhone and watchOS apps|https://github.com/Cap-go/capacitor-watch/|Watch
-@capgo/capacitor-widget-kit|github.com/Cap-go|Build iOS widgets and Live Activities from Capacitor with SVG templates, timers, and action hotspots|https://github.com/Cap-go/capacitor-widget-kit/|Widget Kit
+@capgo/capacitor-widget-kit|github.com/Cap-go|Build WidgetKit and Live Activity surfaces from Capacitor with SVG frames, timers, action hotspots, or full-native widget state sync|https://github.com/Cap-go/capacitor-widget-kit/|Widget Kit
 @capgo/capacitor-brightness|github.com/Cap-go|Control device screen brightness programmatically with support for app-specific and system-wide control|https://github.com/Cap-go/capacitor-brightness/|Brightness
 @capgo/capacitor-light-sensor|github.com/Cap-go|Access the ambient light sensor to measure illuminance levels in lux with real-time updates|https://github.com/Cap-go/capacitor-light-sensor/|Light Sensor
 @capgo/capacitor-video-thumbnails|github.com/Cap-go|Generate thumbnail images from local and remote video files at specific timestamps|https://github.com/Cap-go/capacitor-video-thumbnails/|Video Thumbnails

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-widget-kit.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-widget-kit.md
@@ -3,7 +3,10 @@ locale: en
 ---
 # Using @capgo/capacitor-widget-kit
 
-Capacitor bridge for an iOS-first WidgetKit / Live Activities plugin.
+`@capgo/capacitor-widget-kit` lets a Capacitor app drive WidgetKit and Live Activity experiences in two ways:
+
+- Render resolved SVG template surfaces with frame switching, tap hotspots, and pause/play timers.
+- Keep the widget fully native while the app and widget share JSON session state and async messages.
 
 ## Install
 
@@ -12,54 +15,141 @@ bun add @capgo/capacitor-widget-kit
 bunx cap sync
 ```
 
-## What This Plugin Exposes
+## When To Use SVG Templates
 
-- `areActivitiesSupported` - Check whether the native template activity bridge can run on the current device.
-- `startTemplateActivity` - Persist a generic SVG template activity and start the matching native Live Activity bridge.
-- `updateTemplateActivity` - Replace part or all of the stored activity definition/state.
-- `endTemplateActivity` - End a running activity while optionally persisting one last state snapshot.
+Use SVG templates when the widget surface can be described as SVG. The app stores a template definition, the native bridge resolves placeholders, and widget taps can mutate state later.
 
-## Example Usage
-
-### `areActivitiesSupported`
-
-Check whether the native template activity bridge can run on the current device.
+Good fits include workout timers, delivery status cards, sports scores, or any compact UI where switching between named frames is enough.
 
 ```typescript
 import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
 
-await CapgoWidgetKit.areActivitiesSupported();
+const { activity } = await CapgoWidgetKit.startTemplateActivity({
+  activityId: 'session-1',
+  state: {
+    title: 'Chest Day',
+    frame: 'summary',
+    restDurationMs: 90000,
+  },
+  definition: {
+    id: 'workout-card',
+    timers: [{ id: 'rest', durationPath: 'state.restDurationMs' }],
+    actions: [
+      {
+        id: 'next-frame',
+        frameMutations: [{ op: 'next', path: 'frame', surface: 'lockScreen' }],
+      },
+      {
+        id: 'toggle-rest',
+        timerMutations: [{ op: 'toggle', timerId: 'rest' }],
+      },
+    ],
+    layouts: {
+      lockScreen: {
+        width: 100,
+        height: 40,
+        frameIdPath: 'state.frame',
+        frames: [
+          {
+            id: 'summary',
+            hotspots: [{ id: 'switch', actionId: 'next-frame', x: 0, y: 0, width: 100, height: 40 }],
+            svg: `<svg viewBox="0 0 100 40"><text x="6" y="22">{{state.title}}</text></svg>`,
+          },
+          {
+            id: 'timer',
+            hotspots: [{ id: 'pause-play', actionId: 'toggle-rest', x: 0, y: 0, width: 100, height: 40 }],
+            svg: `<svg viewBox="0 0 100 40"><text x="6" y="22">{{timers.rest.remainingText}}</text></svg>`,
+          },
+        ],
+      },
+    },
+  },
+});
 ```
 
-### `startTemplateActivity`
+## Handle Widget Actions In The App
 
-Persist a generic SVG template activity and start the matching native Live Activity bridge.
+Widget actions are persisted as events. Read and acknowledge them when the app resumes or after a background sync step.
 
 ```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
+const { events } = await CapgoWidgetKit.listTemplateEvents({
+  activityId: activity.activityId,
+  unacknowledgedOnly: true,
+});
 
-await CapgoWidgetKit.startTemplateActivity({} as StartTemplateActivityOptions);
+for (const event of events) {
+  console.log(event.actionId, event.state, event.timers);
+}
+
+await CapgoWidgetKit.acknowledgeTemplateEvents({ activityId: activity.activityId });
 ```
 
-### `updateTemplateActivity`
+## When To Use Full-Native Sessions
 
-Replace part or all of the stored activity definition/state.
+Use full-native sessions when the widget UI is better built directly in Swift, Kotlin, or Java. Capacitor still starts and stops the session, keeps shared state current, and queues work between app and widget code.
 
 ```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
+const { session } = await CapgoWidgetKit.startWidgetSession({
+  widgetId: 'native-session-1',
+  kind: 'workout-controls',
+  state: { isRunning: true, selectedSetId: 'set-1' },
+  metadata: { accent: '#00d69c' },
+});
 
-await CapgoWidgetKit.updateTemplateActivity({} as UpdateTemplateActivityOptions);
+await CapgoWidgetKit.updateWidgetSession({
+  widgetId: session.widgetId,
+  merge: true,
+  state: { isRunning: false },
+});
 ```
 
-### `endTemplateActivity`
+## Queue Async Work Between Widget And App
 
-End a running activity while optionally persisting one last state snapshot.
+Messages can flow from app to widget or widget to app. They stay pending until acknowledged and completed.
 
 ```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
+const { message } = await CapgoWidgetKit.sendWidgetMessage({
+  widgetId: session.widgetId,
+  direction: 'widgetToApp',
+  name: 'syncWorkoutSet',
+  payload: { setId: 'set-1' },
+  expectsResponse: true,
+});
 
-await CapgoWidgetKit.endTemplateActivity({} as EndTemplateActivityOptions);
+await CapgoWidgetKit.acknowledgeWidgetMessages({ messageIds: [message.messageId] });
+
+await CapgoWidgetKit.completeWidgetMessage({
+  messageId: message.messageId,
+  response: { synced: true },
+});
 ```
+
+If the job fails, complete the message with an error:
+
+```typescript
+await CapgoWidgetKit.completeWidgetMessage({
+  messageId: message.messageId,
+  error: 'Sync failed',
+});
+```
+
+## Stop Sessions Cleanly
+
+```typescript
+await CapgoWidgetKit.endTemplateActivity({
+  activityId: activity.activityId,
+  state: { title: 'Workout complete', frame: 'summary' },
+});
+
+await CapgoWidgetKit.stopWidgetSession({
+  widgetId: session.widgetId,
+  state: { isRunning: false },
+});
+```
+
+## Native Setup Notes
+
+For iOS WidgetKit and Live Activities, configure an App Group on the app and widget extension targets and set `CapgoWidgetKitAppGroup` in both `Info.plist` files. Interactive buttons require a widget extension that wires the plugin-provided native bridge and action intent.
 
 ## Full Reference
 

--- a/src/content/docs/docs/plugins/widget-kit/getting-started.mdx
+++ b/src/content/docs/docs/plugins/widget-kit/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: "Install @capgo/capacitor-widget-kit and start using its current Capacitor API."
+description: "Install @capgo/capacitor-widget-kit, create SVG frame/timer widgets, or sync full-native widgets with the app."
 sidebar:
   order: 2
 ---
@@ -18,297 +18,250 @@ bunx cap sync
 import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
 ```
 
-## API Overview
+## iOS Setup
 
-### `areActivitiesSupported`
+For Live Activities and WidgetKit extensions, configure the native app first:
 
-Check whether the native template activity bridge can run on the current device.
+- Use iOS 17+ for interactive Live Activity buttons when possible.
+- Add `NSSupportsLiveActivities` to the app `Info.plist` when using ActivityKit.
+- Add the same App Group to the app target and the widget extension target.
+- Set `CapgoWidgetKitAppGroup` in both `Info.plist` files to the shared App Group identifier.
 
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.areActivitiesSupported();
+```xml
+<key>CapgoWidgetKitAppGroup</key>
+<string>group.app.capgo.widgetkit.exampleapp.widgetkit</string>
 ```
 
-### `startTemplateActivity`
-
-Persist a generic SVG template activity and start the matching native Live Activity bridge.
+## Check Support
 
 ```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
+const { supported, reason } = await CapgoWidgetKit.areActivitiesSupported();
 
-await CapgoWidgetKit.startTemplateActivity({} as StartTemplateActivityOptions);
-```
-
-### `updateTemplateActivity`
-
-Replace part or all of the stored activity definition/state.
-
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.updateTemplateActivity({} as UpdateTemplateActivityOptions);
-```
-
-### `endTemplateActivity`
-
-End a running activity while optionally persisting one last state snapshot.
-
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.endTemplateActivity({} as EndTemplateActivityOptions);
-```
-
-### `performTemplateAction`
-
-Execute one declarative action and record the resulting event.
-
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.performTemplateAction({} as PerformTemplateActionOptions);
-```
-
-### `getTemplateActivity`
-
-Read one activity back from the shared store.
-
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.getTemplateActivity({} as GetTemplateActivityOptions);
-```
-
-### `listTemplateActivities`
-
-List every activity currently known by the plugin.
-
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.listTemplateActivities();
-```
-
-### `listTemplateEvents`
-
-List stored action events so the app can react to widget interactions later.
-
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.listTemplateEvents();
-```
-
-### `acknowledgeTemplateEvents`
-
-Mark previously processed events as acknowledged.
-
-```typescript
-import { CapgoWidgetKit } from '@capgo/capacitor-widget-kit';
-
-await CapgoWidgetKit.acknowledgeTemplateEvents({} as AcknowledgeTemplateEventsOptions);
-```
-
-## Type Reference
-
-### `ActivitiesSupportedResult`
-Result of a Live Activities capability check.
-```typescript
-export interface ActivitiesSupportedResult {
-  /**
-   * Whether the current device and runtime can run the native template activity bridge.
-   */
-  supported: boolean;
-
-  /**
-   * Human-readable reason when support is unavailable.
-   */
-  reason?: string;
+if (!supported) {
+  console.log('WidgetKit bridge unavailable:', reason);
 }
 ```
 
-### `StartTemplateActivityOptions`
-Options for starting a generic SVG template activity.
+## Option 1: SVG Template Activity
+
+Use this mode when the widget can render resolved SVG. The plugin stores state, resolves placeholders, applies tap actions, switches SVG frames, and keeps timer state consistent.
+
 ```typescript
-export interface StartTemplateActivityOptions {
-  /**
-   * Optional explicit activity identifier. When omitted, the native runtime creates one.
-   */
-  activityId?: string;
-
-  /**
-   * Generic SVG template definition.
-   */
-  definition: SvgTemplateDefinition;
-
-  /**
-   * Initial JSON state exposed under `state.*`.
-   */
-  state: SvgTemplateState;
-
-  /**
-   * Optional deep link used when the widget body is tapped.
-   */
-  openUrl?: string;
-}
+const { activity } = await CapgoWidgetKit.startTemplateActivity({
+  activityId: 'workout-session-1',
+  openUrl: 'myapp://workout/session-1',
+  state: {
+    title: 'Chest Day',
+    frame: 'summary',
+    restDurationMs: 90000,
+  },
+  definition: {
+    id: 'workout-card',
+    timers: [
+      {
+        id: 'rest',
+        durationPath: 'state.restDurationMs',
+      },
+    ],
+    actions: [
+      {
+        id: 'next-frame',
+        eventName: 'widget.frame.changed',
+        frameMutations: [
+          {
+            op: 'next',
+            path: 'frame',
+            surface: 'lockScreen',
+          },
+        ],
+      },
+      {
+        id: 'toggle-rest',
+        eventName: 'widget.timer.toggled',
+        timerMutations: [
+          {
+            op: 'toggle',
+            timerId: 'rest',
+          },
+        ],
+      },
+    ],
+    layouts: {
+      lockScreen: {
+        width: 100,
+        height: 40,
+        frameIdPath: 'state.frame',
+        frames: [
+          {
+            id: 'summary',
+            hotspots: [{ id: 'switch', actionId: 'next-frame', x: 0, y: 0, width: 100, height: 40 }],
+            svg: `<svg viewBox="0 0 100 40"><text x="6" y="22">{{state.title}}</text></svg>`,
+          },
+          {
+            id: 'timer',
+            hotspots: [{ id: 'pause-play', actionId: 'toggle-rest', x: 0, y: 0, width: 100, height: 40 }],
+            svg: `<svg viewBox="0 0 100 40"><text x="6" y="22">{{timers.rest.remainingText}}</text></svg>`,
+          },
+        ],
+      },
+    },
+  },
+});
 ```
 
-### `StartTemplateActivityResult`
-Result when starting a generic template activity.
+### Run Actions From The App
+
+Native widgets can trigger the same actions through their hotspot/action wiring. The app can also run them directly:
+
 ```typescript
-export interface StartTemplateActivityResult {
-  /**
-   * Stored activity snapshot.
-   */
-  activity: SvgTemplateActivityRecord;
-}
+await CapgoWidgetKit.performTemplateAction({
+  activityId: activity.activityId,
+  actionId: 'toggle-rest',
+  sourceId: 'app-pause-play-button',
+});
 ```
 
-### `UpdateTemplateActivityOptions`
-Options for updating an existing template activity.
+### Process Widget Events
+
+Actions emit events so the app can process widget interactions after launch or resume:
+
 ```typescript
-export interface UpdateTemplateActivityOptions {
-  /**
-   * Activity identifier returned by `startTemplateActivity`.
-   */
-  activityId: string;
+const { events } = await CapgoWidgetKit.listTemplateEvents({
+  activityId: activity.activityId,
+  unacknowledgedOnly: true,
+});
 
-  /**
-   * Optional replacement definition.
-   */
-  definition?: SvgTemplateDefinition;
-
-  /**
-   * Optional replacement state.
-   */
-  state?: SvgTemplateState;
-
-  /**
-   * Optional replacement deep link.
-   */
-  openUrl?: string;
+for (const event of events) {
+  console.log('Widget event:', event.eventName, event.state, event.timers);
 }
+
+await CapgoWidgetKit.acknowledgeTemplateEvents({
+  activityId: activity.activityId,
+});
 ```
 
-### `TemplateActivityResult`
-Result when reading or updating a single activity.
+### Update Or End The Activity
+
 ```typescript
-export interface TemplateActivityResult {
-  /**
-   * Stored activity snapshot, or `null` when not found.
-   */
-  activity: SvgTemplateActivityRecord | null;
-}
+await CapgoWidgetKit.updateTemplateActivity({
+  activityId: activity.activityId,
+  state: {
+    title: 'Back Day',
+    frame: 'summary',
+    restDurationMs: 120000,
+  },
+});
+
+await CapgoWidgetKit.endTemplateActivity({
+  activityId: activity.activityId,
+  state: { title: 'Workout complete', frame: 'summary' },
+});
 ```
 
-### `EndTemplateActivityOptions`
-Options for ending a template activity.
-```typescript
-export interface EndTemplateActivityOptions {
-  /**
-   * Activity identifier returned by `startTemplateActivity`.
-   */
-  activityId: string;
+## Frame Mutations
 
-  /**
-   * Optional final state persisted before ending.
-   */
-  state?: SvgTemplateState;
-}
+Frame mutations write the active frame id into state. A layout can then read it with `frameIdPath`.
+
+| Operation | Behavior |
+| --- | --- |
+| `set` | Set a specific frame id. Plain strings are treated as literal frame ids; `{{...}}` templates are resolved first. |
+| `next` | Move to the next frame from `frameIds` or the frames declared on `surface`. |
+| `previous` | Move to the previous frame. |
+| `toggle` | Toggle between the first two available frames, or between the current frame and `frameId`. |
+
+Invalid frame ids are ignored when the mutation has a known selectable frame list, so state stays aligned with the rendered surface.
+
+## Timer Mutations
+
+Timer mutations target a named timer from `definition.timers`.
+
+| Operation | Behavior |
+| --- | --- |
+| `start` / `restart` | Start from zero using the current duration. |
+| `pause` | Store elapsed time and clear `startedAt`. |
+| `resume` | Resume only paused timers. Stopped timers stay stopped until an explicit start or restart. |
+| `toggle` | Pause a running timer or resume a paused timer. |
+| `reset` | Clear elapsed time and return to idle. |
+| `stop` | Clear runtime progress and mark the timer stopped. |
+| `setDuration` | Recompute status after a duration change. |
+
+Timer bindings are available to SVG as `{{timers.<id>.remainingText}}`, `{{timers.<id>.elapsedMs}}`, `{{timers.<id>.status}}`, and related fields.
+
+## Option 2: Full-Native Widget Session
+
+Use this mode when the widget UI is built in native code. The plugin gives the app and widget a shared session record and a message queue.
+
+```typescript
+const { session } = await CapgoWidgetKit.startWidgetSession({
+  widgetId: 'native-session-1',
+  kind: 'workout-controls',
+  state: { isRunning: true, selectedSetId: 'set-1' },
+  metadata: { accent: '#00d69c' },
+});
+
+await CapgoWidgetKit.updateWidgetSession({
+  widgetId: session.widgetId,
+  merge: true,
+  state: { isRunning: false },
+});
+
+const { sessions } = await CapgoWidgetKit.listWidgetSessions();
+console.log('Known widget sessions:', sessions);
 ```
 
-### `PerformTemplateActionOptions`
-Options for executing a declarative action.
+## Async Widget Messages
+
+Messages cover work that needs a later response, such as a widget asking the app to sync data.
+
 ```typescript
-export interface PerformTemplateActionOptions {
-  /**
-   * Activity identifier returned by `startTemplateActivity`.
-   */
-  activityId: string;
+const { message } = await CapgoWidgetKit.sendWidgetMessage({
+  widgetId: session.widgetId,
+  direction: 'widgetToApp',
+  name: 'syncWorkoutSet',
+  payload: { setId: 'set-1' },
+  expectsResponse: true,
+});
 
-  /**
-   * Action identifier declared in the template definition.
-   */
-  actionId: string;
+await CapgoWidgetKit.acknowledgeWidgetMessages({
+  messageIds: [message.messageId],
+});
 
-  /**
-   * Optional source identifier, typically the hotspot id that triggered the action.
-   */
-  sourceId?: string;
-
-  /**
-   * Optional payload stored with the emitted event and exposed to declarative patches under `{{action.payload.*}}`.
-   */
-  payload?: JsonObject;
-}
+await CapgoWidgetKit.completeWidgetMessage({
+  messageId: message.messageId,
+  response: { synced: true },
+});
 ```
 
-### `PerformTemplateActionResult`
-Result after executing an action.
-```typescript
-export interface PerformTemplateActionResult {
-  /**
-   * Updated activity snapshot.
-   */
-  activity: SvgTemplateActivityRecord;
+To fail the job, pass `error` instead of `response`:
 
-  /**
-   * Action event emitted by the runtime.
-   */
-  event: SvgTemplateActionEvent;
-}
+```typescript
+await CapgoWidgetKit.completeWidgetMessage({
+  messageId: message.messageId,
+  error: 'Network unavailable',
+});
 ```
 
-### `GetTemplateActivityOptions`
-Options for reading one stored activity.
+`completeWidgetMessage` is idempotent. If the message is already completed or failed, repeated calls return the existing message snapshot.
+
+## Stop A Native Session
+
 ```typescript
-export interface GetTemplateActivityOptions {
-  /**
-   * Activity identifier to load.
-   */
-  activityId: string;
-}
+await CapgoWidgetKit.stopWidgetSession({
+  widgetId: session.widgetId,
+  state: { isRunning: false },
+});
 ```
 
-### `ListTemplateActivitiesResult`
-Result when listing stored activities.
-```typescript
-export interface ListTemplateActivitiesResult {
-  /**
-   * Stored activity snapshots.
-   */
-  activities: SvgTemplateActivityRecord[];
-}
-```
+## API Groups
 
-### `ListTemplateEventsOptions`
-Options when listing action events.
-```typescript
-export interface ListTemplateEventsOptions {
-  /**
-   * Optional activity filter.
-   */
-  activityId?: string;
-
-  /**
-   * When true, only unacknowledged events are returned.
-   */
-  unacknowledgedOnly?: boolean;
-}
-```
-
-### `ListTemplateEventsResult`
-Result when listing action events.
-```typescript
-export interface ListTemplateEventsResult {
-  /**
-   * Matching action events.
-   */
-  events: SvgTemplateActionEvent[];
-}
-```
+| Group | APIs |
+| --- | --- |
+| Capability | `areActivitiesSupported`, `getPluginVersion` |
+| SVG activity lifecycle | `startTemplateActivity`, `updateTemplateActivity`, `endTemplateActivity`, `getTemplateActivity`, `listTemplateActivities` |
+| SVG actions and events | `performTemplateAction`, `listTemplateEvents`, `acknowledgeTemplateEvents` |
+| Native widget sessions | `startWidgetSession`, `updateWidgetSession`, `stopWidgetSession`, `getWidgetSession`, `listWidgetSessions` |
+| Native widget messages | `sendWidgetMessage`, `listWidgetMessages`, `acknowledgeWidgetMessages`, `completeWidgetMessage` |
 
 ## Source Of Truth
 
-This page is generated from the plugin's `src/definitions.ts`. Re-run the sync when the public API changes upstream.
+The full type reference lives in the plugin repository at [`src/definitions.ts`](https://github.com/Cap-go/capacitor-widget-kit/blob/main/src/definitions.ts).

--- a/src/content/docs/docs/plugins/widget-kit/index.mdx
+++ b/src/content/docs/docs/plugins/widget-kit/index.mdx
@@ -1,14 +1,14 @@
 ---
 title: "@capgo/capacitor-widget-kit"
-description: "Capacitor plugin for generic iOS WidgetKit and Live Activities using SVG templates, declarative actions, and shared App Group persistence."
-tableOfContents: false
+description: "Build iOS WidgetKit and Live Activity surfaces from Capacitor with SVG frame templates, timers, action hotspots, and a full-native widget bridge."
+tableOfContents: true
 next: false
 prev: false
 sidebar:
   order: 1
   label: "Introduction"
 hero:
-  tagline: "Capacitor bridge for an iOS-first WidgetKit / Live Activities plugin."
+  tagline: "WidgetKit and Live Activities for Capacitor apps, with SVG-driven templates or full-native widget state sync."
   actions:
     - text: Get started
       link: /docs/plugins/widget-kit/getting-started/
@@ -22,30 +22,81 @@ hero:
 
 ## Overview
 
-Capacitor bridge for an iOS-first WidgetKit / Live Activities plugin.
+`@capgo/capacitor-widget-kit` gives a Capacitor app two ways to drive widgets and Live Activities:
 
-## Core Capabilities
+- SVG template activities: define WidgetKit surfaces as SVG, switch named frames from taps, run pause/play timers, mutate JSON state, and collect action events in the app.
+- Full-native widget sessions: keep the widget UI fully in Swift/Kotlin/Java while Capacitor owns shared JSON state and app-to-widget or widget-to-app messages.
 
-- `areActivitiesSupported` - Check whether the native template activity bridge can run on the current device.
-- `startTemplateActivity` - Persist a generic SVG template activity and start the matching native Live Activity bridge.
-- `updateTemplateActivity` - Replace part or all of the stored activity definition/state.
-- `endTemplateActivity` - End a running activity while optionally persisting one last state snapshot.
+Use SVG templates when your widget can be rendered from resolved SVG strings. Use full-native sessions when the widget needs a custom native UI but still has to start, stop, sync state, or ask the app to complete async work.
+
+## Choose A Mode
+
+| Mode | Best for | Main APIs |
+| --- | --- | --- |
+| SVG template activity | Live Activities or widget surfaces that render from SVG output | `startTemplateActivity`, `performTemplateAction`, `listTemplateEvents` |
+| Full-native widget session | Native-rendered widgets that need shared state and async jobs | `startWidgetSession`, `updateWidgetSession`, `sendWidgetMessage` |
+
+Both modes can live in the same app. For example, a workout app can use an SVG Live Activity for fast frame/timer controls and a full-native widget session for a home-screen widget with a richer native layout.
+
+## SVG Template Capabilities
+
+SVG templates include the pieces needed for interactive widget surfaces:
+
+- `frames` hold named SVG variants such as `summary`, `timer`, or `details`.
+- `frameMutations` switch, toggle, or step through frames after a hotspot action.
+- `timerMutations` start, pause, resume, toggle, reset, stop, or change timer duration.
+- `patches` update JSON state using literal values, templates, timestamps, increments, toggles, or unset operations.
+- `hotspots` map tap areas to action identifiers.
+- `listTemplateEvents` lets the app process widget-originated actions later.
+
+The runtime resolves placeholders like `{{state.title}}`, `{{timers.rest.remainingText}}`, and `{{meta.template.kind}}` before the native bridge returns a surface for rendering.
+
+## Full-Native Bridge Capabilities
+
+Full-native sessions are for widgets that render their own UI natively:
+
+- `startWidgetSession` creates shared state and metadata for native widget code.
+- `updateWidgetSession` merges or replaces state and marks the session active again.
+- `stopWidgetSession` records a final state and marks the session stopped.
+- `sendWidgetMessage` queues app-to-widget or widget-to-app work.
+- `acknowledgeWidgetMessages` marks messages as received.
+- `completeWidgetMessage` stores a response or failure for async jobs.
+
+Messages are idempotent after completion: retrying a completed or failed message returns the existing result instead of overwriting it.
 
 ## Public API
 
 | Method | Description |
 | --- | --- |
 | `areActivitiesSupported` | Check whether the native template activity bridge can run on the current device. |
-| `startTemplateActivity` | Persist a generic SVG template activity and start the matching native Live Activity bridge. |
-| `updateTemplateActivity` | Replace part or all of the stored activity definition/state. |
-| `endTemplateActivity` | End a running activity while optionally persisting one last state snapshot. |
-| `performTemplateAction` | Execute one declarative action and record the resulting event. |
-| `getTemplateActivity` | Read one activity back from the shared store. |
-| `listTemplateActivities` | List every activity currently known by the plugin. |
-| `listTemplateEvents` | List stored action events so the app can react to widget interactions later. |
-| `acknowledgeTemplateEvents` | Mark previously processed events as acknowledged. |
+| `startTemplateActivity` | Persist an SVG template activity and start the native Live Activity bridge. |
+| `updateTemplateActivity` | Replace the activity definition, state, or open URL. |
+| `endTemplateActivity` | End a running activity and optionally persist one last state snapshot. |
+| `performTemplateAction` | Execute declarative patches, frame mutations, timer mutations, and event logging. |
+| `getTemplateActivity` | Read one stored template activity. |
+| `listTemplateActivities` | List every stored template activity. |
+| `listTemplateEvents` | Read action events emitted by template actions. |
+| `acknowledgeTemplateEvents` | Mark template events as processed. |
+| `startWidgetSession` | Start a full-native widget session backed by shared JSON state. |
+| `updateWidgetSession` | Merge or replace a full-native widget session state. |
+| `stopWidgetSession` | Stop a full-native widget session and optionally persist final state. |
+| `getWidgetSession` | Read one full-native widget session. |
+| `listWidgetSessions` | List every full-native widget session. |
+| `sendWidgetMessage` | Queue a message between the app and native widget code. |
+| `listWidgetMessages` | List queued bridge messages. |
+| `acknowledgeWidgetMessages` | Mark bridge messages as acknowledged. |
+| `completeWidgetMessage` | Complete or fail an async bridge message. |
 | `getPluginVersion` | Return the platform implementation version marker. |
+
+## Native Pieces
+
+The plugin also ships native helpers for widget targets:
+
+- `CapgoTemplateWidgetBridge` resolves an SVG template surface into `svg`, `frameId`, `hotspots`, and metadata.
+- `CapgoTemplateActionIntent` connects interactive iOS widget buttons to template actions.
+- `CapgoNativeWidgetBridge` loads full-native sessions and messages from native widget code.
+- Android template helpers provide matching action receiver and widget bridge behavior.
 
 ## Source Of Truth
 
-This reference is synced from `src/definitions.ts` in [capacitor-widget-kit](https://github.com/Cap-go/capacitor-widget-kit/).
+The API reference is synced from [`src/definitions.ts`](https://github.com/Cap-go/capacitor-widget-kit/blob/main/src/definitions.ts) in the plugin repository.


### PR DESCRIPTION
## Summary
- Expand Widget Kit docs around the two implementation modes: SVG template Live Activities and full-native widget sessions.
- Add examples for frame switching, timer mutations, action events, async widget messages, and session lifecycle APIs.
- Update the public plugin tutorial and registry description to match the plugin runtime bridge behavior.

## Checks
- bunx prettier --write <touched files>
- bun run check:docs-mirror
- git diff --check
- bun run check
- bun run build:docs
- bun run build:web