### PR TITLE
[codex] update Cloud Build release status

### DIFF
--- a/apps/docs/src/content/docs/docs/cli/cloud-build/troubleshooting.mdx
+++ b/apps/docs/src/content/docs/docs/cli/cloud-build/troubleshooting.mdx
@@ -404,7 +404,7 @@ Large projects (>200MB) may hit timeout limits. Contact support for enterprise o
 
 1. **Check build configuration**
    - Artifact storage may not be configured
-   - For public beta, contact support about artifact access
+   - Contact support if artifact access is unavailable for your build
 
 2. **For iOS TestFlight submission**
    - Check App Store Connect
@@ -495,12 +495,12 @@ When contacting support, include:
 
 ### Known Limitations
 
-Current limitations during public beta:
+Current limitations:
 
 - Maximum build time: 10 minutes
 - Maximum upload size: ~500MB
 - iOS builds require 24-hour Mac leases, build on Mac will enqueue to ensure optimal usage
-- Build artifact download may not be available
+- Build artifact download availability depends on build destination and artifact storage configuration
 
 These limitations may be adjusted based on feedback.
 

--- a/apps/web/src/content/blog/en/introducing-capgo-cloud-build.md
+++ b/apps/web/src/content/blog/en/introducing-capgo-cloud-build.md
@@ -257,11 +257,11 @@ Cloud Build complements our existing [live update system](/blog/update-your-capa
 
 Use Cloud Build when you add a new plugin or change native configurations. Use live updates for everything else. Together, they give you the fastest possible deployment workflow.
 
-## Current Status: Public Beta
+## Current Status: Fully Released
 
-Cloud Build is currently in **public beta**. We're working with a select group of early adopters to refine the experience before opening it to everyone.
+Cloud Build has been fully released since January and is available to all Capgo users. We're continuing to improve the experience based on production feedback.
 
-Interested in trying it out? [Join our Discord](https://discord.com/invite/VnYRvBfgA6) and let us know - we'd love to have you as an early tester!
+Need help getting started? [Join our Discord](https://discord.com/invite/VnYRvBfgA6) and let us know - we'd love to help you get your first build running.
 
 ## Getting Started
 

--- a/apps/web/src/content/blog/en/introducing-capgo-cloud-build.md
+++ b/apps/web/src/content/blog/en/introducing-capgo-cloud-build.md
@@ -259,7 +259,7 @@ Use Cloud Build when you add a new plugin or change native configurations. Use l
 
 ## Current Status: Fully Released
 
-Cloud Build has been fully released since January and is available to all Capgo users. We're continuing to improve the experience based on production feedback.
+Cloud Build has been fully released since January 2026 and is available to all Capgo users. We're continuing to improve the experience based on production feedback.
 
 Need help getting started? [Join our Discord](https://discord.com/invite/VnYRvBfgA6) and let us know - we'd love to help you get your first build running.
 


### PR DESCRIPTION
## What changed

- Updated the Cloud Build launch blog to say Cloud Build is fully released since January.
- Removed beta-era wording from Cloud Build troubleshooting guidance.
- Kept artifact-access guidance status-neutral for current users.

## Why

People were seeing outdated copy that described Cloud Build as a public beta, even though it has been fully released since January.

## Validation

- `bunx prettier --write apps/web/src/content/blog/en/introducing-capgo-cloud-build.md apps/docs/src/content/docs/docs/cli/cloud-build/troubleshooting.mdx`
- `bun run check`
- Searched Cloud Build docs/blog paths for remaining public-beta wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cloud Build is now fully released, transitioning from public beta status
  * Updated troubleshooting guide with clearer artifact access guidance and support contact instructions
  * Clarified artifact download availability information based on destination and storage configuration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/655)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->