### PR TITLE
[codex] polish Capgo landing UI

### DIFF
--- a/apps/web/src/components/Hero.astro
+++ b/apps/web/src/components/Hero.astro
@@ -198,7 +198,7 @@ const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. $
             </div>
             <a
               href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
-              class="font-pj relative z-10 inline-flex items-center justify-center rounded-xl bg-blue-600 px-8 py-4 text-lg font-bold text-white transition-all duration-200 focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:outline-none"
+              class="font-pj relative z-10 inline-flex items-center justify-center rounded-xl bg-blue-600 px-8 py-4 text-lg font-bold text-white shadow-lg shadow-blue-600/20 transition-all duration-200 hover:bg-blue-500 focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 focus-visible:outline-none active:scale-[0.98]"
             >
               {m.cta_start_free({}, { locale: Astro.locals.locale })}
             </a>
@@ -342,11 +342,11 @@ const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. $
             <span class="text-center text-xs font-semibold text-slate-500">{m.soc2_compliance_short({}, { locale: Astro.locals.locale })}</span>
           </div>
           <div class="flex flex-col items-center gap-1">
-            <img loading="lazy" src="/soc1.svg" alt={m.compliance_soc1({}, { locale: Astro.locals.locale })} class="w-autoo h-10 opacity-90 transition-opacity hover:opacity-80" />
+            <img loading="lazy" src="/soc1.svg" alt={m.compliance_soc1({}, { locale: Astro.locals.locale })} class="h-10 w-auto opacity-90 transition-opacity hover:opacity-80" />
             <span class="text-center text-xs font-semibold text-slate-500">{m.compliance_soc1({}, { locale: Astro.locals.locale })}</span>
           </div>
           <div class="flex flex-col items-center gap-1">
-            <img loading="lazy" src="/gdpr.svg" alt={m.compliance_gdpr({}, { locale: Astro.locals.locale })} class="w-autoo h-10 opacity-90 transition-opacity hover:opacity-80" />
+            <img loading="lazy" src="/gdpr.svg" alt={m.compliance_gdpr({}, { locale: Astro.locals.locale })} class="h-10 w-auto opacity-90 transition-opacity hover:opacity-80" />
             <span class="text-center text-xs font-semibold text-slate-500">{m.compliance_gdpr({}, { locale: Astro.locals.locale })}</span>
           </div>
         </div>

--- a/apps/web/src/components/ProblemSolution.astro
+++ b/apps/web/src/components/ProblemSolution.astro
@@ -45,11 +45,11 @@ const locale = Astro.locals.locale
 
         <!-- Timeline -->
         <div class="mt-4 mb-12 flex flex-wrap justify-center gap-2">
-          <span class="rounded-md border border-gray-700 bg-[#222] px-3 py-1 font-mono text-xs text-gray-300">/👷dev</span>
-          <span class="rounded-md border border-gray-700 bg-[#222] px-3 py-1 font-mono text-xs text-gray-300">/📦build</span>
-          <span class="rounded-md border border-blue-900/50 bg-[#222] px-3 py-1 font-mono text-xs text-blue-300">/🚢submit</span>
-          <span class="rounded-md border border-blue-900/50 bg-[#222] px-3 py-1 font-mono text-xs text-blue-300">/👮review</span>
-          <span class="rounded-md border border-green-900/50 bg-[#222] px-3 py-1 font-mono text-xs text-green-400">/✅live</span>
+          <span class="rounded-md border border-gray-700 bg-[#222] px-3 py-1 font-mono text-xs text-gray-300">/dev</span>
+          <span class="rounded-md border border-gray-700 bg-[#222] px-3 py-1 font-mono text-xs text-gray-300">/build</span>
+          <span class="rounded-md border border-blue-900/50 bg-[#222] px-3 py-1 font-mono text-xs text-blue-300">/submit</span>
+          <span class="rounded-md border border-blue-900/50 bg-[#222] px-3 py-1 font-mono text-xs text-blue-300">/review</span>
+          <span class="rounded-md border border-green-900/50 bg-[#222] px-3 py-1 font-mono text-xs text-green-400">/live</span>
         </div>
 
         <!-- Chat -->
@@ -88,9 +88,9 @@ const locale = Astro.locals.locale
 
         <!-- Timeline -->
         <div class="mt-4 mb-12 flex flex-wrap justify-center gap-2">
-          <span class="rounded-md border border-gray-700 bg-[#222] px-3 py-1 font-mono text-xs text-gray-300">/👷dev</span>
-          <span class="rounded-md border border-gray-700 bg-[#222] px-3 py-1 font-mono text-xs text-gray-300">/📦build</span>
-          <span class="rounded-md border border-green-900/50 bg-[#222] px-3 py-1 font-mono text-xs text-green-400">/✅live</span>
+          <span class="rounded-md border border-gray-700 bg-[#222] px-3 py-1 font-mono text-xs text-gray-300">/dev</span>
+          <span class="rounded-md border border-gray-700 bg-[#222] px-3 py-1 font-mono text-xs text-gray-300">/build</span>
+          <span class="rounded-md border border-green-900/50 bg-[#222] px-3 py-1 font-mono text-xs text-green-400">/live</span>
         </div>
 
         <!-- Chat -->


### PR DESCRIPTION
## Summary

Tiny landing-page UI polish for Capgo:

- removes emoji-prefixed command chips from the problem/solution timeline so the section feels cleaner and more developer-tool native
- adds a subtle shadow, hover color, pressed state, and `focus-visible` ring to the hero CTA
- fixes the `w-autoo` typo on the SOC 1 and GDPR badge images

## Before / After

Before:

![Before](https://gist.githubusercontent.com/riderx/103bb88ee7ff593bae9f03fb0ff5cd88/raw/1f5ec8e2745fee48226166a42197931dc0d150c7/capgo-ui-before.svg)

After:

![After](https://gist.githubusercontent.com/riderx/103bb88ee7ff593bae9f03fb0ff5cd88/raw/21eac131fc36866a0971e1b91fff323273de5d0e/capgo-ui-after.svg)

## Validation

- `bunx prettier --write apps/web/src/components/Hero.astro apps/web/src/components/ProblemSolution.astro`
- `cd apps/web && bun run check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced call-to-action button with improved visual styling including shadow effects and interactive focus states
  * Added SOC1 compliance logo to the trust badges section
  * Updated workflow timeline to use text labels for improved readability with enhanced color-coding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->