### PR TITLE
[codex] market background geofencing docs

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/background-geolocation/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/background-geolocation/getting-started.mdx
@@ -1,9 +1,12 @@
 ---
 title: Getting Started
-description: "Install @capgo/background-geolocation and start using its current Capacitor API."
+description: "Install @capgo/background-geolocation for background location tracking and native geofencing."
 sidebar:
   order: 2
 ---
+
+
+`@capgo/background-geolocation` combines precise background location tracking with native geofencing for iOS and Android. Use it for delivery zones, stores, job sites, campuses, check-ins, route alerts, and any workflow that needs enter or exit events even when the WebView is not running.
 
 ## Install
 
@@ -84,6 +87,44 @@ await BackgroundGeolocation.setPlannedRoute({
   route: [[-74.0060, 40.7128], [-118.2437, 34.0522]]
 });
 ```
+
+### Native geofencing
+
+Geofencing runs in the native layer, so iOS and Android can trigger enter and exit events without relying on the WebView to stay awake. Configure a webhook URL when your backend must receive transitions even while the app UI is suspended.
+
+```typescript
+import { BackgroundGeolocation } from '@capgo/background-geolocation';
+
+await BackgroundGeolocation.setupGeofencing({
+  url: 'https://api.example.com/geofences',
+  notifyOnEntry: true,
+  notifyOnExit: true,
+  payload: { userId: '123' },
+});
+
+await BackgroundGeolocation.addGeofence({
+  identifier: 'store-42',
+  latitude: 37.33182,
+  longitude: -122.03118,
+  radius: 150,
+  payload: { storeId: '42' },
+});
+
+const handle = await BackgroundGeolocation.addListener(
+  'geofenceTransition',
+  (event) => {
+    console.log(event.identifier, event.transition);
+  },
+);
+
+const { regions } = await BackgroundGeolocation.getMonitoredGeofences();
+console.log(regions);
+
+await BackgroundGeolocation.removeGeofence({ identifier: 'store-42' });
+await handle.remove();
+```
+
+On iOS, geofencing requires Always location authorization. On Android 10 and newer, geofencing needs background location permission in addition to foreground location permission.
 
 ## Type Reference
 

--- a/apps/docs/src/content/docs/docs/plugins/background-geolocation/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/background-geolocation/getting-started.mdx
@@ -90,7 +90,7 @@ await BackgroundGeolocation.setPlannedRoute({
 
 ### Native geofencing
 
-Geofencing runs in the native layer, so iOS and Android can trigger enter and exit events without relying on the WebView to stay awake. Configure a webhook URL when your backend must receive transitions even while the app UI is suspended.
+Geofencing runs in the native layer, so iOS and Android can trigger enter and exit events without relying on the WebView to stay awake. Configure an HTTP or HTTPS webhook URL when your backend must receive transitions even while the app UI is suspended.
 
 ```typescript
 import { BackgroundGeolocation } from '@capgo/background-geolocation';
@@ -117,14 +117,26 @@ const handle = await BackgroundGeolocation.addListener(
   },
 );
 
+const errorHandle = await BackgroundGeolocation.addListener(
+  'geofenceError',
+  (event) => {
+    console.error(event.identifier, event.message);
+  },
+);
+
 const { regions } = await BackgroundGeolocation.getMonitoredGeofences();
 console.log(regions);
 
 await BackgroundGeolocation.removeGeofence({ identifier: 'store-42' });
 await handle.remove();
+await errorHandle.remove();
 ```
 
-On iOS, geofencing requires Always location authorization. On Android 10 and newer, geofencing needs background location permission in addition to foreground location permission.
+On iOS, geofencing requires Always location authorization. On Android 10 and newer, add background location permission to your app manifest when you need background geofencing:
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+```
 
 ## Type Reference
 

--- a/apps/docs/src/content/docs/docs/plugins/background-geolocation/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/background-geolocation/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "@capgo/background-geolocation"
-description: "Receive accurate geolocation updates even while the app is in the background."
+description: "Accurate background geolocation and native geofencing for Capacitor apps on iOS and Android."
 tableOfContents: false
 next: false
 prev: false
@@ -8,7 +8,7 @@ sidebar:
   order: 1
   label: "Introduction"
 hero:
-  tagline: "Main plugin interface for background geolocation functionality. Provides methods to manage location updates and access device settings."
+  tagline: "Accurate background location tracking, native geofence enter/exit events, and transition webhooks for Capacitor apps."
   actions:
     - text: Get started
       link: /docs/plugins/background-geolocation/getting-started/
