### PR TITLE
Refresh pricing page design

### DIFF
--- a/apps/web/src/components/pricing/ComparePlans.astro
+++ b/apps/web/src/components/pricing/ComparePlans.astro
@@ -14,6 +14,7 @@ type CompareValue = string | boolean
 interface CompareItem {
   label: string
   emphasis?: boolean
+  faqHref?: string
   href?: string
   value: (plan: Plan) => CompareValue
 }
@@ -101,21 +102,25 @@ const rows: CompareSection[] = [
       {
         label: m.monthly_active_users({}, { locale: Astro.locals.locale }),
         emphasis: true,
+        faqHref: '#faq-mau',
         value: (plan: Database['public']['Tables']['plans']['Row']) => `${numberWithSpaces(plan.mau)}${plan.name === 'Enterprise' ? '+' : ''}`,
       },
       {
         label: 'Bandwidth',
         emphasis: true,
+        faqHref: '#faq-bandwidth',
         value: (plan: Database['public']['Tables']['plans']['Row']) =>
           `${numberWithSpaces(plan.bandwidth)}${plan.name === 'Enterprise' ? '+' : ''} GiB/${m.month({}, { locale: Astro.locals.locale })}`,
       },
       {
         label: 'Storage',
         emphasis: true,
+        faqHref: '#faq-storage',
         value: (plan: Database['public']['Tables']['plans']['Row']) => `${numberWithSpaces(plan.storage)}${plan.name === 'Enterprise' ? '+' : ''} GiB`,
       },
       {
         label: 'Credit-based overages',
+        faqHref: '#faq-credits',
         href: '#credit-pricing',
         value: () => 'Available',
       },
@@ -134,6 +139,7 @@ const rows: CompareSection[] = [
     items: [
       {
         label: 'Native build time',
+        faqHref: '#faq-build-time',
         value: (plan: Database['public']['Tables']['plans']['Row']) => `${buildTimeDisplay(plan.build_time_unit ?? 0)}${plan.name === 'Enterprise' ? '+' : ''}`,
       },
       {
@@ -207,10 +213,12 @@ const rows: CompareSection[] = [
     items: [
       {
         label: 'Stripe payments',
+        faqHref: '#faq-payment-methods',
         value: () => 'All payment options',
       },
       {
         label: 'Custom payment process',
+        faqHref: '#faq-annual-ach',
         value: (plan: Database['public']['Tables']['plans']['Row']) => (included(plan.name, ['Team', 'Enterprise']) ? 'SAP, procurement, and custom workflows' : false),
       },
     ],
@@ -228,6 +236,7 @@ const rows: CompareSection[] = [
       },
       {
         label: m.soc2_compliance({}, { locale: Astro.locals.locale }),
+        faqHref: '#faq-soc2',
         value: (plan: Database['public']['Tables']['plans']['Row']) => plan.name === 'Enterprise',
       },
       {
@@ -287,7 +296,18 @@ const rows: CompareSection[] = [
                         item.emphasis ? 'border-l-4 border-blue-600 bg-blue-50 group-hover:bg-blue-50' : 'bg-white group-hover:bg-gray-50',
                       ]}
                     >
-                      {item.label}
+                      <span class="inline-flex items-center gap-2">
+                        <span>{item.label}</span>
+                        {item.faqHref && (
+                          <a
+                            href={item.faqHref}
+                            class="inline-flex size-5 shrink-0 items-center justify-center rounded-full border border-gray-300 bg-white text-[11px] leading-none font-bold text-gray-500 transition-colors hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700 focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:outline-none"
+                            aria-label={`Open FAQ for ${item.label}`}
+                          >
+                            ?
+                          </a>
+                        )}
+                      </span>
                     </th>
                     {pricing.map((plan) => {
                       const value = item.value(plan)

--- a/apps/web/src/components/pricing/ComparePlans.astro
+++ b/apps/web/src/components/pricing/ComparePlans.astro
@@ -87,7 +87,7 @@ const rows: CompareSection[] = [
         value: () => '90 days',
       },
       {
-        label: 'App logs',
+        label: 'Device logs',
         value: () => '90 days',
       },
       {

--- a/apps/web/src/components/pricing/ComparePlans.astro
+++ b/apps/web/src/components/pricing/ComparePlans.astro
@@ -244,6 +244,10 @@ const rows: CompareSection[] = [
         value: (plan: Database['public']['Tables']['plans']['Row']) => plan.name === 'Enterprise',
       },
       {
+        label: 'ISO 27001',
+        value: (plan: Database['public']['Tables']['plans']['Row']) => (plan.name === 'Enterprise' ? 'Ongoing' : false),
+      },
+      {
         label: 'Signed NDAs & DPAs',
         value: (plan: Database['public']['Tables']['plans']['Row']) => plan.name === 'Enterprise',
       },

--- a/apps/web/src/components/pricing/ComparePlans.astro
+++ b/apps/web/src/components/pricing/ComparePlans.astro
@@ -129,6 +129,14 @@ const rows: CompareSection[] = [
         value: () => true,
       },
       {
+        label: 'Updates under 100ms',
+        value: () => true,
+      },
+      {
+        label: '7-continent replication',
+        value: () => true,
+      },
+      {
         label: 'Signed updates',
         value: () => true,
       },

--- a/apps/web/src/components/pricing/ComparePlans.astro
+++ b/apps/web/src/components/pricing/ComparePlans.astro
@@ -176,6 +176,10 @@ const rows: CompareSection[] = [
         value: () => '+130 plugins',
       },
       {
+        label: 'Ionic enterprise alternative plugins',
+        value: (plan: Database['public']['Tables']['plans']['Row']) => (included(plan.name, ['Team', 'Enterprise']) ? true : false),
+      },
+      {
         label: m.priority_bug_fixes_on_our_plugins({}, { locale: Astro.locals.locale }),
         value: (plan: Database['public']['Tables']['plans']['Row']) => (included(plan.name, ['Maker', 'Team', 'Enterprise']) ? true : false),
       },

--- a/apps/web/src/components/pricing/ComparePlans.astro
+++ b/apps/web/src/components/pricing/ComparePlans.astro
@@ -175,6 +175,10 @@ const rows: CompareSection[] = [
         label: 'Capgo plugins',
         value: () => '+130 plugins',
       },
+      {
+        label: m.priority_bug_fixes_on_our_plugins({}, { locale: Astro.locals.locale }),
+        value: (plan: Database['public']['Tables']['plans']['Row']) => (included(plan.name, ['Maker', 'Team', 'Enterprise']) ? true : false),
+      },
     ],
   },
   {
@@ -192,10 +196,6 @@ const rows: CompareSection[] = [
           if (plan.name === 'Enterprise') return m.direct_slack_channel_support({}, { locale: Astro.locals.locale })
           return m.priority_bug_fixes_on_our_plugins({}, { locale: Astro.locals.locale })
         },
-      },
-      {
-        label: m.priority_bug_fixes_on_our_plugins({}, { locale: Astro.locals.locale }),
-        value: (plan: Database['public']['Tables']['plans']['Row']) => (included(plan.name, ['Maker', 'Team', 'Enterprise']) ? true : false),
       },
       {
         label: 'Dedicated Slack/Teams channel',

--- a/apps/web/src/components/pricing/ComparePlans.astro
+++ b/apps/web/src/components/pricing/ComparePlans.astro
@@ -125,6 +125,10 @@ const rows: CompareSection[] = [
         value: () => 'Available',
       },
       {
+        label: 'Delta updates',
+        value: () => true,
+      },
+      {
         label: 'Signed updates',
         value: () => true,
       },

--- a/apps/web/src/components/pricing/CreditPricing.astro
+++ b/apps/web/src/components/pricing/CreditPricing.astro
@@ -101,64 +101,33 @@ function formatPrice(price: number): string {
 }
 ---
 
-<section id="credit-pricing" class="mx-auto max-w-7xl px-0 py-12 sm:px-6 lg:px-8">
-  <div class="rounded-3xl bg-white p-6 shadow-xl sm:p-8 lg:p-12">
-    <div class="mb-6 text-center sm:mb-8">
-      <h2 class="inline-flex flex-col items-center gap-2 text-2xl font-bold text-gray-900 sm:flex-row sm:gap-3 sm:text-3xl">
+<section id="credit-pricing" class="mx-auto max-w-7xl py-10">
+  <div class="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+    <div class="border-b border-gray-200 p-6 sm:p-8 lg:p-10">
+      <p class="text-sm font-semibold tracking-wide text-blue-700 uppercase">Usage credits</p>
+      <h2 class="mt-3 text-3xl leading-tight font-semibold tracking-tight text-gray-950 sm:text-4xl">
         {m.credit_pricing({}, { locale: Astro.locals.locale })}
       </h2>
+      <p class="mt-4 max-w-2xl text-base leading-7 text-gray-600">Credits cover usage beyond the limits included in your plan.</p>
     </div>
 
-    <div class="grid gap-6 sm:gap-8 md:grid-cols-2 xl:grid-cols-4">
+    <div class="grid md:grid-cols-2 xl:grid-cols-4">
       {
-        sortedCreditTypes.map(([type, typeCredits]) => (
-          <div class="rounded-2xl border border-gray-200 p-4 sm:p-6">
-            <h3 class="mb-4 flex items-center text-lg font-semibold text-gray-900 sm:text-xl">
-              {type === 'mau' && (
-                <svg class="mr-2 h-5 w-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-                  />
-                </svg>
-              )}
-              {type === 'bandwidth' && (
-                <svg class="mr-2 h-4 w-4 text-orange-600" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10" />
-                </svg>
-              )}
-              {type === 'storage' && (
-                <svg class="mr-2 h-5 w-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M5 19a2 2 0 01-2-2V7a2 2 0 012-2h4l2 2h4a2 2 0 012 2v1M5 19h14a2 2 0 002-2v-5a2 2 0 00-2-2H9a2 2 0 00-2 2v5a2 2 0 01-2 2z"
-                  />
-                </svg>
-              )}
-              {type === 'build_time' && (
-                <svg class="mr-2 h-5 w-5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6l4 2" />
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 22a10 10 0 100-20 10 10 0 000 20z" />
-                </svg>
-              )}
-              {getTypeLabel(type)}
-            </h3>
+        sortedCreditTypes.map(([type, typeCredits], typeIndex) => (
+          <div class:list={['border-b border-gray-200 p-6 sm:p-7 xl:border-b-0', typeIndex < sortedCreditTypes.length - 1 && 'xl:border-r']}>
+            <h3 class="text-sm leading-6 font-semibold tracking-wide text-gray-950 uppercase">{getTypeLabel(type)}</h3>
 
-            <div class="space-y-3">
+            <div class="mt-5 divide-y divide-gray-100">
               {typeCredits.map((credit, index) => (
-                <div class="flex flex-col space-y-1 border-b border-gray-100 pb-3 last:border-0 sm:flex-row sm:items-center sm:justify-between sm:space-y-0">
-                  <div class="text-xs text-gray-600 sm:text-sm">
+                <div class="flex items-start justify-between gap-4 py-3 first:pt-0 last:pb-0">
+                  <div class="text-sm leading-6 text-gray-600">
                     {index === 0
                       ? `${m.first({}, { locale: Astro.locals.locale })} ${formatNumber(credit.step_max, type, credit.unit_factor)}`
                       : index === typeCredits.length - 1
                         ? `${m.over({}, { locale: Astro.locals.locale })} ${formatNumber(credit.step_min, type, credit.unit_factor)}`
                         : `${m.next({}, { locale: Astro.locals.locale })} ${formatNumber(credit.step_max - credit.step_min, type, credit.unit_factor)}`}
                   </div>
-                  <div class="text-xs font-medium text-gray-900 sm:text-sm">
+                  <div class="text-right text-sm leading-6 font-semibold text-gray-950">
                     ${formatPrice(credit.price_per_unit)} {getUnitLabel(type)}
                   </div>
                 </div>
@@ -169,11 +138,11 @@ function formatPrice(price: number): string {
       }
     </div>
 
-    <div class="mt-6 space-y-3 text-center sm:mt-8 sm:space-y-4">
-      <p class="text-xs text-gray-600 sm:text-sm">
+    <div class="space-y-2 border-t border-gray-200 bg-gray-50 p-6 text-sm leading-6 text-gray-600 sm:p-8">
+      <p>
         {m.storage_calculated_info({}, { locale: Astro.locals.locale })}
       </p>
-      <p class="text-xs text-gray-500 sm:text-sm">
+      <p>
         {m.credits_usage_info({}, { locale: Astro.locals.locale })}
       </p>
     </div>

--- a/apps/web/src/components/pricing/Faq.astro
+++ b/apps/web/src/components/pricing/Faq.astro
@@ -114,7 +114,7 @@ import m from '@/copy/messages'
           </div>
         </details>
 
-        <details class="group border-b border-gray-700 last:border-b-0 open:border-blue-500/40 open:bg-blue-950/40">
+        <details class="group border-b border-gray-700 last:border-b-0 open:border-blue-500/40 open:bg-blue-950/40" id="faq-mau-limit">
           <summary class="flex cursor-pointer items-center justify-between px-8 py-6 transition-all duration-200 group-open:bg-blue-900/40 hover:bg-gray-700/60">
             <span class="pr-4 text-lg font-medium text-white transition-colors duration-200 group-open:text-blue-400 group-hover:text-blue-400"
               >{m.what_happens_if_i_reach_the_mau_limit({}, { locale: Astro.locals.locale })}</span
@@ -135,7 +135,7 @@ import m from '@/copy/messages'
           </div>
         </details>
 
-        <details class="group border-b border-gray-700 last:border-b-0 open:border-blue-500/40 open:bg-blue-950/40">
+        <details class="group border-b border-gray-700 last:border-b-0 open:border-blue-500/40 open:bg-blue-950/40" id="faq-storage-limit">
           <summary class="flex cursor-pointer items-center justify-between px-8 py-6 transition-all duration-200 group-open:bg-blue-900/40 hover:bg-gray-700/60">
             <span class="pr-4 text-lg font-medium text-white transition-colors duration-200 group-open:text-blue-400 group-hover:text-blue-400"
               >{m.what_happens_if_i_reach_the_storage_limit({}, { locale: Astro.locals.locale })}</span
@@ -156,7 +156,7 @@ import m from '@/copy/messages'
           </div>
         </details>
 
-        <details class="group border-b border-gray-700 last:border-b-0 open:border-blue-500/40 open:bg-blue-950/40">
+        <details class="group border-b border-gray-700 last:border-b-0 open:border-blue-500/40 open:bg-blue-950/40" id="faq-bandwidth-limit">
           <summary class="flex cursor-pointer items-center justify-between px-8 py-6 transition-all duration-200 group-open:bg-blue-900/40 hover:bg-gray-700/60">
             <span class="pr-4 text-lg font-medium text-white transition-colors duration-200 group-open:text-blue-400 group-hover:text-blue-400"
               >{m.what_happens_if_i_reach_the_bandwidth_limit({}, { locale: Astro.locals.locale })}</span
@@ -208,7 +208,7 @@ import m from '@/copy/messages'
       </div>
 
       <div class="space-y-1 overflow-hidden rounded-2xl border border-gray-700 bg-gray-800 shadow-xl shadow-black/20">
-        <details class="group border-b border-gray-700 last:border-b-0 open:border-blue-500/40 open:bg-blue-950/40">
+        <details class="group border-b border-gray-700 last:border-b-0 open:border-blue-500/40 open:bg-blue-950/40" id="faq-annual-ach">
           <summary class="flex cursor-pointer items-center justify-between px-8 py-6 transition-all duration-200 group-open:bg-blue-900/40 hover:bg-gray-700/60">
             <span class="pr-4 text-lg font-medium text-white transition-colors duration-200 group-open:text-blue-400 group-hover:text-blue-400"
               >{m.do_you_offer_annual_billing_and_ach_payment_options({}, { locale: Astro.locals.locale })}</span
@@ -229,7 +229,7 @@ import m from '@/copy/messages'
           </div>
         </details>
 
-        <details class="group border-b border-gray-700 last:border-b-0 open:border-blue-500/40 open:bg-blue-950/40">
+        <details class="group border-b border-gray-700 last:border-b-0 open:border-blue-500/40 open:bg-blue-950/40" id="faq-payment-methods">
           <summary class="flex cursor-pointer items-center justify-between px-8 py-6 transition-all duration-200 group-open:bg-blue-900/40 hover:bg-gray-700/60">
             <span class="pr-4 text-lg font-medium text-white transition-colors duration-200 group-open:text-blue-400 group-hover:text-blue-400"
               >{m.what_payment_methods_do_you_accept({}, { locale: Astro.locals.locale })}</span
@@ -334,7 +334,7 @@ import m from '@/copy/messages'
           </div>
         </details>
 
-        <details class="group border-b border-gray-700 last:border-b-0 open:border-blue-500/40 open:bg-blue-950/40">
+        <details class="group border-b border-gray-700 last:border-b-0 open:border-blue-500/40 open:bg-blue-950/40" id="faq-credits">
           <summary class="flex cursor-pointer items-center justify-between px-8 py-6 transition-all duration-200 group-open:bg-blue-900/40 hover:bg-gray-700/60">
             <span class="pr-4 text-lg font-medium text-white transition-colors duration-200 group-open:text-blue-400 group-hover:text-blue-400"
               >{m.can_i_use_credits_without_subscription({}, { locale: Astro.locals.locale })}</span

--- a/apps/web/src/components/pricing/Plans.astro
+++ b/apps/web/src/components/pricing/Plans.astro
@@ -111,7 +111,7 @@ function buildTimeDisplay(buildTimeSeconds: number) {
             </a>
             {plan.name === 'Enterprise' && (
               <a
-                href="https://cal.com/team/capgo/demo"
+                href="https://cal.com/team/capgo/capgo-enterprise-inquiry"
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="Talk to our team"

--- a/apps/web/src/components/pricing/Plans.astro
+++ b/apps/web/src/components/pricing/Plans.astro
@@ -69,12 +69,12 @@ function buildTimeDisplay(buildTimeSeconds: number) {
       pricing.map((plan) => (
         <div
           class:list={[
-            'relative flex flex-col border-b border-gray-200 bg-white p-6 sm:border-r lg:min-h-[620px] lg:border-b-0 lg:p-7',
+            'relative flex flex-col border-b border-gray-200 bg-white p-6 sm:border-r lg:min-h-[580px] lg:border-b-0 lg:p-7',
             plan.name === 'Maker' ? 'bg-blue-50/40' : '',
           ]}
           data-plan={plan.name}
         >
-          <div class="flex min-h-32 items-start justify-between gap-3">
+          <div class="flex min-h-24 items-start justify-between gap-3">
             <div>
               <h3 class="text-2xl font-semibold tracking-tight text-gray-950">{plan.name}</h3>
               <p class="mt-3 text-sm leading-6 text-gray-600">{descToText(plan.description)}</p>
@@ -84,7 +84,7 @@ function buildTimeDisplay(buildTimeSeconds: number) {
             )}
           </div>
 
-          <div class="mt-8 lg:mt-16">
+          <div class="mt-6 lg:mt-8">
             <div class="flex items-end gap-1">
               <p class="text-4xl font-semibold tracking-tight text-gray-950 sm:text-5xl" data-price>
                 {priceDisplay(plan.price_m, plan.price_y, plan.name)}
@@ -128,7 +128,7 @@ function buildTimeDisplay(buildTimeSeconds: number) {
             )}
           </div>
 
-          <div class="mt-10 lg:mt-16">
+          <div class="mt-10 lg:mt-12">
             <p class="text-xs font-semibold tracking-wide text-gray-500 uppercase">Includes:</p>
             <ul class="mt-5 space-y-4 text-sm leading-6 text-gray-700">
               {planHighlights(plan).map((highlight) => (

--- a/apps/web/src/pages/pricing.astro
+++ b/apps/web/src/pages/pricing.astro
@@ -39,6 +39,7 @@ const makeSeoTitle = (primary: string, descriptionText: string) => {
 const title = makeSeoTitle(m.pricing({}, { locale }), description)
 
 const content: { title: string; description: string; ldJSON?: any } = { title, description }
+const serviceDisruptionPolicyUrl = `${getRelativeLocaleUrl(locale, 'support-policy')}#service-disruption-and-ending`
 
 const config = Astro.locals.runtimeConfig
 
@@ -217,10 +218,7 @@ if (plans.length > 0) {
 
       <!-- Service disruption policy link -->
       <div class="mt-10 mb-10 text-center">
-        <a
-          href={getRelativeLocaleUrl(Astro.locals.locale, '/support-policy#service-disruption-and-ending')}
-          class="inline-flex items-center text-sm font-semibold text-blue-600 hover:underline"
-        >
+        <a href={serviceDisruptionPolicyUrl} class="inline-flex items-center text-sm font-semibold text-blue-600 hover:underline">
           {m.support_policy_service_disruption_link_text({}, { locale: Astro.locals.locale })}
           <svg class="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>


### PR DESCRIPTION
## Summary
- Simplify the top pricing cards into cleaner Expo-style columns and tighten the card spacing
- Add a grouped plan comparison table with highlighted key limits and links to credit pricing
- Restyle Enterprise, credit pricing, premium support, and FAQ sections to match the new pricing page design
- Add Enterprise contact avatars

## Validation
- bun run check
- cd apps/web && NODE_OPTIONS=--max-old-space-size=16384 bunx astro check
- Desktop/mobile browser review for pricing cards, credit pricing, Enterprise, and premium support sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style Updates**
  * Redesigned pricing cards with adjusted spacing, reduced header/card heights, and cleaner layout
  * Simplified credit-type cards to uppercase labels without per-type icons
  * Pricing footer restyled and moved into a compact, bordered informational block
  * Conditional borders added between credit grid cells
  * Renamed a comparison label from “App logs” to “Device logs”

* **New Features**
  * Comparison table rows can include clickable FAQ deep-links for select features
  * Updated Enterprise “Talk to our team” link to the enterprise inquiry page

* **Accessibility**
  * FAQs given explicit anchors for direct linking and improved navigation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/668)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->