### PR TITLE
[codex] add recaptcha plugin docs

### DIFF
--- a/apps/docs/src/config/llmsCustomSets.ts
+++ b/apps/docs/src/config/llmsCustomSets.ts
@@ -84,6 +84,7 @@ Plugin Intune|Microsoft Intune MAM and MSAL plugin|docs/plugins/intune/**
 Plugin Persistent Account|persistent account storage plugin|docs/plugins/persistent-account/**
 Plugin Photo Library|photo library access plugin|docs/plugins/photo-library/**
 Plugin Printer|printing plugin for documents and images|docs/plugins/printer/**
+Plugin reCAPTCHA|reCAPTCHA and reCAPTCHA Enterprise token plugin for Web, Android, and iOS|docs/plugins/recaptcha/**
 Plugin RealtimeKit|real-time communication plugin|docs/plugins/realtimekit/**
 Plugin Ricoh 360 Camera|Ricoh 360 camera integration plugin|docs/plugins/ricoh360-camera/**
 Plugin Screen Orientation|screen orientation control plugin|docs/plugins/screen-orientation/**

--- a/apps/docs/src/config/llmsCustomSets.ts
+++ b/apps/docs/src/config/llmsCustomSets.ts
@@ -84,8 +84,8 @@ Plugin Intune|Microsoft Intune MAM and MSAL plugin|docs/plugins/intune/**
 Plugin Persistent Account|persistent account storage plugin|docs/plugins/persistent-account/**
 Plugin Photo Library|photo library access plugin|docs/plugins/photo-library/**
 Plugin Printer|printing plugin for documents and images|docs/plugins/printer/**
-Plugin reCAPTCHA|reCAPTCHA and reCAPTCHA Enterprise token plugin for Web, Android, and iOS|docs/plugins/recaptcha/**
 Plugin RealtimeKit|real-time communication plugin|docs/plugins/realtimekit/**
+Plugin reCAPTCHA|reCAPTCHA and reCAPTCHA Enterprise token plugin for Web, Android, and iOS|docs/plugins/recaptcha/**
 Plugin Ricoh 360 Camera|Ricoh 360 camera integration plugin|docs/plugins/ricoh360-camera/**
 Plugin Screen Orientation|screen orientation control plugin|docs/plugins/screen-orientation/**
 Plugin Screen Recorder|screen recording plugin|docs/plugins/screen-recorder/**

--- a/apps/docs/src/config/llmsCustomSets.ts
+++ b/apps/docs/src/config/llmsCustomSets.ts
@@ -85,7 +85,7 @@ Plugin Persistent Account|persistent account storage plugin|docs/plugins/persist
 Plugin Photo Library|photo library access plugin|docs/plugins/photo-library/**
 Plugin Printer|printing plugin for documents and images|docs/plugins/printer/**
 Plugin RealtimeKit|real-time communication plugin|docs/plugins/realtimekit/**
-Plugin reCAPTCHA|reCAPTCHA and reCAPTCHA Enterprise token plugin for Web, Android, and iOS|docs/plugins/recaptcha/**
+Plugin reCAPTCHA|Web reCAPTCHA, Web reCAPTCHA Enterprise, and native Enterprise mobile token plugin|docs/plugins/recaptcha/**
 Plugin Ricoh 360 Camera|Ricoh 360 camera integration plugin|docs/plugins/ricoh360-camera/**
 Plugin Screen Orientation|screen orientation control plugin|docs/plugins/screen-orientation/**
 Plugin Screen Recorder|screen recording plugin|docs/plugins/screen-recorder/**

--- a/apps/docs/src/config/sidebar.mjs
+++ b/apps/docs/src/config/sidebar.mjs
@@ -171,6 +171,7 @@ const pluginEntries = [
   ['Persistent Account', 'persistent-account'],
   ['Photo Library', 'photo-library'],
   ['Printer', 'printer'],
+  ['reCAPTCHA', 'recaptcha', [linkItem('iOS setup', '/docs/plugins/recaptcha/ios'), linkItem('Android setup', '/docs/plugins/recaptcha/android')]],
   ['RealtimeKit', 'realtimekit'],
   ['Ricoh 360 Camera', 'ricoh360-camera'],
   ['Screen Orientation', 'screen-orientation'],

--- a/apps/docs/src/content/docs/docs/plugins/recaptcha/android.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/recaptcha/android.mdx
@@ -9,6 +9,8 @@ sidebar:
 
 Create an Android mobile application key in Google Cloud reCAPTCHA. Register the package name used by your Capacitor app, then set the key in `capacitor.config.ts`.
 
+Android uses Google's mobile reCAPTCHA SDK. Regular, non-Enterprise reCAPTCHA v3 is only available on Web in this plugin; `enterprise: false` is rejected on Android.
+
 ```ts
 import type { CapacitorConfig } from '@capacitor/cli';
 import '@capgo/capacitor-recaptcha';

--- a/apps/docs/src/content/docs/docs/plugins/recaptcha/android.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/recaptcha/android.mdx
@@ -1,0 +1,48 @@
+---
+title: Android Setup
+description: Android-specific setup for @capgo/capacitor-recaptcha.
+sidebar:
+  order: 3
+---
+
+## Site Key
+
+Create an Android mobile application key in Google Cloud reCAPTCHA. Register the package name used by your Capacitor app, then set the key in `capacitor.config.ts`.
+
+```ts
+import type { CapacitorConfig } from '@capacitor/cli';
+import '@capgo/capacitor-recaptcha';
+
+const config: CapacitorConfig = {
+  plugins: {
+    Recaptcha: {
+      androidSiteKey: 'ANDROID_SITE_KEY',
+    },
+  },
+};
+
+export default config;
+```
+
+## Dependency
+
+The plugin includes the Google Android reCAPTCHA dependency:
+
+```gradle
+com.google.android.recaptcha:recaptcha:18.8.0
+```
+
+You can override the dependency version from the app Gradle config with `recaptchaVersion` when you need to pin a newer Google SDK release.
+
+## Execute
+
+```ts
+import { Recaptcha } from '@capgo/capacitor-recaptcha';
+
+const { token } = await Recaptcha.execute({
+  action: 'checkout',
+  timeout: 10000,
+});
+```
+
+Send the token to your backend immediately and create a reCAPTCHA assessment before accepting the protected request.

--- a/apps/docs/src/content/docs/docs/plugins/recaptcha/android.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/recaptcha/android.mdx
@@ -32,7 +32,14 @@ The plugin includes the Google Android reCAPTCHA dependency:
 com.google.android.recaptcha:recaptcha:18.8.0
 ```
 
+Google's Android reCAPTCHA SDK requires core library desugaring in the consuming app. The plugin enables it automatically during `npx cap sync android` and adds:
+
+```gradle
+com.android.tools:desugar_jdk_libs:2.1.5
+```
+
 You can override the dependency version from the app Gradle config with `recaptchaVersion` when you need to pin a newer Google SDK release.
+You can override the desugaring dependency with `desugarJdkLibsVersion`.
 
 ## Execute
 

--- a/apps/docs/src/content/docs/docs/plugins/recaptcha/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/recaptcha/getting-started.mdx
@@ -69,8 +69,8 @@ const { token } = await Recaptcha.execute({
 });
 ```
 
-On Android and iOS, the native Google mobile SDK is used and the returned result reports `enterprise: true`.
+On Android and iOS, Google's native mobile SDK path is Enterprise/mobile only. Passing `enterprise: false` on native platforms is rejected so a standard Web v3 key is not used accidentally.
 
 ## Migration Notes
 
-The plugin accepts the old Cordova option aliases `sitekeyAndroid` and `sitekeyWeb` during execution. Prefer the Capacitor config names for new code.
+The plugin accepts the old Cordova option aliases `sitekeyAndroid` and `sitekeyWeb` in call options and Capacitor config. It also accepts `sitekeyIos` and `sitekeyIOS` as iOS migration aliases. Prefer the Capacitor config names for new code.

--- a/apps/docs/src/content/docs/docs/plugins/recaptcha/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/recaptcha/getting-started.mdx
@@ -1,0 +1,76 @@
+---
+title: Getting Started
+description: "Install @capgo/capacitor-recaptcha and generate reCAPTCHA tokens in a Capacitor app."
+sidebar:
+  order: 2
+---
+
+## Install
+
+```bash
+npm install @capgo/capacitor-recaptcha
+npx cap sync
+```
+
+## Configure Site Keys
+
+Create platform keys in Google Cloud reCAPTCHA, then add them to `capacitor.config.ts`.
+
+```ts
+import type { CapacitorConfig } from '@capacitor/cli';
+import '@capgo/capacitor-recaptcha';
+
+const config: CapacitorConfig = {
+  appId: 'com.example.app',
+  appName: 'Example',
+  webDir: 'dist',
+  plugins: {
+    Recaptcha: {
+      androidSiteKey: 'ANDROID_SITE_KEY',
+      iosSiteKey: 'IOS_SITE_KEY',
+      webSiteKey: 'WEB_SITE_KEY',
+      enterprise: true,
+    },
+  },
+};
+
+export default config;
+```
+
+`androidSiteKey`, `iosSiteKey`, and `webSiteKey` override the shared `siteKey`. You can also pass a `siteKey` directly to `load()` or `execute()` when the key depends on your environment.
+
+## Generate A Token
+
+```ts
+import { Recaptcha } from '@capgo/capacitor-recaptcha';
+
+const { token } = await Recaptcha.execute({
+  action: 'login',
+});
+
+await fetch('/api/recaptcha-assessment', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ token, action: 'login' }),
+});
+```
+
+`execute()` calls `load()` automatically when the client is not ready, so an explicit preload step is optional.
+
+## Web Standard reCAPTCHA v3
+
+Set `enterprise: false` to load Google's standard Web reCAPTCHA v3 script.
+
+```ts
+const { token } = await Recaptcha.execute({
+  siteKey: 'WEB_V3_SITE_KEY',
+  enterprise: false,
+  action: 'signup',
+});
+```
+
+On Android and iOS, the native Google mobile SDK is used and the returned result reports `enterprise: true`.
+
+## Migration Notes
+
+The plugin accepts the old Cordova option aliases `sitekeyAndroid` and `sitekeyWeb` during execution. Prefer the Capacitor config names for new code.

--- a/apps/docs/src/content/docs/docs/plugins/recaptcha/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/recaptcha/index.mdx
@@ -1,0 +1,53 @@
+---
+title: "@capgo/capacitor-recaptcha"
+description: "Generate reCAPTCHA and reCAPTCHA Enterprise tokens from Capacitor apps."
+tableOfContents: false
+next: false
+prev: false
+sidebar:
+  order: 1
+  label: "Introduction"
+hero:
+  tagline: "Generate reCAPTCHA and reCAPTCHA Enterprise tokens on Web, Android, and iOS before sensitive backend requests."
+  actions:
+    - text: Get started
+      link: /docs/plugins/recaptcha/getting-started/
+      icon: right-arrow
+      variant: primary
+    - text: GitHub
+      link: https://github.com/Cap-go/capacitor-recaptcha/
+      icon: external
+      variant: minimal
+---
+
+## Overview
+
+`@capgo/capacitor-recaptcha` loads Google reCAPTCHA on each Capacitor platform and returns a token for a named action.
+
+Use it before sensitive requests such as login, signup, checkout, password reset, or abuse-prone form submissions. Send the token to your backend and create a reCAPTCHA assessment there.
+
+## Core Capabilities
+
+- `load` - Loads and caches the platform reCAPTCHA client.
+- `execute` - Runs reCAPTCHA for an action and returns a token.
+- `getPluginVersion` - Returns the native implementation version marker.
+
+## Platform Support
+
+| Platform | Support |
+| --- | --- |
+| Web | reCAPTCHA v3 with `api.js`, or reCAPTCHA Enterprise with `enterprise.js` |
+| Android | Google mobile reCAPTCHA SDK |
+| iOS | Google `RecaptchaEnterprise` SDK |
+
+## Public API
+
+| Method | Description |
+| --- | --- |
+| `load` | Loads and caches the reCAPTCHA client for the current platform. |
+| `execute` | Executes reCAPTCHA for an action and returns a token for backend assessment. |
+| `getPluginVersion` | Returns the platform implementation version marker. |
+
+## Source Of Truth
+
+This reference is synced from `src/definitions.ts` in [capacitor-recaptcha](https://github.com/Cap-go/capacitor-recaptcha/).

--- a/apps/docs/src/content/docs/docs/plugins/recaptcha/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/recaptcha/index.mdx
@@ -37,8 +37,8 @@ Use it before sensitive requests such as login, signup, checkout, password reset
 | Platform | Support |
 | --- | --- |
 | Web | reCAPTCHA v3 with `api.js`, or reCAPTCHA Enterprise with `enterprise.js` |
-| Android | Google mobile reCAPTCHA SDK |
-| iOS | Google `RecaptchaEnterprise` SDK |
+| Android | Google mobile reCAPTCHA SDK. Native regular reCAPTCHA v3 is not a separate mode; `enterprise: false` is rejected. |
+| iOS | Google `RecaptchaEnterprise` SDK. Native regular reCAPTCHA v3 is not a separate mode; `enterprise: false` is rejected. |
 
 ## Public API
 

--- a/apps/docs/src/content/docs/docs/plugins/recaptcha/ios.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/recaptcha/ios.mdx
@@ -9,6 +9,8 @@ sidebar:
 
 Create an iOS mobile application key in Google Cloud reCAPTCHA. Register the bundle identifier used by your Capacitor app, then set the key in `capacitor.config.ts`.
 
+iOS uses Google's `RecaptchaEnterprise` mobile SDK. Regular, non-Enterprise reCAPTCHA v3 is only available on Web in this plugin; `enterprise: false` is rejected on iOS.
+
 ```ts
 import type { CapacitorConfig } from '@capacitor/cli';
 import '@capgo/capacitor-recaptcha';

--- a/apps/docs/src/content/docs/docs/plugins/recaptcha/ios.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/recaptcha/ios.mdx
@@ -1,0 +1,42 @@
+---
+title: iOS Setup
+description: iOS-specific setup for @capgo/capacitor-recaptcha.
+sidebar:
+  order: 4
+---
+
+## Site Key
+
+Create an iOS mobile application key in Google Cloud reCAPTCHA. Register the bundle identifier used by your Capacitor app, then set the key in `capacitor.config.ts`.
+
+```ts
+import type { CapacitorConfig } from '@capacitor/cli';
+import '@capgo/capacitor-recaptcha';
+
+const config: CapacitorConfig = {
+  plugins: {
+    Recaptcha: {
+      iosSiteKey: 'IOS_SITE_KEY',
+    },
+  },
+};
+
+export default config;
+```
+
+## Dependency
+
+The plugin ships CocoaPods and Swift Package Manager metadata for Google's `RecaptchaEnterprise` iOS SDK. Running `npx cap sync ios` installs the native dependency through your selected Capacitor iOS workflow.
+
+## Execute
+
+```ts
+import { Recaptcha } from '@capgo/capacitor-recaptcha';
+
+const { token } = await Recaptcha.execute({
+  action: 'password_reset',
+  timeout: 10000,
+});
+```
+
+Send the token to your backend immediately and create a reCAPTCHA assessment before accepting the protected request.

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -61,7 +61,7 @@ const actionDefinitionRows =
 @capgo/capacitor-android-sms-retriever|github.com/Cap-go|Read one app-targeted verification SMS without SMS permissions and request SIM phone number hints on Android|https://github.com/Cap-go/capacitor-android-sms-retriever/|Android SMS Retriever
 @capgo/capacitor-appinsights|github.com/Cap-go|Track app usage, performance metrics, and user behavior with Apptopia AppInsights|https://github.com/Cap-go/capacitor-appinsights/|AppInsights
 @capgo/capacitor-app-attest|github.com/Cap-go|Capacitor plugin for cross-platform device attestation using Apple App Attest and Google Play Integrity Standard|https://github.com/Cap-go/capacitor-app-attest/|App Attest
-@capgo/capacitor-recaptcha|github.com/Cap-go|Generate reCAPTCHA and reCAPTCHA Enterprise tokens on Web, Android, and iOS|https://github.com/Cap-go/capacitor-recaptcha/|reCAPTCHA
+@capgo/capacitor-recaptcha|github.com/Cap-go|Generate Web reCAPTCHA or reCAPTCHA Enterprise tokens plus native Enterprise mobile tokens|https://github.com/Cap-go/capacitor-recaptcha/|reCAPTCHA
 @capgo/capacitor-audiosession|github.com/Cap-go|Configure iOS audio session for background playback, mixing, and routing control|https://github.com/Cap-go/capacitor-audiosession/|Audio Session
 @capgo/capacitor-background-geolocation|github.com/Cap-go|Accurate background location tracking with native iOS and Android geofencing plus transition webhooks|https://github.com/Cap-go/capacitor-background-geolocation/|Background Geolocation
 @capgo/capacitor-background-task|github.com/Cap-go|Schedule periodic background fetch tasks on iOS and Android with Expo-style task registration|https://github.com/Cap-go/capacitor-background-task/|Background Task

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -61,6 +61,7 @@ const actionDefinitionRows =
 @capgo/capacitor-android-sms-retriever|github.com/Cap-go|Read one app-targeted verification SMS without SMS permissions and request SIM phone number hints on Android|https://github.com/Cap-go/capacitor-android-sms-retriever/|Android SMS Retriever
 @capgo/capacitor-appinsights|github.com/Cap-go|Track app usage, performance metrics, and user behavior with Apptopia AppInsights|https://github.com/Cap-go/capacitor-appinsights/|AppInsights
 @capgo/capacitor-app-attest|github.com/Cap-go|Capacitor plugin for cross-platform device attestation using Apple App Attest and Google Play Integrity Standard|https://github.com/Cap-go/capacitor-app-attest/|App Attest
+@capgo/capacitor-recaptcha|github.com/Cap-go|Generate reCAPTCHA and reCAPTCHA Enterprise tokens on Web, Android, and iOS|https://github.com/Cap-go/capacitor-recaptcha/|reCAPTCHA
 @capgo/capacitor-audiosession|github.com/Cap-go|Configure iOS audio session for background playback, mixing, and routing control|https://github.com/Cap-go/capacitor-audiosession/|Audio Session
 @capgo/capacitor-background-geolocation|github.com/Cap-go|Accurate background location tracking with native iOS and Android geofencing plus transition webhooks|https://github.com/Cap-go/capacitor-background-geolocation/|Background Geolocation
 @capgo/capacitor-background-task|github.com/Cap-go|Schedule periodic background fetch tasks on iOS and Android with Expo-style task registration|https://github.com/Cap-go/capacitor-background-task/|Background Task
@@ -194,6 +195,7 @@ const pluginIconsByName: Record<string, string> = {
   '@capgo/capacitor-android-sms-retriever': 'ChatBubbleLeft',
   '@capgo/capacitor-appinsights': 'ChartBar',
   '@capgo/capacitor-app-attest': 'ShieldCheck',
+  '@capgo/capacitor-recaptcha': 'ShieldCheck',
   '@capgo/capacitor-audiosession': 'SpeakerWave',
   '@capgo/capacitor-background-geolocation': 'MapPin',
   '@capgo/capacitor-background-task': 'Clock',

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-recaptcha.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-recaptcha.md
@@ -1,0 +1,52 @@
+---
+locale: en
+---
+# Using @capgo/capacitor-recaptcha
+
+Generate reCAPTCHA and reCAPTCHA Enterprise tokens from Web, Android, and iOS Capacitor apps.
+
+## Install
+
+```bash
+npm install @capgo/capacitor-recaptcha
+npx cap sync
+```
+
+## Configure
+
+```typescript
+import type { CapacitorConfig } from '@capacitor/cli';
+import '@capgo/capacitor-recaptcha';
+
+const config: CapacitorConfig = {
+  plugins: {
+    Recaptcha: {
+      androidSiteKey: 'ANDROID_SITE_KEY',
+      iosSiteKey: 'IOS_SITE_KEY',
+      webSiteKey: 'WEB_SITE_KEY',
+      enterprise: true,
+    },
+  },
+};
+
+export default config;
+```
+
+Use `enterprise: false` only when the Web implementation should load standard reCAPTCHA v3 instead of reCAPTCHA Enterprise.
+
+## Generate A Token
+
+```typescript
+import { Recaptcha } from '@capgo/capacitor-recaptcha';
+
+const { token } = await Recaptcha.execute({
+  action: 'login',
+});
+```
+
+Send the token to your backend and create a reCAPTCHA assessment before accepting the protected request.
+
+## Full Reference
+
+- GitHub: https://github.com/Cap-go/capacitor-recaptcha/
+- Docs: /docs/plugins/recaptcha/

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-recaptcha.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-recaptcha.md
@@ -32,7 +32,7 @@ const config: CapacitorConfig = {
 export default config;
 ```
 
-Use `enterprise: false` only when the Web implementation should load standard reCAPTCHA v3 instead of reCAPTCHA Enterprise.
+Use `enterprise: false` only when the Web implementation should load standard reCAPTCHA v3 instead of reCAPTCHA Enterprise. Android and iOS use Google's Enterprise/mobile SDK path and reject `enterprise: false`.
 
 ## Generate A Token
 


### PR DESCRIPTION
## Summary
- add @capgo/capacitor-recaptcha to the plugin registry
- add docs pages for overview, getting started, iOS setup, and Android setup
- add the plugin tutorial entry and refresh stars/download metadata

## Validation
- NODE_OPTIONS=--max-old-space-size=16384 bun run check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the Capacitor reCAPTCHA plugin including getting started guide and platform-specific setup instructions for Android, iOS, and Web
  * Included setup examples and token generation workflows
  * Added tutorial content to help users integrate the plugin
  * Plugin now available in the plugins directory

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/677)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->