### PR TITLE
[codex] centralize plugin count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,12 @@ bunx @tailwindcss/upgrade --force
 
 - Do not switch Open Graph or Twitter/X social meta images to `webp`; use `png` or `jpg`/`jpeg` for those assets and tags.
 
+## Plugin Count Copy
+
+- Never hardcode the number of Capgo plugins in text, marketing copy, docs, or UI.
+- Use the real registry-derived count from `apps/web/src/config/plugins.ts` (`pluginCount` or `pluginCountLabel`) anywhere code can import it.
+- In Markdown or static content that cannot import the registry value, avoid stating a plugin count and link to the live plugin directory instead.
+
 ## Adding A Plugin To The Website
 
 - Add the plugin registry entry in `apps/web/src/config/plugins.ts` inside `actionDefinitionRows` with the package name, title, short description, and GitHub URL.

--- a/apps/docs/src/config/plugins.ts
+++ b/apps/docs/src/config/plugins.ts
@@ -1,1 +1,1 @@
-export { actions, type Action, type Plugin } from '../../../web/src/config/plugins'
+export { actions, pluginCount, pluginCountLabel, type Action, type Plugin } from '../../../web/src/config/plugins'

--- a/apps/docs/src/content/docs/docs/index.mdx
+++ b/apps/docs/src/content/docs/docs/index.mdx
@@ -17,6 +17,7 @@ hero:
 ---
 
 import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
+import { pluginCountLabel } from '@/config/plugins';
 
 ## 🚀 Capgo Cloud - Live Updates Made Simple
 
@@ -49,7 +50,7 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
     href="/docs/plugins/electron-updater/"
   />
   <LinkCard
-    title="20+ Capacitor Plugins"
+    title={`${pluginCountLabel} Capacitor Plugins`}
     description="Explore our collection of production-ready plugins for biometrics, purchases, camera, storage, and more native features."
     href="/docs/plugins/"
   />

