### PR TITLE
[codex] fix homepage feature spacing

### DIFF
--- a/apps/web/src/components/Hero.astro
+++ b/apps/web/src/components/Hero.astro
@@ -221,8 +221,8 @@ const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. $
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
       <!-- Single Horizontal Bar with Features and Stats -->
       <div class="mx-auto max-w-6xl">
-        <div class="rounded-3xl border border-white/10 bg-linear-to-br from-[#1a1d24]/50 to-[#14161b]/50 backdrop-blur-sm">
-          <div class="my-6 grid grid-cols-1 items-start gap-12 md:grid-cols-3">
+        <div class="rounded-3xl border border-white/10 bg-linear-to-br from-[#1a1d24]/50 to-[#14161b]/50 p-6 backdrop-blur-sm sm:p-8 lg:p-10">
+          <div class="grid grid-cols-1 items-start gap-12 md:grid-cols-3">
             <!-- Production Recovery -->
             <div class="flex flex-col items-center gap-4 text-center">
               <div class="shrink-0">


### PR DESCRIPTION
## Summary

Fixes the homepage hero feature bar spacing so the left and right feature columns no longer sit against the bordered container.

## Root cause

The feature grid used vertical margin on the grid itself but the bordered wrapper had no inner padding, which left the first and last columns too close to the border.

## Validation

- `bunx prettier --write apps/web/src/components/Hero.astro`
- `NODE_OPTIONS=--max-old-space-size=16384 bunx astro check` in `apps/web`
- Headless browser visual check on the local homepage preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted padding and spacing in the Features Bar section for improved visual consistency across different screen sizes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/663)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->