### PR TITLE
[codex] remove Capgo CLI repo mentions

### DIFF
--- a/apps/shared/copy/messages.ts
+++ b/apps/shared/copy/messages.ts
@@ -355,8 +355,6 @@ const messages = {
   bug_bounty_payment_note:
     'Payments are issued only after we have identified the issue, fixed it, opened a pull request, and you have verified after release that the fix works for you. This process usually takes between 20 and 30 days. Please do not send messages like "to get paid"; payment happens only once the release is live and you\'ve tested and validated the fix.',
   bug_bounty_program: 'Bug Bounty Program',
-  bug_bounty_repo_cli: 'Capgo CLI',
-  bug_bounty_repo_cli_desc: 'Command-line interface for managing Capgo deployments and live updates',
   bug_bounty_repo_landing: 'Capgo Backend & Landing',
   bug_bounty_repo_landing_desc: 'Main Capgo repository including backend services and landing website',
   bug_bounty_repo_updater: 'Capacitor Updater Plugin',

--- a/apps/web/public/plugins-readme.md
+++ b/apps/web/public/plugins-readme.md
@@ -70,7 +70,7 @@ Explore real-world apps using Capgo in production in the [Showcase](https://capg
 
 <table>
 <tr>
-<td align="center" width="33%">
+<td align="center" width="50%">
 <h3><a href="https://github.com/Cap-go/capacitor-updater/">Updater</a></h3>
 <p><code>@capgo/capacitor-updater</code></p>
 <p>Deploy live updates instantly to your users without app store review delays</p>
@@ -80,7 +80,7 @@ Explore real-world apps using Capgo in production in the [Showcase](https://capg
 </p>
 <p><a href="https://capgo.app/plugins/capacitor-updater/">Docs</a> | <a href="https://github.com/Cap-go/capacitor-updater/">GitHub</a></p>
 </td>
-<td align="center" width="33%">
+<td align="center" width="50%">
 <h3><a href="https://github.com/Cap-go/capgo/">Capgo Console</a></h3>
 <p><code>Capgo Console</code></p>
 <p>Front and back base on Supabase</p>
@@ -88,16 +88,6 @@ Explore real-world apps using Capgo in production in the [Showcase](https://capg
 <a href="https://github.com/Cap-go/capgo/"><img src="https://img.shields.io/github/stars/Cap-go/capgo?style=flat-square&label=stars" alt="GitHub stars"></a>
 </p>
 <p><a href="https://capgo.app/docs/">Docs</a> | <a href="https://github.com/Cap-go/capgo/">GitHub</a></p>
-</td>
-<td align="center" width="33%">
-<h3><a href="https://github.com/Cap-go/cli/">Capgo CLI</a></h3>
-<p><code>@capgo/cli</code></p>
-<p>Manage/Upload your Cloud/ Self hosted apps from CLI</p>
-<p>
-<a href="https://www.npmjs.com/package/@capgo/cli"><img src="https://img.shields.io/npm/dw/@capgo/cli?style=flat-square&label=downloads" alt="npm downloads"></a>
-<a href="https://github.com/Cap-go/cli/"><img src="https://img.shields.io/github/stars/Cap-go/cli?style=flat-square&label=stars" alt="GitHub stars"></a>
-</p>
-<p><a href="https://capgo.app/docs/cli/overview/">Docs</a> | <a href="https://github.com/Cap-go/cli/">GitHub</a></p>
 </td>
 </tr>
 </table>

--- a/apps/web/src/content/blog/en/how-to-use-semantic-versioning-with-capgo-ota-updates.md
+++ b/apps/web/src/content/blog/en/how-to-use-semantic-versioning-with-capgo-ota-updates.md
@@ -296,7 +296,7 @@ For larger teams, the following version management matrix can help organize upda
 Even with precautions, updates can fail. If that happens, follow these recovery steps:
 
 1.  Roll back to a previous stable bundle.
-2.  Increment version numbers for any new fixes (note: version numbers cannot be reused after deletion) [\[2\]](https://github.com/Cap-go/CLI).
+2.  Increment version numbers for any new fixes (note: version numbers cannot be reused after deletion) [\[2\]](https://github.com/Cap-go/capgo).
 3.  Verify updates during app startup to ensure they work as expected.
 
 Capgo's updater is designed to handle disruptions. For example, if the server is unreachable or an update is deleted, the app continues to function normally [\[3\]](https://capgo.app/docs/faq/). Additionally, failed network requests are automatically retried during the next app launch [\[3\]](https://capgo.app/docs/faq/). This built-in resilience minimizes downtime and ensures smoother operations.

--- a/apps/web/src/pages/bug-bounty.astro
+++ b/apps/web/src/pages/bug-bounty.astro
@@ -28,12 +28,6 @@ const repositories = [
     securityUrl: 'https://github.com/Cap-go/capgo/security/advisories/new',
   },
   {
-    name: m.bug_bounty_repo_cli({}, { locale: Astro.locals.locale }),
-    desc: m.bug_bounty_repo_cli_desc({}, { locale: Astro.locals.locale }),
-    url: 'https://github.com/Cap-go/CLI',
-    securityUrl: 'https://github.com/Cap-go/CLI/security/advisories/new',
-  },
-  {
     name: m.bug_bounty_repo_updater({}, { locale: Astro.locals.locale }),
     desc: m.bug_bounty_repo_updater_desc({}, { locale: Astro.locals.locale }),
     url: 'https://github.com/Cap-go/capacitor-updater',

--- a/scripts/action.mjs
+++ b/scripts/action.mjs
@@ -1,13 +1,5 @@
 export const actions = [
   {
-    name: '@capgo/cli',
-    author: 'github.com/riderx',
-    description: 'A CLI to upload to capgo servers',
-    href: 'https://github.com/Cap-go/capgo-cli/',
-    title: 'CLI',
-    // icon: CommandLineIcon,
-  },
-  {
     name: '@capgo/standard-version',
     author: 'Martin Donadieu',
     description: 'replacement for `npm version` with automatic CHANGELOG generation',

--- a/scripts/generate-plugins-readme.ts
+++ b/scripts/generate-plugins-readme.ts
@@ -47,6 +47,7 @@ const capgoCloudCards: CardData[] = [
     href: 'https://github.com/Cap-go/capacitor-updater/',
     description: 'Deploy live updates instantly to your users without app store review delays',
     docsUrl: 'https://capgo.app/plugins/capacitor-updater/',
+    width: '50%',
   },
   {
     title: 'Capgo Console',
@@ -54,13 +55,7 @@ const capgoCloudCards: CardData[] = [
     href: 'https://github.com/Cap-go/capgo/',
     description: 'Front and back base on Supabase',
     docsUrl: 'https://capgo.app/docs/',
-  },
-  {
-    title: 'Capgo CLI',
-    name: '@capgo/cli',
-    href: 'https://github.com/Cap-go/cli/',
-    description: 'Manage/Upload your Cloud/ Self hosted apps from CLI',
-    docsUrl: 'https://capgo.app/docs/cli/overview/',
+    width: '50%',
   },
 ]
 


### PR DESCRIPTION
## Summary

- Remove the separate Capgo CLI repository from the bug bounty repository list.
- Remove the Capgo CLI GitHub card from the generated plugins README data and generated public README.
- Update the old `Cap-go/CLI` blog reference to point at the merged Capgo console repository.

## Why

The Capgo CLI repository has been merged into the Capgo console repository, so website references should no longer point users to the retired standalone CLI repo.

## Validation

- `bunx prettier --write apps/web/src/pages/bug-bounty.astro apps/shared/copy/messages.ts scripts/action.mjs scripts/generate-plugins-readme.ts apps/web/src/content/blog/en/how-to-use-semantic-versioning-with-capgo-ota-updates.md apps/web/public/plugins-readme.md`
- `bun run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed CLI repository entry from bug bounty listings.
  * Updated plugins documentation layout for improved display.
  * Cleaned up internal message references related to CLI.

* **Documentation**
  * Fixed hyperlink references in versioning guide.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/674)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->