@@ -22,23 +22,34 @@ hero:
 
 ## Overview
 
-Main plugin interface for background geolocation functionality. Provides methods to manage location updates and access device settings.
+Use `@capgo/background-geolocation` when your Capacitor app needs precise location updates in the foreground or background, native circular geofences on iOS and Android, and backend delivery for geofence transitions when the WebView is suspended.
 
 ## Core Capabilities
 
-- `start` - To start listening for changes in the device's location, call this method. A Promise is returned to indicate that it finished the call. The callback will be called every time a new location is available, or if there was an error when calling this method. Don't rely on promise rejection for this.
-- `stop` - Stops location updates.
-- `openSettings` - Opens the device's location settings page. Useful for directing users to enable location services or adjust permissions.
-- `setPlannedRoute` - Plays a sound file when the user deviates from the planned route. This should be used to play a sound (in the background too, only for native).
+- `start` - Stream accurate foreground or background location updates.
+- `stop` - Stop active location tracking cleanly.
+- `openSettings` - Send users to native location settings when permissions need attention.
+- `setPlannedRoute` - Play a native sound when the user deviates from a planned route.
+- `setupGeofencing` - Configure native geofence defaults and optional transition webhook delivery.
+- `addGeofence` - Monitor a circular iOS or Android geofence region by identifier.
+- `removeGeofence` / `removeAllGeofences` - Stop monitoring one or all registered geofences.
+- `getMonitoredGeofences` - List region identifiers currently monitored by the native layer.
+- `geofenceTransition` listener - Receive enter and exit events while the app is active.
 
 ## Public API
 
 | Method | Description |
 | --- | --- |
-| `start` | To start listening for changes in the device's location, call this method. A Promise is returned to indicate that it finished the call. The callback will be called every time a new location is available, or if there was an error when calling this method. Don't rely on promise rejection for this. |
+| `start` | Streams accurate foreground or background location updates. |
 | `stop` | Stops location updates. |
 | `openSettings` | Opens the device's location settings page. Useful for directing users to enable location services or adjust permissions. |
-| `setPlannedRoute` | Plays a sound file when the user deviates from the planned route. This should be used to play a sound (in the background too, only for native). |
+| `setPlannedRoute` | Plays a native sound when the user deviates from a planned route. |
+| `setupGeofencing` | Configures geofence defaults and optional native transition POST delivery. |
+| `addGeofence` | Starts monitoring a circular geofence on iOS and Android. |
+| `removeGeofence` | Stops monitoring one geofence by identifier. |
+| `removeAllGeofences` | Stops monitoring all geofences registered by this plugin. |
+| `getMonitoredGeofences` | Returns the identifiers currently monitored by the native layer. |
+| `addListener('geofenceTransition', ...)` | Receives geofence enter and exit events while the app is alive. |
 | `getPluginVersion` | Get the native Capacitor plugin version. |
 
 ## Source Of Truth

--- a/apps/docs/src/content/docs/docs/plugins/background-geolocation/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/background-geolocation/index.mdx
@@ -35,6 +35,7 @@ Use `@capgo/background-geolocation` when your Capacitor app needs precise locati
 - `removeGeofence` / `removeAllGeofences` - Stop monitoring one or all registered geofences.
 - `getMonitoredGeofences` - List region identifiers currently monitored by the native layer.
 - `geofenceTransition` listener - Receive enter and exit events while the app is active.
+- `geofenceError` listener - Handle native monitoring errors without changing the transition event shape.
 
 ## Public API
 
@@ -50,6 +51,7 @@ Use `@capgo/background-geolocation` when your Capacitor app needs precise locati
 | `removeAllGeofences` | Stops monitoring all geofences registered by this plugin. |
 | `getMonitoredGeofences` | Returns the identifiers currently monitored by the native layer. |
 | `addListener('geofenceTransition', ...)` | Receives geofence enter and exit events while the app is alive. |
+| `addListener('geofenceError', ...)` | Receives native geofence monitoring errors while the app is alive. |
 | `getPluginVersion` | Get the native Capacitor plugin version. |
 
 ## Source Of Truth

