### PR TITLE
[codex] Document transitions React JSX setup

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/transitions/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/transitions/getting-started.mdx
@@ -119,6 +119,33 @@ export function InboxPage() {
 }
 ```
 
+### React JSX TypeScript
+
+Importing from `@capgo/capacitor-transitions/react` includes JSX typings for `cap-router-outlet`, `cap-page`, `cap-header`, `cap-content`, and `cap-footer`. In most React projects, that import makes the custom elements valid in TSX automatically.
+
+If TypeScript still reports `Property 'cap-router-outlet' does not exist on type 'JSX.IntrinsicElements'`, add a project declaration file:
+
+```ts
+// src/capgo-transitions.d.ts
+import '@capgo/capacitor-transitions/react';
+```
+
+For Vite, Create React App, and most webpack React apps, placing that file inside `src/` is enough. For Next.js, put it in `src/` or the project root and make sure `tsconfig.json` includes it:
+
+```json
+{
+  "include": ["src", "src/capgo-transitions.d.ts"]
+}
+```
+
+For custom TypeScript or webpack setups that use a separate `types/` folder, include that folder instead:
+
+```json
+{
+  "include": ["src", "types"]
+}
+```
+
 ## Swipe Back
 
 Enable or disable the iOS edge gesture from markup:

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-transitions.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-transitions.md
@@ -104,6 +104,21 @@ export function InboxPage() {
 }
 ```
 
+The React subpath includes JSX typings for the custom elements. If TypeScript still reports that `cap-router-outlet` does not exist on `JSX.IntrinsicElements`, add this file:
+
+```ts
+// src/capgo-transitions.d.ts
+import '@capgo/capacitor-transitions/react';
+```
+
+For Vite, Create React App, and most webpack React apps, keeping that file under `src/` is enough. For Next.js or custom TypeScript setups, make sure it is included by `tsconfig.json`:
+
+```json
+{
+  "include": ["src", "src/capgo-transitions.d.ts"]
+}
+```
+
 ## Enable swipe back
 
 Use `swipe-gesture="auto"` to enable the gesture only when Capacitor reports a native iOS runtime:

--- a/src/content/docs/docs/plugins/transitions/getting-started.mdx
+++ b/src/content/docs/docs/plugins/transitions/getting-started.mdx
@@ -119,6 +119,33 @@ export function InboxPage() {
 }
 ```
 
+### React JSX TypeScript
+
+Importing from `@capgo/capacitor-transitions/react` includes JSX typings for `cap-router-outlet`, `cap-page`, `cap-header`, `cap-content`, and `cap-footer`. In most React projects, that import makes the custom elements valid in TSX automatically.
+
+If TypeScript still reports `Property 'cap-router-outlet' does not exist on type 'JSX.IntrinsicElements'`, add a project declaration file:
+
+```ts
+// src/capgo-transitions.d.ts
+import '@capgo/capacitor-transitions/react';
+```
+
+For Vite, Create React App, and most webpack React apps, placing that file inside `src/` is enough. For Next.js, put it in `src/` or the project root and make sure `tsconfig.json` includes it:
+
+```json
+{
+  "include": ["src", "src/capgo-transitions.d.ts"]
+}
+```
+
+For custom TypeScript or webpack setups that use a separate `types/` folder, include that folder instead:
+
+```json
+{
+  "include": ["src", "types"]
+}
+```
+
 ## Swipe Back
 
 Enable or disable the iOS edge gesture from markup:


### PR DESCRIPTION
## What
- Add React JSX TypeScript setup docs for @capgo/capacitor-transitions.
- Document automatic typings from the React subpath and manual .d.ts fallback for Vite, webpack/CRA, Next.js, and custom TypeScript setups.

## Why
- React TSX users can otherwise see custom elements like cap-router-outlet as unknown JSX elements.

## How
- Added the setup guidance to docs, mirrored docs, and the web tutorial.

## Testing
- bun run check
- bun run ci:verify:docs
- bun run ci:verify:web

## Not Tested
- Remote CI is still pending on this new PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added React JSX TypeScript configuration guidance for Capacitor Transitions plugin, including setup instructions for declaration files and `tsconfig.json` examples for common project setups (Vite, Create React App, webpack, Next.js, and custom configurations).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/666)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->