### PR TITLE
Add native navigation plugin docs

### DIFF
--- a/apps/docs/src/config/llmsCustomSets.ts
+++ b/apps/docs/src/config/llmsCustomSets.ts
@@ -68,6 +68,7 @@ Plugin Native Audio|native audio playback plugin|docs/plugins/native-audio/**
 Plugin Native Biometric|biometric authentication plugin for fingerprint and face ID|docs/plugins/native-biometric/**
 Plugin Native Geocoder|native geocoding plugin for address lookup|docs/plugins/nativegeocoder/**
 Plugin Native Market|app store deep linking plugin|docs/plugins/native-market/**
+Plugin Native Navigation|native navbar, tabbar, and transition shell plugin for Capacitor WebView apps|docs/plugins/native-navigation/**
 Plugin Native Purchases|in-app purchases, subscriptions, paywalls, revenue playbook, and monetization plugin|docs/plugins/native-purchases/**
 Plugin Navigation Bar|Android navigation bar customization plugin|docs/plugins/navigation-bar/**
 Plugin NFC|NFC reading and writing plugin|docs/plugins/nfc/**

--- a/apps/docs/src/config/sidebar.mjs
+++ b/apps/docs/src/config/sidebar.mjs
@@ -130,6 +130,7 @@ const pluginEntries = [
   ['Native Biometric', 'native-biometric'],
   ['Native Geocoder', 'nativegeocoder'],
   ['Native Market', 'native-market'],
+  ['Native Navigation', 'native-navigation'],
   section(
     'Native Purchases',
     [

--- a/apps/docs/src/content/docs/docs/plugins/native-navigation/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-navigation/getting-started.mdx
@@ -1,0 +1,200 @@
+---
+title: Getting Started
+description: Install @capgo/native-navigation and render native navigation chrome over a Capacitor WebView.
+sidebar:
+  order: 2
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+import { PackageManagers } from 'starlight-package-managers'
+
+<Steps>
+1. **Install the package**
+   <PackageManagers pkg="@capgo/native-navigation" pkgManagers={['bun']} />
+
+2. **Sync native projects**
+   <PackageManagers type="exec" pkg="cap" args="sync" pkgManagers={['bun']} />
+
+3. **Configure native chrome**
+
+   ```ts
+   import { NativeNavigation } from '@capgo/native-navigation';
+
+   await NativeNavigation.configure({
+     contentInsetMode: 'css',
+     animationDuration: 360,
+     colors: {
+       tint: '#0f172a',
+       inactiveTint: '#64748b',
+     },
+   });
+   ```
+
+4. **Render the native navbar**
+
+   ```ts
+   await NativeNavigation.setNavbar({
+     title: 'Home',
+     subtitle: 'Native chrome',
+     transparent: true,
+     backButton: { visible: false },
+     rightItems: [
+       {
+         id: 'compose',
+         title: 'Compose',
+         icon: {
+           svg: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>',
+         },
+       },
+     ],
+   });
+   ```
+
+5. **Render the native tabbar**
+
+   ```ts
+   await NativeNavigation.setTabbar({
+     selectedId: 'home',
+     labels: true,
+     icons: true,
+     tabs: [
+       {
+         id: 'home',
+         title: 'Home',
+         icon: {
+           svg: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 10v10h14V10"/></svg>',
+         },
+       },
+       {
+         id: 'settings',
+         title: 'Settings',
+         badge: '2',
+         icon: {
+           svg: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3"/></svg>',
+         },
+       },
+     ],
+   });
+   ```
+
+6. **Handle native intent events**
+
+   ```ts
+   await NativeNavigation.addListener('navbarBack', () => {
+     router.back();
+   });
+
+   await NativeNavigation.addListener('navbarItemTap', ({ id }) => {
+     if (id === 'compose') router.push('/compose');
+   });
+
+   await NativeNavigation.addListener('tabSelect', ({ id }) => {
+     router.push(`/${id}`);
+   });
+   ```
+</Steps>
+
+## Transition flow
+
+Native transitions are a transaction around your normal JavaScript route change:
+
+```ts
+const transition = await NativeNavigation.beginTransition({
+  direction: 'forward',
+});
+
+router.push('/detail');
+await router.ready?.();
+
+await NativeNavigation.setNavbar({
+  title: 'Detail',
+  backButton: { visible: true, title: 'Back' },
+});
+
+await NativeNavigation.finishTransition({
+  id: transition.id,
+  direction: 'forward',
+});
+```
+
+## CSS insets
+
+With `contentInsetMode: 'css'`, the plugin writes native bar dimensions to `document.documentElement`.
+
+```css
+.page {
+  padding-top: var(--cap-native-navigation-top);
+  padding-bottom: var(--cap-native-navigation-bottom);
+}
+```
+
+Available variables:
+
+- `--cap-native-navigation-top`
+- `--cap-native-navigation-right`
+- `--cap-native-navigation-bottom`
+- `--cap-native-navigation-left`
+- `--cap-native-navbar-height`
+- `--cap-native-tabbar-height`
+
+## Icon descriptors
+
+Icons must be serializable because native UI renders them. You can use cross-platform SVG, platform-specific SVG, SF Symbols, bundled iOS images, Android drawable resources, or bundled Android images.
+
+```ts
+const icon = {
+  svg: '<svg viewBox="0 0 24 24"><path d="M3 10.5 12 3l9 7.5"/></svg>',
+  width: 24,
+  height: 24,
+  template: true,
+  src: 'fallback_asset_name',
+  ios: {
+    svg: '<svg viewBox="0 0 24 24"><path d="M3 10.5 12 3l9 7.5"/></svg>',
+    sfSymbol: 'house.fill',
+    image: 'BundledAssetName',
+  },
+  android: {
+    svg: '<svg viewBox="0 0 24 24"><path d="M3 10.5 12 3l9 7.5"/></svg>',
+    resource: 'ic_menu_view',
+    image: 'bundled_drawable_name',
+  },
+};
+```
+
+Inline SVG supports the icon-focused subset used by common icon sets such as Lucide and Feather: `path`, `line`, `polyline`, `polygon`, `circle`, and `rect`. SVG icons are rendered as template images by default, so native tint colors can recolor them.
+
+## Optional web components
+
+The package can register custom elements for framework-agnostic declarative setup:
+
+```ts
+import { defineNativeNavigationElements } from '@capgo/native-navigation';
+
+defineNativeNavigationElements();
+```
+
+```html
+<cap-native-navigation-provider enabled="true" content-inset-mode="css"></cap-native-navigation-provider>
+
+<cap-native-navbar
+  title="Home"
+  transparent
+  right-items='[{"id":"compose","title":"Compose","icon":{"svg":"<svg viewBox=\"0 0 24 24\"><path d=\"M12 20h9\"/></svg>"}}]'
+></cap-native-navbar>
+
+<cap-native-tabbar
+  selected-id="home"
+  tabs='[{"id":"home","title":"Home","icon":{"ios":{"sfSymbol":"house.fill"}}}]'
+></cap-native-tabbar>
+```
+
+<Aside type="note">
+  The web components are optional. React, Vue, Angular, Svelte, Solid, and vanilla apps can all use the imperative API directly.
+</Aside>
+
+## Platform notes
+
+- iOS renders `UINavigationBar` and `UITabBar`; iOS 26+ uses the system Liquid Glass bar behavior.
+- Android renders an AppCompat toolbar and Material bottom navigation.
+- Web fallback does not draw native bars. It mirrors events and inset variables for browser development.
+- The plugin keeps one full-screen Capacitor WebView. Native owns the frame, bars, safe-area reporting, and transition shell.

--- a/apps/docs/src/content/docs/docs/plugins/native-navigation/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-navigation/index.mdx
@@ -1,0 +1,63 @@
+---
+title: "@capgo/native-navigation"
+description: Native navbar, tabbar, and transition shell chrome for Capacitor apps that keep content in one WebView.
+tableOfContents: false
+next: false
+prev: false
+sidebar:
+  order: 1
+  label: "Introduction"
+hero:
+  tagline: Render iOS and Android navigation chrome natively while JavaScript keeps owning routes, content, icons, labels, and bar state.
+  actions:
+    - text: Get started
+      link: /docs/plugins/native-navigation/getting-started/
+      icon: right-arrow
+      variant: primary
+    - text: GitHub
+      link: https://github.com/Cap-go/capacitor-native-navigation/
+      icon: external
+      variant: minimal
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+<CardGrid stagger>
+  <Card title="Native chrome" icon="puzzle">
+    Draw the top navigation bar and bottom tab bar with platform UI instead of web components.
+  </Card>
+  <Card title="Web-owned routes" icon="rocket">
+    Native emits user intent events, then your existing router changes the WebView content.
+  </Card>
+  <Card title="Serialized icons" icon="pencil">
+    Configure tabs and buttons with SVG, SF Symbol, bundled image, or Android drawable descriptors.
+  </Card>
+  <Card title="Native transition shell" icon="setting">
+    Capture the current WebView, update content in JavaScript, then finish with a native snapshot-to-WebView animation.
+  </Card>
+</CardGrid>
+
+## Core API
+
+- `configure(options?)` enables the native chrome host and controls content insets.
+- `setNavbar(options)` updates native title, subtitle, back button, buttons, colors, transparency, and visibility.
+- `setTabbar(options)` updates tabs, selected tab, badges, labels, icons, colors, and visibility.
+- `beginTransition(options?)` captures the outgoing WebView before the JavaScript route change.
+- `finishTransition(options?)` animates from the captured snapshot to the live WebView after route content is ready.
+- `getPluginVersion()` returns the native implementation version marker.
+
+## Events
+
+- `navbarBack` fires when the native back affordance is tapped.
+- `navbarItemTap` fires when a native navbar action button is tapped.
+- `tabSelect` fires when a native tab is selected.
+- `safeAreaChanged` reports native bar and safe-area inset changes.
+- `transitionStart` and `transitionEnd` report native transition boundaries.
+
+## Platform Model
+
+iOS uses `UINavigationBar` and `UITabBar`. On iOS 26 and newer, the plugin lets the system render Liquid Glass behavior; older versions use native translucent/material fallbacks.
+
+Android uses an AppCompat toolbar and Material bottom navigation with edge-to-edge placement.
+
+The plugin does not create one native WebView per route. Version 1 keeps a single Capacitor WebView for bridge stability and lets native own only the frame, bar visuals, tab selection chrome, safe-area reporting, and transition shell.

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -21,6 +21,7 @@ export interface Plugin extends Action {
 
 const actionDefinitionRows =
   String.raw`@capgo/native-market|github.com/Cap-go|Deep link users directly to your app page on Google Play Store or Apple App Store|https://github.com/Cap-go/capacitor-native-market/|Native Market
+@capgo/native-navigation|github.com/Cap-go|Render native navbars, tabbars, and transition shells over a full-screen Capacitor WebView|https://github.com/Cap-go/capacitor-native-navigation/|Native Navigation
 @capgo/capacitor-native-biometric|github.com/Cap-go|Secure authentication using Face ID, Touch ID, and Android biometric APIs|https://github.com/Cap-go/capacitor-native-biometric/|Native Biometric
 @capgo/camera-preview|github.com/Cap-go|Display live camera feed as overlay with customizable controls and capture capabilities|https://github.com/Cap-go/capacitor-camera-preview/|Camera Preview
 @capgo/capacitor-updater|github.com/Cap-go|Deploy live updates instantly to your users without app store review delays|https://github.com/Cap-go/capacitor-updater/|Updater
@@ -151,6 +152,7 @@ const actionDefinitionRows =
 
 const pluginIconsByName: Record<string, string> = {
   '@capgo/native-market': 'ArchiveBoxArrowDown',
+  '@capgo/native-navigation': 'DevicePhoneMobile',
   '@capgo/capacitor-native-biometric': 'FingerPrint',
   '@capgo/camera-preview': 'Camera',
   '@capgo/capacitor-updater': 'ArrowPath',

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-native-navigation.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-native-navigation.md
@@ -1,0 +1,147 @@
+---
+locale: en
+published: true
+---
+# Using @capgo/native-navigation
+
+`@capgo/native-navigation` renders native top navigation, bottom tab chrome, and route transition shells over a single full-screen Capacitor WebView. Your web framework still owns routes and content, while native owns the app frame.
+
+## Install and sync
+
+```bash
+bun add @capgo/native-navigation
+bunx cap sync
+```
+
+## Configure the native frame
+
+```ts
+import { NativeNavigation } from '@capgo/native-navigation';
+
+await NativeNavigation.configure({
+  contentInsetMode: 'css',
+  animationDuration: 360,
+  colors: {
+    tint: '#0f172a',
+    inactiveTint: '#64748b',
+  },
+});
+```
+
+## Render a native navbar
+
+```ts
+await NativeNavigation.setNavbar({
+  title: 'Inbox',
+  subtitle: 'Native chrome',
+  transparent: true,
+  backButton: { visible: false },
+  rightItems: [
+    {
+      id: 'compose',
+      title: 'Compose',
+      icon: {
+        svg: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>',
+      },
+    },
+  ],
+});
+```
+
+## Render a native tabbar
+
+```ts
+await NativeNavigation.setTabbar({
+  selectedId: 'inbox',
+  labels: true,
+  icons: true,
+  tabs: [
+    {
+      id: 'inbox',
+      title: 'Inbox',
+      icon: {
+        svg: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16v16H4z"/><path d="m4 13 4 4h8l4-4"/></svg>',
+      },
+    },
+    {
+      id: 'search',
+      title: 'Search',
+      icon: {
+        svg: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-3-3"/></svg>',
+      },
+    },
+  ],
+});
+```
+
+## Connect native events to your router
+
+Native bars emit intent. Your router still performs the route change:
+
+```ts
+await NativeNavigation.addListener('navbarBack', () => {
+  router.back();
+});
+
+await NativeNavigation.addListener('navbarItemTap', ({ id }) => {
+  if (id === 'compose') router.push('/compose');
+});
+
+await NativeNavigation.addListener('tabSelect', ({ id }) => {
+  router.push(`/${id}`);
+});
+```
+
+## Animate route changes
+
+Use a transition transaction around your normal web route update:
+
+```ts
+const transition = await NativeNavigation.beginTransition({
+  direction: 'forward',
+});
+
+router.push('/message/42');
+await router.ready?.();
+
+await NativeNavigation.setNavbar({
+  title: 'Message',
+  backButton: { visible: true, title: 'Inbox' },
+});
+
+await NativeNavigation.finishTransition({
+  id: transition.id,
+  direction: 'forward',
+});
+```
+
+## Pad content with native insets
+
+When `contentInsetMode` is `css`, the plugin writes CSS variables for the native bars:
+
+```css
+.page {
+  padding-top: var(--cap-native-navigation-top);
+  padding-bottom: var(--cap-native-navigation-bottom);
+}
+```
+
+## Icon choices
+
+Icons are native descriptors, not React or Vue nodes. Use SVG when you do not want to bundle native assets:
+
+```ts
+const icon = {
+  svg: '<svg viewBox="0 0 24 24"><path d="M3 10.5 12 3l9 7.5"/></svg>',
+  template: true,
+  ios: { sfSymbol: 'house.fill' },
+  android: { resource: 'ic_menu_view' },
+};
+```
+
+Inline SVG supports `path`, `line`, `polyline`, `polygon`, `circle`, and `rect`, which covers common icon sets such as Lucide and Feather.
+
+## Full Reference
+
+- GitHub: https://github.com/Cap-go/capacitor-native-navigation/
+- Docs: /docs/plugins/native-navigation/


### PR DESCRIPTION
## Summary
- add @capgo/native-navigation to the plugin registry, sidebar, and LLM docs export
- add plugin overview/getting-started docs
- add the web tutorial page

## Checks
- bun run ci:verify:docs
- bun run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Native Navigation plugin documentation including overview, Getting Started guide, and comprehensive tutorial. Coverage includes installation, native navbar and tabbar configuration, event handling and listeners, transition workflow management, CSS variable integration for styling, icon descriptor setup with inline SVG support, web components registration, and platform-specific rendering details for iOS, Android, and web fallback.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/656)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->