--- a/apps/shared/copy/messages.ts
+++ b/apps/shared/copy/messages.ts
@@ -48,7 +48,7 @@ const messages = {
   alternatives_been_doing_desc:
     'Capgo created the first serious independent Capacitor live-update platform after Appflow. Since then, others have copied the pattern. We kept shipping: 5-minute automatic setup, manual control, native rollback, CLI compatibility checks, logs, channels, and production scale.',
   alternatives_been_doing_title: 'We pioneered the independent Capacitor live-update path',
-  alternatives_biggest_plugin_desc: 'We maintain 100+ free, open-source Capacitor plugins. More than anyone else in the ecosystem except the Capacitor team itself.',
+  alternatives_biggest_plugin_desc: 'We maintain {pluginCountLabel} free, open-source Capacitor plugins. More than anyone else in the ecosystem except the Capacitor team itself.',
   alternatives_biggest_plugin_note: 'So yeah, we know a thing or two about Capacitor.',
   alternatives_biggest_plugin_title: '🚀 Biggest plugin provider after official Capacitor',
   alternatives_bootstrapped_desc: 'No investors. No debt. Just sustainable revenue from happy customers.',
@@ -156,7 +156,7 @@ const messages = {
   appflow_experience_desc:
     'Capgo created the first serious independent Capacitor live-update platform after Appflow. We have handled billions of updates, every App Store policy shift, and the weird device failures that only show up in production.',
   appflow_experience_note:
-    "Also: we're the <strong>biggest Capacitor plugin provider</strong> after the official Capacitor team, with 100+ open-source plugins. We know the ecosystem inside and out.",
+    "Also: we're the <strong>biggest Capacitor plugin provider</strong> after the official Capacitor team, with {pluginCountLabel} open-source plugins. We know the ecosystem inside and out.",
   appflow_experience_title: '4. We pioneered the independent path',
   appflow_faq_a1: "Nope. Whatever you're using now (GitHub Actions, GitLab CI, Jenkins, etc.) keeps working. Just change the upload step to use our CLI instead of Appflow's.",
   appflow_faq_a2:
@@ -499,7 +499,7 @@ const messages = {
   capwesome_diff_plugins_capawesome:
     '<strong class="text-white">Capawesome:</strong> They also make great plugins, quality-focused approach. Some are paid - that\'s their main business.',
   capwesome_diff_plugins_capgo:
-    '<strong class="text-white">Capgo:</strong> We maintain <strong class="text-emerald-400">100+ Capacitor plugins</strong> - biggest provider after official Capacitor team. All free and open source.',
+    '<strong class="text-white">Capgo:</strong> We maintain <strong class="text-emerald-400">{pluginCountLabel} Capacitor plugins</strong> - biggest provider after official Capacitor team. All free and open source.',
   capwesome_diff_plugins_note: 'Different philosophies: we go broad with all-free plugins, they focus on paid premium plugins.',
   capwesome_diff_plugins_title: 'Plugin Ecosystem',
   capwesome_diff_pricing_capawesome:
@@ -549,7 +549,7 @@ const messages = {
   capwesome_quick_facts_capgo_li4: '✅ $14/month start',
   capwesome_quick_facts_capgo_li5: '✅ 100% open source (plugin + backend)',
   capwesome_quick_facts_capgo_li6: '✅ Family business, bootstrapped',
-  capwesome_quick_facts_capgo_li7: '✅ 100+ free plugins',
+  capwesome_quick_facts_capgo_li7: '✅ {pluginCountLabel} free plugins',
   capwesome_quick_facts_capgo_li8: '✅ Self-hosting option',
   capwesome_quick_facts_legend: '✅ = Strong point | ⚠️ = Depends on needs | ❌ = Not available | ⚪ = Unknown/Not disclosed',
   capwesome_quick_facts_title: 'Quick facts (no BS)',
@@ -1253,7 +1253,7 @@ const messages = {
   footer: 'Footer',
   free_mobile_tools: 'Free Mobile Tools',
   footer_tagline_part1: 'Power your Capacitor apps with',
-  footer_tagline_part2: 'over 90+production-ready plugins',
+  footer_tagline_part2: '{pluginCountLabel} production-ready plugins',
   for_the_pay_as_you_go_plan: 'for any plan with credit-based usage',
   for_ultra_fast_delivery: 'for ultra-fast delivery',
   four_definitions_title: '4. Definitions',

--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -1,5 +1,6 @@
 ---
 import m from '@/copy/messages'
+import { pluginCountLabel } from '@/config/plugins'
 import { getLocalizedPath } from '@/services/locale-path'
 import { locales } from '@/services/locale'
 import { getRelativeLocaleUrl } from 'astro:i18n'
@@ -182,7 +183,7 @@ const navigation: Record<string, NavigationItem[]> = {
     <div class="mb-12 flex flex-col items-start justify-between lg:flex-row lg:items-center">
       <h2 class="mb-6 max-w-2xl text-3xl font-bold tracking-tight text-white md:text-4xl lg:mb-0">
         {m.footer_tagline_part1({}, { locale: Astro.locals.locale })}
-        <span class="block text-zinc-500">{m.footer_tagline_part2({}, { locale: Astro.locals.locale })}</span>
+        <span class="block text-zinc-500">{m.footer_tagline_part2({ pluginCountLabel }, { locale: Astro.locals.locale })}</span>
       </h2>
       <a
         href={getRelativeLocaleUrl(Astro.locals.locale, 'plugins')}

--- a/apps/web/src/components/pricing/ComparePlans.astro
+++ b/apps/web/src/components/pricing/ComparePlans.astro
@@ -2,6 +2,7 @@
 import { numberWithSpaces } from '@/services/misc'
 import type { Database } from '@/services/supabase.types'
 import m from '@/copy/messages'
+import { pluginCountLabel } from '@/config/plugins'
 
 interface Props {
   pricing: Database['public']['Tables']['plans']['Row'][]
@@ -173,7 +174,7 @@ const rows: CompareSection[] = [
     items: [
       {
         label: 'Capgo plugins',
-        value: () => '+130 plugins',
+        value: () => `${pluginCountLabel} plugins`,
       },
       {
         label: 'Ionic enterprise alternative plugins',

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -286,3 +286,6 @@ export const actions: Action[] = actionDefinitionRows.map((row) => {
   const [name, author, description, href, title] = row.split('|')
   return { name, author, description, href, title, icon: pluginIconsByName[name] }
 })
+
+export const pluginCount = actions.length
+export const pluginCountLabel = `${pluginCount}+`

--- a/apps/web/src/content/blog/en/appflow-shutdown-alternative.md
+++ b/apps/web/src/content/blog/en/appflow-shutdown-alternative.md
@@ -85,7 +85,7 @@ We love Ionic and Capacitor, and we're here for the long haul. If any part of th
 
 ### Proven Track Record
 - **Massive Scale**: Serving over 30 million live updates daily in our cloud infrastructure, with even more in self-hosted environments
-- **Active Development**: Created and maintained over 20 plugins in the Capacitor ecosystem: [explore our plugins](https://github.com/cap-go/)
+- **Active Development**: Created and maintained a broad plugin collection in the Capacitor ecosystem: [explore our plugins](https://github.com/cap-go/)
 - **Growing Community**: Successfully helping numerous teams transition to Capgo this year
 - **Complete Solutions**: Providing comprehensive CI/CD solutions, from tutorials to full service integration
 - **Sustainable Model**: Self-funded and profitable, ensuring long-term stability for our users

--- a/apps/web/src/content/blog/en/capacitor-comprehensive-guide.md
+++ b/apps/web/src/content/blog/en/capacitor-comprehensive-guide.md
@@ -92,7 +92,7 @@ You can use pre-baked, optimized components from Ionic Framework, Quasar, Framew
 
 ## How many plugins does Capacitor have?
 
-Capacitor has 26 core plugins and numerous community-built plugins. Check out [awesome-capacitor](https://github.com/riderx/awesome-capacitor/), the [capacitor-community](https://github.com/capacitor-community/) organization, and [Capgo](https://capgo.app/plugins/) with 91 plugins for community plugin resources.
+Capacitor has 26 core plugins and numerous community-built plugins. Check out [awesome-capacitor](https://github.com/riderx/awesome-capacitor/), the [capacitor-community](https://github.com/capacitor-community/) organization, and the [Capgo plugin directory](https://capgo.app/plugins/) for community plugin resources.
 
 ## Is there a VS Code Extension for Capacitor?
 

--- a/apps/web/src/content/blog/en/creating-and-deleting-update-channels-in-capacitor.md
+++ b/apps/web/src/content/blog/en/creating-and-deleting-update-channels-in-capacitor.md
@@ -251,7 +251,7 @@ Getting started with Capgo is simple and quick. Just follow these three steps:
 
 > "@Capgo is a must have tools for developers, who want to be more productive. Avoiding review for bugfix is golden." - Bessie Cooper [\[1\]](https://capgo.app/)
 
-Capgo supports over 30 plugins and works seamlessly with CI/CD pipelines, making it easy to fit into your existing development process. It enhances [update management](https://capgo.app/docs/getting-started/deploy/) while keeping everything efficient and straightforward.
+Capgo supports a broad plugin collection and works seamlessly with CI/CD pipelines, making it easy to fit into your existing development process. It enhances [update management](https://capgo.app/docs/getting-started/deploy/) while keeping everything efficient and straightforward.
 
 ## Summary
 

--- a/apps/web/src/pages/about.astro
+++ b/apps/web/src/pages/about.astro
@@ -3,6 +3,7 @@ import Layout from '@/layouts/Layout.astro'
 import m from '@/copy/messages'
 import { getRelativeLocaleUrl } from 'astro:i18n'
 import { createLdJsonGraph, createPersonLdJson, createWebPageLdJson } from '@/lib/ldJson'
+import { pluginCountLabel } from '@/config/plugins'
 import type { Thing } from 'schema-dts'
 
 const title = [Astro.locals.runtimeConfig.public.brand, m.about_capgo({}, { locale: Astro.locals.locale })].join(' | ')
@@ -130,7 +131,8 @@ const content = {
             </div>
             <h3 class="mb-2 text-xl font-bold text-white">Enterprise Support Contracts</h3>
             <p class="text-sm text-gray-300">
-              Multiple Fortune 500 companies have long-term support contracts with us, ensuring Capgo and our 30+ plugins will be maintained and improved for years to come.
+              Multiple Fortune 500 companies have long-term support contracts with us, ensuring Capgo and our {pluginCountLabel} plugins will be maintained and improved for years to
+              come.
             </p>
           </div>
         </div>
@@ -140,7 +142,7 @@ const content = {
           <h3 class="mb-4 text-center text-xl font-bold text-white">Why Enterprises Trust Capgo</h3>
           <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
             <div class="text-center">
-              <p class="text-2xl font-bold text-white">30+</p>
+              <p class="text-2xl font-bold text-white">{pluginCountLabel}</p>
               <p class="text-xs text-gray-400">Open Source Plugins</p>
             </div>
             <div class="text-center">
@@ -392,7 +394,8 @@ const content = {
                 { locale: Astro.locals.locale },
               )
             }
-            With 30+ maintained plugins and long-term support contracts with multiple enterprises, we're building infrastructure that companies can depend on for the next decade.
+            With {pluginCountLabel} maintained plugins and long-term support contracts with multiple enterprises, we're building infrastructure that companies can depend on for the next
+            decade.
           </p>
           <h3 class="mb-4 text-2xl font-bold text-white">💪 {m.practicing_what_we_preach({}, { locale: Astro.locals.locale })}</h3>
           <p class="mb-6 text-gray-300">

--- a/apps/web/src/pages/alternatives.astro
+++ b/apps/web/src/pages/alternatives.astro
@@ -2,6 +2,7 @@
 import Layout from '@/layouts/Layout.astro'
 import { getRelativeLocaleUrl } from 'astro:i18n'
 import m from '@/copy/messages'
+import { pluginCountLabel } from '@/config/plugins'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
 
 const locale = Astro.locals.locale
@@ -98,7 +99,7 @@ const content = {
             {m.alternatives_biggest_plugin_title({}, { locale })}
           </h3>
           <p class="mb-2 text-gray-300">
-            {m.alternatives_biggest_plugin_desc({}, { locale })}
+            {m.alternatives_biggest_plugin_desc({ pluginCountLabel }, { locale })}
           </p>
           <p class="text-gray-400">
             {m.alternatives_biggest_plugin_note({}, { locale })}

--- a/apps/web/src/pages/capwesome.astro
+++ b/apps/web/src/pages/capwesome.astro
@@ -2,6 +2,7 @@
 import Layout from '@/layouts/Layout.astro'
 import { getRelativeLocaleUrl } from 'astro:i18n'
 import m from '@/copy/messages'
+import { pluginCountLabel } from '@/config/plugins'
 
 const locale = Astro.locals.locale
 const title = m.capwesome_title({}, { locale })
@@ -130,7 +131,7 @@ const migrationGuideUrl = getRelativeLocaleUrl(locale, 'docs/upgrade/from-capawe
               {m.capwesome_diff_plugins_title({}, { locale })}
             </h3>
             <div class="space-y-2 text-gray-300">
-              <p set:html={m.capwesome_diff_plugins_capgo({}, { locale })} />
+              <p set:html={m.capwesome_diff_plugins_capgo({ pluginCountLabel }, { locale })} />
               <p set:html={m.capwesome_diff_plugins_capawesome({}, { locale })} />
               <p class="pt-2 text-sm text-gray-400">
                 {m.capwesome_diff_plugins_note({}, { locale })}
@@ -239,7 +240,7 @@ const migrationGuideUrl = getRelativeLocaleUrl(locale, 'docs/upgrade/from-capawe
               <li>{m.capwesome_quick_facts_capgo_li4({}, { locale })}</li>
               <li>{m.capwesome_quick_facts_capgo_li5({}, { locale })}</li>
               <li>{m.capwesome_quick_facts_capgo_li6({}, { locale })}</li>
-              <li>{m.capwesome_quick_facts_capgo_li7({}, { locale })}</li>
+              <li>{m.capwesome_quick_facts_capgo_li7({ pluginCountLabel }, { locale })}</li>
               <li>{m.capwesome_quick_facts_capgo_li8({}, { locale })}</li>
             </ul>
           </div>

--- a/apps/web/src/pages/ionic-appflow.astro
+++ b/apps/web/src/pages/ionic-appflow.astro
@@ -2,6 +2,7 @@
 import Layout from '@/layouts/Layout.astro'
 import { getRelativeLocaleUrl } from 'astro:i18n'
 import m from '@/copy/messages'
+import { pluginCountLabel } from '@/config/plugins'
 
 const locale = Astro.locals.locale
 const title = m.capflow_title({}, { locale })
@@ -118,7 +119,7 @@ const migrationServicesUrl = getRelativeLocaleUrl(locale, 'consulting')
             <p class="text-gray-300">
               {m.appflow_experience_desc({}, { locale })}
             </p>
-            <p class="mt-2 text-sm text-gray-400" set:html={m.appflow_experience_note({}, { locale })} />
+            <p class="mt-2 text-sm text-gray-400" set:html={m.appflow_experience_note({ pluginCountLabel }, { locale })} />
           </div>
 
           <!-- Support -->


### PR DESCRIPTION
## Summary

- Derive the public plugin count from the plugin registry instead of hardcoded marketing numbers.
- Reuse the shared count in footer, pricing, docs, about, alternatives, Appflow, and Capawesome copy.
- Remove stale plugin-count claims from older blog posts where a dynamic registry value is not available.

## Why

The site had inconsistent plugin totals such as 20+, 30+, 90+, 100+, and 130+. The registry already knows the current count, so the display copy should use that single source where possible.

## Validation

- `bunx prettier --write <touched files>`
- `bun run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized plugin count configuration to be dynamically sourced from a single configuration value instead of hardcoded numbers across multiple pages and components, ensuring consistent and easily updatable plugin count information throughout the site.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/669)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->