--- a/apps/web/public/plugins-readme.md
+++ b/apps/web/public/plugins-readme.md
@@ -305,7 +305,7 @@ A collection of high-quality Capacitor plugins maintained by [Capgo](https://cap
 <td align="center" width="33%">
 <h3><a href="https://github.com/Cap-go/capacitor-background-geolocation/">Background Geolocation</a></h3>
 <p><code>@capgo/capacitor-background-geolocation</code></p>
-<p>Track device location continuously in background with battery-efficient geofencing</p>
+<p>Accurate background location tracking with native iOS and Android geofencing plus transition webhooks</p>
 <p>
 <a href="https://www.npmjs.com/package/@capgo/capacitor-background-geolocation"><img src="https://img.shields.io/npm/dw/@capgo/capacitor-background-geolocation?style=flat-square&label=downloads" alt="npm downloads"></a>
 <a href="https://github.com/Cap-go/capacitor-background-geolocation/"><img src="https://img.shields.io/github/stars/Cap-go/capacitor-background-geolocation?style=flat-square&label=stars" alt="GitHub stars"></a>

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -60,7 +60,7 @@ const actionDefinitionRows =
 @capgo/capacitor-appinsights|github.com/Cap-go|Track app usage, performance metrics, and user behavior with Apptopia AppInsights|https://github.com/Cap-go/capacitor-appinsights/|AppInsights
 @capgo/capacitor-app-attest|github.com/Cap-go|Capacitor plugin for cross-platform device attestation using Apple App Attest and Google Play Integrity Standard|https://github.com/Cap-go/capacitor-app-attest/|App Attest
 @capgo/capacitor-audiosession|github.com/Cap-go|Configure iOS audio session for background playback, mixing, and routing control|https://github.com/Cap-go/capacitor-audiosession/|Audio Session
-@capgo/capacitor-background-geolocation|github.com/Cap-go|Track device location continuously in background with battery-efficient geofencing|https://github.com/Cap-go/capacitor-background-geolocation/|Background Geolocation
+@capgo/capacitor-background-geolocation|github.com/Cap-go|Accurate background location tracking with native iOS and Android geofencing plus transition webhooks|https://github.com/Cap-go/capacitor-background-geolocation/|Background Geolocation
 @capgo/capacitor-document-scanner|github.com/Cap-go|Scan documents with auto edge detection, perspective correction, and PDF export|https://github.com/Cap-go/capacitor-document-scanner/|Document Scanner
 @capgo/capacitor-downloader|github.com/Cap-go|Download large files in background with progress tracking and pause/resume support|https://github.com/Cap-go/capacitor-downloader/|Downloader
 @capgo/capacitor-env|github.com/Cap-go|Securely manage environment variables and configuration across different build environments|https://github.com/Cap-go/capacitor-env/|Env

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-background-geolocation.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-background-geolocation.md
@@ -23,6 +23,7 @@ bunx cap sync
 - `removeGeofence` / `removeAllGeofences` - Stop monitoring one or all registered regions.
 - `getMonitoredGeofences` - List monitored region identifiers.
 - `geofenceTransition` listener - Receive enter and exit events while the app is active.
+- `geofenceError` listener - Handle native monitoring errors separately from transition events.
 
 ## Example Usage
 
@@ -89,7 +90,7 @@ await BackgroundGeolocation.setPlannedRoute({
 
 ### Native geofencing
 
-Monitor stores, job sites, delivery zones, campuses, or check-in areas with native iOS and Android geofences. Add a `url` to let native code POST transition payloads while the WebView is suspended.
+Monitor stores, job sites, delivery zones, campuses, or check-in areas with native iOS and Android geofences. Add an HTTP or HTTPS `url` to let native code POST transition payloads while the WebView is suspended.
 
 ```typescript
 import { BackgroundGeolocation } from '@capgo/background-geolocation';
@@ -113,8 +114,20 @@ const listener = await BackgroundGeolocation.addListener(
   (event) => console.log(event.identifier, event.transition),
 );
 
+const errorListener = await BackgroundGeolocation.addListener(
+  'geofenceError',
+  (event) => console.error(event.identifier, event.message),
+);
+
 await BackgroundGeolocation.removeGeofence({ identifier: 'warehouse' });
 await listener.remove();
+await errorListener.remove();
+```
+
+On Android, add `ACCESS_BACKGROUND_LOCATION` to your app manifest only when you need background geofencing:
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 ```
 
 ## Full Reference

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-background-geolocation.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-background-geolocation.md
@@ -3,7 +3,7 @@ locale: en
 ---
 # Using @capgo/background-geolocation
 
-Main plugin interface for background geolocation functionality. Provides methods to manage location updates and access device settings.
+Accurate background geolocation and native geofencing for Capacitor apps on iOS and Android. Use it to stream precise location updates, monitor circular regions, and deliver geofence enter/exit transitions to JavaScript or your backend.
 
 ## Install
 
@@ -14,10 +14,15 @@ bunx cap sync
 
 ## What This Plugin Exposes
 
-- `start` - To start listening for changes in the device's location, call this method. A Promise is returned to indicate that it finished the call. The callback will be called every time a new location is available, or if there was an error when calling this method. Don't rely on promise rejection for this.
-- `stop` - Stops location updates.
-- `openSettings` - Opens the device's location settings page. Useful for directing users to enable location services or adjust permissions.
-- `setPlannedRoute` - Plays a sound file when the user deviates from the planned route. This should be used to play a sound (in the background too, only for native).
+- `start` - Stream accurate foreground or background location updates.
+- `stop` - Stop active location tracking.
+- `openSettings` - Open native settings when users need to fix location permissions.
+- `setPlannedRoute` - Play a native sound when the user leaves a planned route.
+- `setupGeofencing` - Configure native geofence defaults and optional transition webhook delivery.
+- `addGeofence` - Monitor a circular iOS or Android geofence region.
+- `removeGeofence` / `removeAllGeofences` - Stop monitoring one or all registered regions.
+- `getMonitoredGeofences` - List monitored region identifiers.
+- `geofenceTransition` listener - Receive enter and exit events while the app is active.
 
 ## Example Usage
 
@@ -80,6 +85,36 @@ await BackgroundGeolocation.setPlannedRoute({
   soundFile: "notification.mp3",
   route: [[-74.0060, 40.7128], [-118.2437, 34.0522]]
 });
+```
+
+### Native geofencing
+
+Monitor stores, job sites, delivery zones, campuses, or check-in areas with native iOS and Android geofences. Add a `url` to let native code POST transition payloads while the WebView is suspended.
+
+```typescript
+import { BackgroundGeolocation } from '@capgo/background-geolocation';
+
+await BackgroundGeolocation.setupGeofencing({
+  url: 'https://api.example.com/geofences',
+  notifyOnEntry: true,
+  notifyOnExit: true,
+  payload: { userId: '123' },
+});
+
+await BackgroundGeolocation.addGeofence({
+  identifier: 'warehouse',
+  latitude: 40.7128,
+  longitude: -74.006,
+  radius: 200,
+});
+
+const listener = await BackgroundGeolocation.addListener(
+  'geofenceTransition',
+  (event) => console.log(event.identifier, event.transition),
+);
+
+await BackgroundGeolocation.removeGeofence({ identifier: 'warehouse' });
+await listener.remove();
 ```
 
 ## Full Reference

--- a/scripts/action.mjs
+++ b/scripts/action.mjs
@@ -333,7 +333,7 @@ export const actions = [
   {
     name: '@capgo/capacitor-background-geolocation',
     author: 'Martin Donadieu',
-    description: 'Track device location in background with battery optimization',
+    description: 'Accurate background location tracking with native geofencing and transition webhooks',
     href: 'https://github.com/Cap-go/capacitor-background-geolocation/',
     title: 'Background Geolocation',
   },


### PR DESCRIPTION
## What

- Updates the `@capgo/background-geolocation` docs intro, API overview, getting-started guide, and tutorial to highlight native geofencing.
- Refreshes plugin card and generated plugin README marketing copy to mention iOS/Android geofencing and transition webhooks.

## Why

The plugin now includes native geofence monitoring, enter/exit events, and transition webhook delivery. The website copy should make that capability visible in docs and marketing surfaces.

## How

- Added geofencing setup and listener examples to the plugin docs and tutorial.
- Expanded the public API tables and feature bullets with the new geofence methods.
- Updated the plugin registry descriptions used by website/plugin listing surfaces.

## Testing

- `bunx prettier --write apps/docs/src/content/docs/docs/plugins/background-geolocation/index.mdx apps/docs/src/content/docs/docs/plugins/background-geolocation/getting-started.mdx apps/web/src/content/plugins-tutorials/en/capacitor-background-geolocation.md apps/web/src/config/plugins.ts scripts/action.mjs apps/web/public/plugins-readme.md`
- `bun run check`

## Not Tested

- Live website deployment preview manual review, pending CI preview availability.