### PR TITLE
[codex] fix Ahrefs SEO issues

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -90,6 +90,7 @@ export default defineConfig({
     srcDir: SRC_DIR,
     publicDir: PUBLIC_DIR,
     cpuCount: CPU_COUNT,
+    assetsDir: '_docs',
     optimizeDepsInclude: ['mermaid'],
     extraPlugins: [
       viteStaticCopy({

--- a/apps/shared/astro-config.mjs
+++ b/apps/shared/astro-config.mjs
@@ -70,7 +70,36 @@ export function buildSharedIntegrations({ pluginIcons, pageLastModDates }) {
   ]
 }
 
-export function buildSharedViteConfig({ srcDir, publicDir, cpuCount, optimizeDepsInclude = [], extraPlugins = [], ssrNoExternal }) {
+function assetBasename(value) {
+  const normalized = (value || 'asset').replaceAll('\\', '/')
+  const fileName = normalized.split('/').pop() || 'asset'
+  const extIndex = fileName.lastIndexOf('.')
+  return extIndex > 0 ? fileName.slice(0, extIndex) : fileName
+}
+
+function sanitizeAssetBasename(value) {
+  return (
+    assetBasename(value)
+      .replace(/@_@astro/gi, '-astro')
+      .replace(/[^A-Za-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'asset'
+  )
+}
+
+function buildAssetFileNames(assetsDir) {
+  return (assetInfo) => {
+    const rawName = assetInfo.name || assetInfo.names?.[0] || 'asset'
+    const safeName = sanitizeAssetBasename(rawName)
+    const isCss = rawName.toLowerCase().endsWith('.css')
+
+    if (isCss && safeName === 'global') return `${assetsDir}/global[extname]`
+    if (isCss) return `${assetsDir}/${safeName}.[hash][extname]`
+
+    return `${assetsDir}/${safeName}.[hash][extname]`
+  }
+}
+
+export function buildSharedViteConfig({ srcDir, publicDir, cpuCount, optimizeDepsInclude = [], extraPlugins = [], ssrNoExternal, assetsDir = '_astro' }) {
   const viteConfig = {
     resolve: {
       alias: [
@@ -87,6 +116,7 @@ export function buildSharedViteConfig({ srcDir, publicDir, cpuCount, optimizeDep
       cssMinify: 'esbuild',
       rollupOptions: {
         output: {
+          assetFileNames: buildAssetFileNames(assetsDir),
           manualChunks: undefined,
         },
         maxParallelFileOps: cpuCount * 3,

--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -55,6 +55,15 @@ const rendered = __translationWorkerTest.renderTranslatedHtml(parts, segments, t
 assert(rendered.includes('FR: Ship mobile updates instantly to every user'), 'Renderer did not write translated body text')
 assert(rendered.includes('current < total'), 'Renderer changed skipped script content')
 
+const titleSegmentIndex = segments.findIndex((segment) => segment.text.includes('Capgo - Live Updates for Capacitor Apps'))
+assert(titleSegmentIndex >= 0, 'Parser did not collect the title segment')
+const emptyTitleTranslations = segments.map((segment, index) => (index === titleSegmentIndex ? '' : segment.text))
+const renderedEmptyTitleFallback = __translationWorkerTest.renderTranslatedHtml(parts, segments, emptyTitleTranslations)
+assert(
+  renderedEmptyTitleFallback.includes('<title>Capgo - Live Updates for Capacitor Apps</title>'),
+  'Renderer did not preserve the source title when a translated title was empty',
+)
+
 const localizedMeta = __translationWorkerTest.expandShortMetaDescriptions(
   '<head><meta name="description" content="短い説明"><meta property="og:description" content="短い説明"></head>',
   'ja',

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -152,7 +152,7 @@ const CACHE_KEEP_SECONDS = 7 * 24 * 60 * 60
 const TRANSLATION_SOURCE_CHECK_SECONDS = 5 * 60
 const TRANSLATION_PENDING_SECONDS = 10 * 60
 const TRANSLATION_COORDINATOR_PENDING_MS = 15 * 60 * 1000
-const TRANSLATION_CACHE_VERSION = '2026-05-06-seo-meta-description-v2-localized-links'
+const TRANSLATION_CACHE_VERSION = '2026-05-10-ahrefs-head-assets-v1'
 const TRANSLATION_SOURCE_HASH_HEADER = 'X-Capgo-Translation-Source-Hash'
 const CLIENT_NO_STORE = 'no-store, max-age=0, must-revalidate'
 const MAX_HTML_BYTES = 1_500_000
@@ -1437,8 +1437,9 @@ function renderTranslatedHtml(parts: HtmlPart[], segments: Segment[], translatio
       if (typeof part === 'string') return part
 
       const segment = segments[part.segmentIndex]
-      const translated = translations[part.segmentIndex]
-      if (typeof translated !== 'string') throw new Error(`Missing translation for segment ${part.segmentIndex}`)
+      const rawTranslated = translations[part.segmentIndex]
+      if (typeof rawTranslated !== 'string') throw new Error(`Missing translation for segment ${part.segmentIndex}`)
+      const translated = normalizedTranslationValue(rawTranslated) ? rawTranslated : segment.text
       if (segment.mode === 'attribute') {
         return `${segment.leading}${escapeHtmlAttribute(translated, segment.quote)}${segment.trailing}`
       }

--- a/apps/web/src/pages/blog/[slug].astro
+++ b/apps/web/src/pages/blog/[slug].astro
@@ -5,6 +5,7 @@ import { formatTime } from '@/config/app'
 import Layout from '@/layouts/Layout.astro'
 import { createNewsArticleLdJson } from '@/lib/ldJson'
 import m from '@/copy/messages'
+import { defaultLocale, locales } from '@/services/locale'
 import type { GetStaticPaths } from 'astro'
 import type { CollectionEntry } from 'astro:content'
 import { getCollection, render } from 'astro:content'
@@ -60,19 +61,17 @@ if (!entry) {
 }
 
 const related = allPublishedEntries.filter((j) => j.data.slug !== Astro.params.slug && j.data.locale === Astro.locals.locale).slice(0, 3)
-const seenLocales = new Set()
-const alternateVersions = entries
-  .filter(({ data }) => {
-    if (seenLocales.has(data.locale)) return false
-    seenLocales.add(data.locale)
-    return true
-  })
-  .map(({ data }) => ({
-    slug: data.slug,
-    locale: data.locale,
-    url:
-      data.locale === 'en' ? `${Astro.locals.runtimeConfig.public.baseUrl}/blog/${data.slug}/` : `${Astro.locals.runtimeConfig.public.baseUrl}/${data.locale}/blog/${data.slug}/`,
-  }))
+const entriesByLocale = new Map<string, CollectionEntry<'blog'>>(entries.map((localizedEntry) => [localizedEntry.data.locale, localizedEntry]))
+const fallbackEntry = entriesByLocale.get(defaultLocale) ?? entry
+const alternateVersions = locales.map((locale) => {
+  const alternateEntry = entriesByLocale.get(locale) ?? fallbackEntry
+  const slug = alternateEntry.data.slug
+  return {
+    slug,
+    locale,
+    url: locale === defaultLocale ? `${Astro.locals.runtimeConfig.public.baseUrl}/blog/${slug}/` : `${Astro.locals.runtimeConfig.public.baseUrl}/${locale}/blog/${slug}/`,
+  }
+})
 
 const { Content, headings } = await render(entry)
 

--- a/apps/web/src/worker/index.ts
+++ b/apps/web/src/worker/index.ts
@@ -161,9 +161,10 @@ type LinkDefinition = {
   type?: string
 }
 
-const HOMEPAGE_LINK_HEADERS: LinkDefinition[] = [
-  { href: '/docs/public-api/', rel: 'service-doc', type: 'text/html' },
-]
+const HOMEPAGE_LINK_HEADERS: LinkDefinition[] = [{ href: '/docs/public-api/', rel: 'service-doc', type: 'text/html' }]
+
+const GLOBAL_CSS_PATH = '/_astro/global.css'
+const LEGACY_GLOBAL_CSS_PATH_PATTERN = /^\/_astro\/global\.[A-Za-z0-9_-]+\.css$/
 
 const routeDefinitions: Record<string, RouteDefinition> = {
   '/sponsors.json': {
@@ -174,6 +175,26 @@ const routeDefinitions: Record<string, RouteDefinition> = {
     methods: ['GET'],
     handle: async () => await handleStatus(),
   },
+}
+
+function isGlobalCssPath(pathname: string): boolean {
+  return pathname === GLOBAL_CSS_PATH || LEGACY_GLOBAL_CSS_PATH_PATTERN.test(pathname)
+}
+
+function globalCssRequest(request: Request): Request {
+  const url = new URL(request.url)
+  url.pathname = GLOBAL_CSS_PATH
+  return new Request(url.toString(), request)
+}
+
+function withGlobalCssCacheHeaders(response: Response): Response {
+  const headers = new Headers(response.headers)
+  headers.set('Cache-Control', 'public, max-age=300, must-revalidate')
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
 }
 
 async function handleRouteRequest(request: Request, env: Env, pathname: string): Promise<Response | null> {
@@ -219,7 +240,8 @@ export default {
     if (toolRouteResponse) return toolRouteResponse
     const routeResponse = await handleRouteRequest(request, env, pathname)
     if (routeResponse) return routeResponse
-    const assetResponse = await env.ASSETS.fetch(request)
+    const assetResponse = await env.ASSETS.fetch(isGlobalCssPath(pathname) ? globalCssRequest(request) : request)
+    if (isGlobalCssPath(pathname)) return withGlobalCssCacheHeaders(assetResponse)
     if (pathname === '/' || pathname === '/index.html') {
       return withLinkHeaders(assetResponse, HOMEPAGE_LINK_HEADERS)
     }


### PR DESCRIPTION
## Summary
- emit complete reciprocal hreflang alternates for blog pages, including edge-translated locale paths
- make the web global stylesheet stable at `/_astro/global.css` and route old hashed global CSS requests to it
- sanitize generated CSS asset names for docs so crawlers do not see redirected `@_@astro` CSS URLs
- refresh translated page cache keys and preserve source text when translation returns an empty segment

## Root Cause
Ahrefs was crawling stale translated HTML and source blog pages with incomplete alternate clusters. The web app also emitted hash-based global CSS URLs that could disappear after deploys, while docs generated a CSS filename containing `@` that Cloudflare redirected.

## Validation
- `bunx prettier --write 'apps/web/src/pages/blog/[slug].astro' apps/shared/astro-config.mjs apps/docs/astro.config.mjs apps/web/src/worker/index.ts apps/translation-worker/src/index.ts apps/translation-worker/scripts/verify-parser.ts`
- `NODE_OPTIONS=--max-old-space-size=16384 bunx astro check` in `apps/web`
- `NODE_OPTIONS=--max-old-space-size=16384 bunx astro check` in `apps/docs`
- `bun run check` in `apps/translation-worker`
- `bun run check:docs-mirror`
- `bun run build`