### PR TITLE
Improve live update marketing positioning

### DIFF
--- a/apps/shared/copy/messages.ts
+++ b/apps/shared/copy/messages.ts
@@ -32,30 +32,33 @@ const messages = {
   all_systems_normal_uptime: 'All systems normal: 99% uptime',
   already_have_account: 'Already have an account?',
   alternatives: 'Alternatives',
-  alternatives_appflow_credit: "💚 Credit where it's due: Ionic built amazing tools and educated a whole generation of hybrid app developers. Respect.",
+  alternatives_appflow_credit:
+    "Credit where it's due: Ionic proved live updates could be valuable for serious teams. Capgo took that idea out of an expensive closed bundle and made it open, focused, and flexible for Capacitor teams.",
   alternatives_appflow_migration_guide: 'Migration guide →',
   alternatives_appflow_reality: "Ionic announced they're winding down Appflow. Existing customers can use it until end of 2027, but no new customers or features.",
   alternatives_appflow_reality_label: 'The reality:',
   alternatives_appflow_status: '⚠️ Shutting down December 31, 2027',
-  alternatives_appflow_when_good: 'Appflow was great if you wanted everything in one place - CI/CD, live updates, native builds. The pioneers of this space.',
+  alternatives_appflow_when_good: 'Appflow was great if you wanted everything in one place - CI/CD, live updates, native builds - and had the budget for it.',
   alternatives_appflow_when_good_label: 'When it was good:',
   alternatives_appflow_why_different_label: "Why we're different:",
   alternatives_appflow_why_different_li1: "We're not shutting down (kinda important!)",
   alternatives_appflow_why_different_li2: '$14/month vs their $499/month',
   alternatives_appflow_why_different_li3: 'Open source vs closed source',
-  alternatives_appflow_why_different_li4: "Focus on updates only, so we're better at it",
-  alternatives_been_doing_desc: "Started in 2020. We've seen every edge case, survived every App Store policy change, and processed billions of updates. We're not going anywhere.",
-  alternatives_been_doing_title: "⏰ We've been doing this for 4 years",
-  alternatives_biggest_plugin_desc: 'We maintain 90+free, open-source Capacitor plugins. More than anyone else in the ecosystem except the Capacitor team itself.',
+  alternatives_appflow_why_different_li4: 'Focused live updates with 5-minute automatic setup for simple teams and manual control for advanced release workflows',
+  alternatives_been_doing_desc:
+    'Capgo created the first serious independent Capacitor live-update platform after Appflow. Since then, others have copied the pattern. We kept shipping: 5-minute automatic setup, manual control, native rollback, CLI compatibility checks, logs, channels, and production scale.',
+  alternatives_been_doing_title: 'We pioneered the independent Capacitor live-update path',
+  alternatives_biggest_plugin_desc: 'We maintain 100+ free, open-source Capacitor plugins. More than anyone else in the ecosystem except the Capacitor team itself.',
   alternatives_biggest_plugin_note: 'So yeah, we know a thing or two about Capacitor.',
   alternatives_biggest_plugin_title: '🚀 Biggest plugin provider after official Capacitor',
   alternatives_bootstrapped_desc: 'No investors. No debt. Just sustainable revenue from happy customers.',
   alternatives_bootstrapped_note: "That means we can charge fair prices ($14/month starter, not $499), and we won't suddenly shut down or 10x our pricing.",
   alternatives_bootstrapped_title: '💰 Bootstrapped and profitable',
   alternatives_capawesome_credit:
-    "💚 Credit where it's due: Robin (Capawesome founder) does great work. Being inspired by our approach when building their solution is honestly flattering. The ecosystem is better with multiple options.",
-  alternatives_capawesome_diff_experience: "<strong>Experience:</strong> We've been doing this since 2020 (they launched live updates in 2024)",
-  alternatives_capawesome_diff_focus: "<strong>Focus:</strong> Live updates is our core business; for them it's a side offering to their paid plugins",
+    'Credit where it is due: Robin (Capawesome founder) does good work. Their live updates follow a path Capgo opened for the ecosystem. Multiple options are healthy; depth, scale, and transparency still matter.',
+  alternatives_capawesome_diff_experience: '<strong>Experience:</strong> Capgo started the independent Capacitor live-update category in 2020; they launched live updates in 2024',
+  alternatives_capawesome_diff_focus:
+    '<strong>Focus:</strong> Live updates is our core business, with automatic setup and advanced manual flows; for them it is a side offering to paid plugins',
   alternatives_capawesome_diff_pricing: '<strong>Pricing:</strong> Both affordable - we start at $14/month, they start at €9/month',
   alternatives_capawesome_diff_scale: "<strong>Scale:</strong> We serve 1B+ updates/month, 50M+ devices (they don't publish stats yet)",
   alternatives_capawesome_diff_security:
@@ -64,9 +67,10 @@ const messages = {
   alternatives_capawesome_differences_label: 'Honest differences:',
   alternatives_capawesome_full_comparison: 'Full comparison →',
   alternatives_capawesome_reality:
-    'Capawesome is a solid, newer option with good German engineering. They were inspired by Capgo when building their live updates solution. They also make great Capacitor plugins.',
+    'Capawesome is a solid, newer option with good German engineering. Their live-update product arrived after Capgo had already proven the independent Capacitor path at scale.',
   alternatives_capawesome_status: '✅ Active and well-maintained',
-  alternatives_capawesome_when_good: "If you want a simpler interface and don't need some of the advanced features, it's a fine choice.",
+  alternatives_capawesome_when_good:
+    "If you want a newer simple interface and don't need Capgo's advanced release controls, scale history, or open backend, it can be a fine choice.",
   alternatives_codepush_credit: "💚 Credit where it's due: CodePush proved the live update model works at massive scale.",
   alternatives_codepush_reality:
     "CodePush was free and worked well... until Microsoft stopped maintaining it. It's in legacy mode for React Native, and there's no official Capacitor support.",
@@ -86,12 +90,13 @@ const messages = {
   alternatives_family_business_li1: 'Legal entities in both US and Europe',
   alternatives_family_business_li2: 'Dedicated infrastructure for China',
   alternatives_family_business_title: '👨‍👩‍👧‍👦 Family business',
-  alternatives_hero_subtitle: "Your team needs a live update solution that won't disappear. Here's an honest look at your options.",
-  alternatives_hero_title: "Choose a Platform That Won't Shut Down",
+  alternatives_hero_subtitle:
+    "Before Capgo, serious Capacitor live updates mostly meant Appflow. We built the independent path, and we're still the most complete and flexible option for teams that need control.",
+  alternatives_hero_title: 'Choose the Capacitor Live Update Platform That Led the Category',
   alternatives_human_support_desc: 'No chatbots. No "AI assistants." No ticket systems that lose your message.',
   alternatives_human_support_note: "You get Martin or someone from the family. Usually within hours. Sometimes within minutes. Yes, even on weekends (we can't help ourselves 😅).",
   alternatives_human_support_title: '🙋 Only human support',
-  alternatives_meta_description: 'Looking for Capacitor live update solutions? Honest comparison of Capgo vs alternatives. No BS, just real talk about each platform.',
+  alternatives_meta_description: 'Compare Capacitor live update platforms and see why Capgo remains the original independent, open, and most complete Appflow alternative.',
   alternatives_not_good_at_ci_cd:
     "Unlike Appflow's bundled approach, we give you flexibility. Use our Cloud Build for native iOS/Android builds, or integrate with your own CI/CD (GitHub Actions, GitLab CI, etc). Your choice - both work great.",
   alternatives_not_good_at_ci_cd_label: 'All-in-one CI/CD:',
@@ -120,20 +125,21 @@ const messages = {
   alternatives_what_different_title: 'What actually makes Capgo different',
   alternatives_why_choose_title: 'Why people actually choose us',
   alternatives_why_exists_p1:
-    "Look, we could make a fancy table showing how Capgo crushes every competitor on every metric. That's what everyone does. But it's BS, and you know it.",
+    'A lot of live-update pages now sound the same because most newer tools copied the Capgo playbook: channels, rollbacks, CLI uploads, and app-store-safe web updates.',
   alternatives_why_exists_p2:
-    'The truth? All the live update platforms do pretty much the same thing now: push JavaScript updates to your Capacitor apps. API? We all have one. Channels? Yep. Rollbacks? Sure.',
-  alternatives_why_exists_p3: "So what actually matters? Let's talk about that instead.",
+    'The difference is depth. Capgo has automatic setup for teams that want to ship in 5 minutes, manual and half-manual modes for advanced release logic, CLI checks that warn about incompatible native changes, device logs, dynamic channels, encryption, and proven production scale.',
+  alternatives_why_exists_p3: 'So the real question is not who can upload a bundle. It is who has the safest, most flexible system around that bundle.',
   alternatives_why_exists_title: 'Why this page exists',
   analytics: 'Analytics',
   and: 'and',
   app_mobile: 'App mobile',
   app_store_compliant: 'App Store compliant',
   appflow_credit_p1:
-    '<strong class="text-emerald-400">Ionic built something amazing.</strong> Appflow was the first platform to make live updates actually work at scale. They pioneered channels, rollbacks, native builds integration - the whole playbook.',
-  appflow_credit_p2: "They educated an entire generation of developers on hybrid app development. Without Ionic's work, products like Capgo wouldn't exist.",
-  appflow_credit_p3: 'So yeah, massive respect to the Ionic team. This is a bummer for everyone.',
-  appflow_credit_title: "First, let's give credit where it's due",
+    '<strong class="text-emerald-400">Ionic proved the model.</strong> Before Capgo, serious Capacitor live updates mostly meant Appflow: useful, closed, expensive, and tied to a broad all-in-one platform.',
+  appflow_credit_p2:
+    'Capgo was built to make that workflow independent: open source, affordable, focused on live updates, and flexible enough for teams that need more than the basic Appflow path.',
+  appflow_credit_p3: 'So yes, respect to Ionic. But Capgo is not a clone of what is shutting down. It is the mature independent path that others now copy.',
+  appflow_credit_title: "Let's give credit, then be clear about what changed",
   appflow_cta_book_migration: 'Book migration call',
   appflow_cta_questions:
     'Questions? <a href="https://discord.gg/VCXxSVjefW" class="text-emerald-400 hover:underline">Join our Discord</a> or <a href="mailto:support@capgo.app" class="text-emerald-400 hover:underline">email us</a>',
@@ -147,10 +153,11 @@ const messages = {
   appflow_enterprise_help_desc:
     'If your Appflow stack includes Ionic enterprise plugins, use the <a href="{pluginsUrl}" class="text-emerald-300 hover:underline">Ionic Enterprise Plugins guide</a>. Paid support is available on demand - <a href="{supportUrl}" class="text-emerald-300 hover:underline">see support options</a>. Need a hands-on migration? We offer paid migration services - <a href="{migrationUrl}" class="text-emerald-300 hover:underline">learn more</a>.',
   appflow_enterprise_help_title: 'Enterprise plugins and paid help (optional)',
-  appflow_experience_desc: "4 years of live updates at scale. Billions of updates served. Every App Store policy change, every edge case, every weird device - we've seen it.",
+  appflow_experience_desc:
+    'Capgo created the first serious independent Capacitor live-update platform after Appflow. We have handled billions of updates, every App Store policy shift, and the weird device failures that only show up in production.',
   appflow_experience_note:
-    "Also: we're the <strong>biggest Capacitor plugin provider</strong> after the official Capacitor team (30+ plugins). We know the ecosystem inside and out.",
-  appflow_experience_title: "4. We've been doing this since 2020",
+    "Also: we're the <strong>biggest Capacitor plugin provider</strong> after the official Capacitor team, with 100+ open-source plugins. We know the ecosystem inside and out.",
+  appflow_experience_title: '4. We pioneered the independent path',
   appflow_faq_a1: "Nope. Whatever you're using now (GitHub Actions, GitLab CI, Jenkins, etc.) keeps working. Just change the upload step to use our CLI instead of Appflow's.",
   appflow_faq_a2:
     "We do cloud native builds! We just don't do the full CI/CD automation pipeline. You can trigger builds through our CLI or API, but we're not trying to replace your GitHub Actions/GitLab CI workflow - we integrate with it.",
@@ -162,11 +169,14 @@ const messages = {
   appflow_faq_q3: 'Will this save money?',
   appflow_faq_q4: "How's the reliability?",
   appflow_faq_title: 'Common questions',
-  appflow_focus_desc: 'Appflow did live updates + CI/CD + native builds. We just do <strong class="text-white">live updates</strong>.',
-  appflow_focus_note: "IMO it's better to keep concerns separate anyway. Use GitHub Actions (or whatever) for CI/CD. Use Capgo for updates. Each tool does what it's best at.",
-  appflow_focus_title: '6. Focus on one thing (and do it really well)',
+  appflow_focus_desc:
+    'Appflow bundled live updates, CI/CD, and native builds. Capgo focuses on the live-update system itself: automatic setup in 5 minutes when you want the easy path, plus manual and half-manual flows when your release logic is more advanced.',
+  appflow_focus_note:
+    'Use GitHub Actions, GitLab, Jenkins, our Builder, or your own scripts for native build work. Use Capgo for the update layer: targeting, rollout, rollback, observability, and safety checks.',
+  appflow_focus_title: '6. Focused, complete, and flexible',
   appflow_footer_note: 'Built with respect for what Ionic created. Here to help you keep shipping.',
-  appflow_hero_subtitle: "Let's talk honestly about what's happening and what your options are.",
+  appflow_hero_subtitle:
+    'Appflow was the expensive default. Capgo is the original independent, open-source path for Capacitor live updates, with deeper controls and proven scale.',
   appflow_hero_title: 'Migrating from Appflow?',
   appflow_migration_basics_title: 'The basics:',
   appflow_migration_guide_text: 'Full migration guide: <a href="{url}" class="underline hover:text-emerald-200">docs/upgrade/from-appflow-to-capgo</a>',
@@ -178,10 +188,10 @@ const messages = {
   appflow_migration_stuck:
     'Stuck? <a href="https://cal.com/team/capgo/appflow-migration" class="text-blue-300 underline hover:text-blue-200">Book a free migration call</a> and we\'ll walk you through it.',
   appflow_not_good_at_ci_cd:
-    "Unlike Appflow's bundled approach, we give you flexibility. Use our Cloud Build for native iOS/Android builds, or integrate with your own CI/CD (GitHub Actions, GitLab CI, etc). Your choice - both work great.",
+    'We are not trying to lock you into a single all-in-one pipeline. Use our Cloud Build for native iOS/Android builds, or integrate with your own CI/CD (GitHub Actions, GitLab CI, Jenkins, local scripts, etc.). The live-update layer stays flexible either way.',
   appflow_not_good_at_ci_cd_label: 'All-in-one CI/CD:',
   appflow_not_good_at_docs:
-    "Basic automatic updates are well documented and clear. But Capgo offers many update modes (manual, half-manual, channel_default, etc.) - not all use cases are equally easy to understand yet. We're working on it.",
+    'Basic automatic updates are well documented and take minutes to set up. Capgo also supports advanced modes (manual, half-manual, channel_default, dynamic assignment, per-user channels), and we are still improving docs for every edge case.',
   appflow_not_good_at_docs_label: 'Documentation complexity:',
   appflow_not_good_at_title: "🤔 What we're NOT (honesty time)",
   appflow_not_shutting_desc:
@@ -225,7 +235,7 @@ const messages = {
   appflow_testimonial_4_author: '— Mobile team lead, Germany',
   appflow_testimonials_more: 'More testimonials:',
   appflow_testimonials_title: 'What people actually say',
-  appflow_what_different_title: 'What makes Capgo different',
+  appflow_what_different_title: 'Why Capgo is not just another Appflow replacement',
   application_definition: '<strong>Application</strong> means the software program provided by the Company downloaded by You on any electronic device named {brand}.',
   application_definition_refund: 'Application means the software program provided by the Company downloaded by You on any electronic device, named $1',
   apps: 'Apps',
@@ -426,14 +436,14 @@ const messages = {
     'No, changes to capacitor.config.ts cannot be sent through Capgo live updates. The Capacitor configuration file is read at native build time and compiled into the native app binary. This means any changes to capacitor.config.ts (such as plugin configurations, app ID, server settings, or native plugin options) require a new native release through the App Store or Google Play. Capgo can only update web assets (HTML, CSS, JavaScript) that are loaded at runtime.',
   capacitor_config_changes_question: 'Can I update capacitor.config.ts changes via Capgo?',
   capacitor_power_approximately_1_of_apps_on_google_play_store: 'Capacitor power approximately $1% of apps on Google Play Store',
-  capflow_meta_description: "See how Capgo's native OTA platform compares to Ionic AppFlow across reliability, automation, and pricing.",
+  capflow_meta_description: 'See why Capgo is the original independent Appflow alternative for Capacitor live updates, with deeper automation, safety, flexibility, and scale.',
   capflow_nav_label: 'Ionic AppFlow vs Capgo',
   capflow_title: 'Ionic AppFlow vs Capgo',
   capgo_enables_development_teams_at_some_of_the_most_innovative_companies: 'Capgo enables development teams at some of the most innovative companies.',
   capgo_gives_you_the_best_insights_you_need_to_create_a_truly_professional_mobile_app: 'Capgo gives you the best insights you need to create a truly professional mobile app.',
   capgo_home: 'Capgo home',
   capgo_is_the_cutting_edge_live_update_system_designed_specifically_for_capacitor_applications:
-    'Capgo is the cutting-edge live update system designed specifically for Capacitor applications.',
+    'Capgo is the original independent live update system designed specifically for Capacitor applications.',
   capgo_is_used_to_update_its_own_apps_allowing_us_to_continuously_improve_and_refine_our_product_through_real_world_usage:
     'Capgo is used to update its own apps, allowing us to continuously improve and refine our product through real-world usage.',
   capgo_usage_explanation: "At Capgo, we don't count emulators and dev builds in your usage. Learn more about this",
@@ -1300,8 +1310,9 @@ const messages = {
   help_customers_with_app_issues: 'Help customers with app issues efficiently',
   here: 'here.',
   hero_secondary_cta: 'See live updates',
-  hero_subtitle_line2: 'Control rollout with channels, rollback, and device logs before a bad deploy becomes a support incident.',
-  hero_subtitle_part1: 'Ship JavaScript and asset fixes in minutes while native changes keep the normal store review path.',
+  hero_subtitle_line2: 'Capgo controls rollout with channels, rollback, device logs, and CLI safety checks before a bad deploy becomes a support incident.',
+  hero_subtitle_part1:
+    'Ship JavaScript and asset fixes in minutes with the live-update platform that opened the independent Capacitor path while native changes keep the normal store review path.',
   hero_subtitle_part2: '',
   high_enterprise_response: '2 business hours<br />Monday - Friday',
   high_priority_response: '2 hours<br />24/7 × 365',
@@ -1329,7 +1340,8 @@ const messages = {
   home_cities_worldwide: 'Cities Worldwide',
   home_countries_covered: 'Countries Covered',
   home_countries_desc: 'Global presence everywhere',
-  home_deploy_cli_desc: 'Build as usual, upload changed JavaScript and assets with the CLI or API, and target the channels that should receive them.',
+  home_deploy_cli_desc:
+    'Build as usual, upload changed JavaScript and assets with the CLI or API, and target the channels that should receive them. Start automatic in 5 minutes or go manual for advanced release logic.',
   home_global_infrastructure_desc: 'Powered by serverless edge computing and distributed databases across 300+ cities and 13,000+ networks for ultra-fast global delivery.',
   home_global_network_label: 'Global Network',
   home_hero_outcome_compliance_desc: 'Update JavaScript, CSS, copy, configuration, and assets while native code keeps going through normal App Store and Play review.',
@@ -1341,7 +1353,8 @@ const messages = {
   home_important_update_badge: 'Important Update',
   home_latency_from_users: 'From 95% of users',
   home_locations_active: '300+ Locations Active',
-  home_migration_cta_desc: "Join thousands of developers who've already made the switch to a more reliable, feature-rich alternative that's built to last.",
+  home_migration_cta_desc:
+    "Join thousands of developers who've already moved from expensive, limited live updates to the original independent Capacitor platform built for scale, flexibility, and safety.",
   home_migration_cta_title: 'Ready to migrate from Ionic Appflow?',
   home_multi_provider_resilience: 'Triple-provider resilience',
   home_network_connections: 'Network Connections',
@@ -1385,7 +1398,7 @@ const messages = {
   instant_ota_updates_capacitor: 'Instant OTA updates for Capacitor apps',
   instant_rollback: 'Instant Rollback',
   instant_updates: 'Push fixes without a store release',
-  instant_updates_for_capacitor: 'Instant updates for CapacitorJS Apps',
+  instant_updates_for_capacitor: 'The independent live update platform for CapacitorJS apps',
   instant_updates_for_capacitor_apps: 'Live updates for Capacitor apps',
   instant_updates_for_capacitor_apps_description:
     'When a web-layer bug is live, ship the fix through Capgo instead of waiting days for app store approval. Users get the update in the background while native changes stay in the normal review path.',
@@ -1409,7 +1422,7 @@ const messages = {
   it_all_started_with_a_github_issue_where_many_developers_voiced_their_frustration_with_the_high_costs_of_existing_solutions_like_appflow:
     'It all started with a GitHub issue where many developers voiced their frustration with the high costs of existing solutions like Appflow.',
   it_s_faster_cheaper_and_requires_fewer_developers_to_do_it: "It's faster, cheaper, and requires fewer developers to do it.",
-  iterate_faster: 'built for fast-moving teams',
+  iterate_faster: 'the original independent Capacitor live-update platform',
   javascript_and_typescript: 'JavaScript and TypeScript',
   jobs: 'Jobs',
   join_leading_enterprises: 'Join leading enterprises who trust Capgo to deliver secure, scalable live updates to millions of users worldwide.',
@@ -1446,7 +1459,8 @@ const messages = {
   lightning_fast: 'Lightning Fast',
   little_experience_with_capacitorjs: 'Little experience with CapacitorJS',
   live_update: 'Live Update',
-  live_update_channels_desc: 'Channels let you target specific user groups with specific builds. Manage channels from the cloud dashboard, API, or mobile app.',
+  live_update_channels_desc:
+    'Channels let you target specific user groups with specific builds. Manage channels from the cloud dashboard, API, mobile app, or your own advanced release logic.',
   live_update_channels_feature1_desc: 'Create, configure, and switch channels from the web dashboard. Roll back instantly with one click.',
   live_update_channels_feature1_title: 'Cloud Dashboard Control',
   live_update_channels_feature2_desc: 'Automate channel management with our CLI or REST API. Perfect for CI/CD integration.',
@@ -1471,15 +1485,15 @@ const messages = {
   live_update_comparison_healing: 'Self-healing updates',
   live_update_comparison_native: 'Native crash recovery',
   live_update_comparison_rollback: 'Automatic rollback',
-  live_update_comparison_subtitle: 'See why intelligent updates matter',
-  live_update_comparison_title: 'Capgo vs Manual Updates',
+  live_update_comparison_subtitle: 'Uploading a bundle is easy. Protecting customers at scale is the hard part.',
+  live_update_comparison_title: 'Capgo vs Basic Update Systems',
   live_update_comparison_validation: 'Pre-deployment validation',
   live_update_decision_1: 'You need a recovery path for production bugs that does not depend on App Store or Play review time.',
   live_update_decision_2: 'Your app has multiple customer cohorts, white-label deployments, beta testers, or support-only debug channels.',
   live_update_decision_3: 'Your team needs compliance-friendly control: signed bundles, rollback, auditability, and a self-hosting path.',
   live_update_decision_title: 'Choose live updates when these statements are true',
-  live_update_cta_subtitle: 'Start with 14 days free. No credit card required.',
-  live_update_cta_title: 'Ready to Ship Safer Updates?',
+  live_update_cta_subtitle: 'Start automatic in 5 minutes. Switch to manual control when your release strategy needs it.',
+  live_update_cta_title: 'Ready for the Most Complete Capacitor Live Update System?',
   live_update_delta_command: 'Upload with delta updates enabled',
   live_update_delta_desc:
     'Traditional updates download the entire bundle every time. With delta updates, devices only download the files that actually changed - saving 50-90% bandwidth.',
@@ -1490,7 +1504,7 @@ const messages = {
   live_update_delta_feature3_desc: 'Just add --partial to your upload command to enable delta updates for your bundle.',
   live_update_delta_feature3_title: 'Enable with One Flag',
   live_update_delta_title: 'Delta Updates',
-  live_update_description: 'Intelligent OTA updates with automatic rollback protection',
+  live_update_description: 'The original independent Capacitor live update platform with automatic setup, advanced manual flows, CLI safety checks, and native rollback protection',
   live_update_dynamic_bullet1_prefix: 'Add an in-app “Update Track” menu: list channels and let testers jump from',
   live_update_dynamic_bullet1_suffix: 'in seconds (no reinstall).',
   live_update_dynamic_bullet2: 'Spin up a pull-request channel per feature, route QA or beta users there, then snap them back to prod when approved.',
@@ -1518,7 +1532,8 @@ const messages = {
   live_update_feature_auto_rollback: 'Automatic Rollback',
   live_update_feature_auto_rollback_desc: "If your app doesn't call notifyAppReady() within 10 seconds, we automatically roll back to the last working version.",
   live_update_feature_breaking_detection: 'Breaking Update Detection',
-  live_update_feature_breaking_detection_desc: 'CLI scans native dependencies and warns you before deploying incompatible updates. See compatibility status for every package.',
+  live_update_feature_breaking_detection_desc:
+    'CLI scans native dependencies and warns you before deploying incompatible updates. Ship web changes fast without pushing native-breaking code to customers.',
   live_update_feature_encryption: 'Tamper-Proof Updates',
   live_update_feature_encryption_desc:
     "Every update is checksummed, signed, and encrypted end-to-end. No one can tamper with updates - not even Capgo can see what's inside your bundles.",
@@ -1528,13 +1543,13 @@ const messages = {
   live_update_feature_preflight_desc: 'Validates notifyAppReady(), index.html, bundle size limits, and checksums before accepting any upload.',
   live_update_feature_self_healing: 'Self-Healing Updates',
   live_update_feature_self_healing_desc: 'Fallback bundle mechanism always maintains a working version. Your users never see a broken app.',
-  live_update_features_subtitle: 'More than just file uploads. Capgo understands your app and protects your users.',
-  live_update_features_title: 'Intelligent Update System',
+  live_update_features_subtitle: 'Most tools can upload files. Capgo adds the release controls, native safety, logs, and rollback behavior production teams need.',
+  live_update_features_title: 'The Complete Live Update System',
   live_update_get_started: 'Get Started',
   live_update_hero_subtitle:
-    'Ship updates with confidence. Our CLI catches breaking changes before deploy. Our native engine auto-recovers if anything goes wrong. Your users never see a broken app.',
-  live_update_hero_title: 'Ship Faster. Break Nothing.',
-  live_update_how_it_works_subtitle: 'A safety net at every step of the update process',
+    'Before Capgo, serious Capacitor live updates mostly meant Appflow: expensive, closed, and basic. Capgo created the independent path and kept going with 5-minute setup, advanced manual control, CLI safety checks, native rollback, dynamic channels, logs, and encryption.',
+  live_update_hero_title: 'The Live Update Platform Others Copy',
+  live_update_how_it_works_subtitle: 'Automatic when you want speed. Manual when you need control. Safety checks at every step.',
   live_update_how_it_works_title: 'How It Works',
   live_update_logs_bullet1: 'Per-device timelines highlight stalled downloads, checksum issues, or missing notifyAppReady().',
   live_update_logs_bullet2: 'Channel guardrails proven: see disableAutoUpdateToMajor, emulator/dev blocks, and platform filters in real time.',
@@ -1551,7 +1566,21 @@ const messages = {
   live_update_lts_capacitor7: 'Capacitor 7',
   live_update_lts_capacitor8: 'Capacitor 8',
   live_update_lts_desc:
-    'No pressure to upgrade immediately. Capgo officially supports Capacitor 8, 7, 6, 5 and now Electron - giving you years of support and flexibility to upgrade on your own schedule.',
+    'No pressure to upgrade immediately. Capgo officially supports Capacitor 8, 7, 6, 5 and Electron - giving you years of support and flexibility to upgrade on your own schedule.',
+  live_update_proof_card1_desc:
+    'When Appflow was the only serious option, live updates were closed, expensive, and tied to a broad platform. Capgo made the independent Capacitor path real.',
+  live_update_proof_card1_title: 'First independent path',
+  live_update_proof_card2_desc:
+    'Use the automatic path to install and ship in 5 minutes, or switch to manual and half-manual flows for custom rollout, support, QA, and per-user scenarios.',
+  live_update_proof_card2_title: 'Automatic or manual',
+  live_update_proof_card3_desc: '1B+ updates per month, 50M+ devices, dynamic channels, device logs, delta updates, encryption, self-hosting, and native recovery.',
+  live_update_proof_card3_title: 'Most complete at scale',
+  live_update_proof_card4_desc: 'The CLI checks native dependencies, required files, bundle integrity, duplicate versions, and hub compatibility before updates reach users.',
+  live_update_proof_card4_title: 'Safety before deploy',
+  live_update_proof_desc:
+    'Capgo is not a basic bundle uploader. It is the release system around the bundle: targeting, validation, observability, rollback, and control for teams that cannot afford to break production.',
+  live_update_proof_kicker: 'Why Capgo leads',
+  live_update_proof_title: 'We built the independent category after Appflow. Then kept going.',
   live_update_lts_electron: 'Electron',
   live_update_lts_electron_new: 'New',
   live_update_lts_supported: 'Fully Supported',
@@ -1598,7 +1627,8 @@ const messages = {
   live_update_support_scenario_step3_desc: 'User confirms the fix works. Promote the bundle to production for everyone.',
   live_update_support_scenario_step3_title: '3. Verify & Ship to All',
   live_update_support_scenario_title: "Fix One User's Bug in Minutes",
-  live_update_validation_desc: "Manual updates give you all the tools to break your app. Capgo's CLI catches mistakes before they reach your users.",
+  live_update_validation_desc:
+    "Manual updates give you all the tools to break your app. Capgo's CLI catches incompatible native changes and release mistakes before they reach your users.",
   live_update_validation_feature1_desc:
     "CLI scans your native plugins and compares versions. If your JS bundle expects a newer native plugin version than what's installed, we warn you before deploy.",
   live_update_validation_feature1_title: 'Native Dependency Check',

--- a/apps/web/src/pages/live-update.astro
+++ b/apps/web/src/pages/live-update.astro
@@ -148,6 +148,48 @@ const decisionCriteria = [m.live_update_decision_1({}, { locale }), m.live_updat
         </div>
       </section>
 
+      <!-- Category Leadership Section -->
+      <section class="bg-gray-900 px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
+        <div class="mx-auto max-w-7xl">
+          <div class="grid gap-10 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+            <div>
+              <p class="inline-flex rounded-full border border-blue-400/30 bg-blue-500/10 px-3 py-1 text-xs font-semibold tracking-wide text-sky-100 uppercase">
+                {m.live_update_proof_kicker({}, { locale })}
+              </p>
+              <h2 class="font-pj mt-4 text-3xl leading-tight font-bold text-white sm:text-4xl">
+                {m.live_update_proof_title({}, { locale })}
+              </h2>
+              <p class="mt-5 text-lg leading-8 text-gray-300">
+                {m.live_update_proof_desc({}, { locale })}
+              </p>
+            </div>
+
+            <div class="grid gap-4 sm:grid-cols-2">
+              <div class="rounded-2xl border border-gray-700 bg-gray-800 p-5">
+                <div class="mb-4 flex h-9 w-9 items-center justify-center rounded-lg bg-blue-500/15 text-sm font-bold text-blue-200 ring-1 ring-blue-300/30">01</div>
+                <h3 class="font-pj text-lg font-bold text-white">{m.live_update_proof_card1_title({}, { locale })}</h3>
+                <p class="mt-2 text-sm leading-6 text-gray-400">{m.live_update_proof_card1_desc({}, { locale })}</p>
+              </div>
+              <div class="rounded-2xl border border-gray-700 bg-gray-800 p-5">
+                <div class="mb-4 flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-500/15 text-sm font-bold text-emerald-200 ring-1 ring-emerald-300/30">02</div>
+                <h3 class="font-pj text-lg font-bold text-white">{m.live_update_proof_card2_title({}, { locale })}</h3>
+                <p class="mt-2 text-sm leading-6 text-gray-400">{m.live_update_proof_card2_desc({}, { locale })}</p>
+              </div>
+              <div class="rounded-2xl border border-gray-700 bg-gray-800 p-5">
+                <div class="mb-4 flex h-9 w-9 items-center justify-center rounded-lg bg-amber-500/15 text-sm font-bold text-amber-200 ring-1 ring-amber-300/30">03</div>
+                <h3 class="font-pj text-lg font-bold text-white">{m.live_update_proof_card3_title({}, { locale })}</h3>
+                <p class="mt-2 text-sm leading-6 text-gray-400">{m.live_update_proof_card3_desc({}, { locale })}</p>
+              </div>
+              <div class="rounded-2xl border border-gray-700 bg-gray-800 p-5">
+                <div class="mb-4 flex h-9 w-9 items-center justify-center rounded-lg bg-rose-500/15 text-sm font-bold text-rose-200 ring-1 ring-rose-300/30">04</div>
+                <h3 class="font-pj text-lg font-bold text-white">{m.live_update_proof_card4_title({}, { locale })}</h3>
+                <p class="mt-2 text-sm leading-6 text-gray-400">{m.live_update_proof_card4_desc({}, { locale })}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <!-- Features Grid Section -->
       <section class="bg-gray-900 py-12 sm:py-16 lg:py-20">
         <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -851,8 +893,11 @@ npx @capgo/cli bundle upload <span class="text-cyan-400">--partial</span>
         <div class="flex flex-wrap justify-center gap-6">
           <div class="relative flex w-40 flex-col items-center rounded-2xl border border-blue-500/50 bg-gray-800 p-6">
             <span class="absolute -top-2 rounded-full bg-blue-500 px-2 py-0.5 text-xs font-bold text-white">{m.live_update_lts_electron_new({}, { locale })}</span>
-            <svg class="h-10 w-10 text-blue-400" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"></path>
+            <svg class="h-10 w-10 text-[#9feaf9]" viewBox="0 0 256 256" fill="none" aria-hidden="true">
+              <ellipse cx="128" cy="128" rx="110" ry="42" stroke="currentColor" stroke-width="12"></ellipse>
+              <ellipse cx="128" cy="128" rx="110" ry="42" stroke="currentColor" stroke-width="12" transform="rotate(60 128 128)"></ellipse>
+              <ellipse cx="128" cy="128" rx="110" ry="42" stroke="currentColor" stroke-width="12" transform="rotate(-60 128 128)"></ellipse>
+              <circle cx="128" cy="128" r="16" fill="currentColor"></circle>
             </svg>
             <span class="mt-2 text-sm font-medium text-gray-300">{m.live_update_lts_electron({}, { locale })}</span>
             <span class="mt-1 text-xs text-blue-400">{m.live_update_lts_supported({}, { locale })}</span>


### PR DESCRIPTION
Summary:
- Reposition Capgo as the original independent Capacitor live-update path after Appflow.
- Add a live-update leadership section covering first independent path, automatic/manual setup, production scale, and CLI safety checks.
- Tighten homepage, alternatives, and Appflow comparison copy around flexibility, completeness, scale, and safety.
- Replace the broken Electron placeholder on the live-update page with an inline Electron-style atom mark.

Validation:
- bunx prettier --write apps/shared/copy/messages.ts apps/web/src/pages/live-update.astro
- bun run check
- bun run build
- Headless local render of /live-update/ in the in-app browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new proof cards section to the live-update page featuring numbered cards that highlight key product benefits.

* **Content Updates**
  * Refreshed marketing copy and messaging across multiple site pages, including comparison pages, hero sections, and call-to-action content.
  * Updated visual icons for improved design consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/657)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->