### PR TITLE
[codex] Document native purchases commitment billing

### DIFF
--- a/apps/docs/src/config/sidebar.mjs
+++ b/apps/docs/src/config/sidebar.mjs
@@ -148,6 +148,7 @@ const pluginEntries = [
         linkItem('Sandbox Testing', '/docs/plugins/native-purchases/ios-sandbox-testing'),
         linkItem('Subscription Groups', '/docs/plugins/native-purchases/ios-subscription-group'),
         linkItem('Create Subscription', '/docs/plugins/native-purchases/ios-create-subscription'),
+        linkItem('Monthly Commitment Plans', '/docs/plugins/native-purchases/ios-monthly-commitment'),
         linkItem('Introductory Offers', '/docs/plugins/native-purchases/ios-introductory-offer'),
         linkItem('App Store Review', '/docs/plugins/native-purchases/ios-app-store-review'),
       ]),

--- a/apps/docs/src/content/docs/docs/plugins/native-purchases/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-purchases/getting-started.mdx
@@ -65,6 +65,10 @@ import { PackageManagers } from 'starlight-package-managers'
    await NativePurchases.restorePurchases();
    ```
 
+   :::tip[iOS monthly commitment plans]
+   If a supported iOS subscription returns `pricingTerms`, you can show a monthly billing option with a 12-month commitment and pass `billingPlanType: 'monthly'` to `purchaseProduct()`. See [iOS monthly commitment billing plans](/docs/plugins/native-purchases/ios-monthly-commitment/) for the full flow.
+   :::
+
    <Tabs>
      <TabItem label="iOS">
        - Create in-app products and subscriptions in App Store Connect.<br />
@@ -183,6 +187,7 @@ class PurchaseService {
 | `productIdentifier` | iOS + Android | SKU/Product ID configured in App Store Connect / Google Play Console. |
 | `productType` | Android only | `PURCHASE_TYPE.INAPP` or `PURCHASE_TYPE.SUBS`. Defaults to `INAPP`. Always set to `SUBS` for subscriptions. |
 | `planIdentifier` | Android subscriptions | Base Plan ID from Google Play Console. Required for subscriptions, ignored on iOS and in-app purchases. |
+| `billingPlanType` | iOS subscriptions | StoreKit billing plan to purchase. Use `'monthly'` for monthly billing with a 12-month commitment when `product.pricingTerms` exposes that option. |
 | `quantity` | iOS | Only for in-app purchases, defaults to `1`. Android always purchases one item. |
 | `appAccountToken` | iOS + Android | UUID/string linking the purchase to your user. Required to be UUID on iOS; Android accepts any obfuscated string up to 64 chars. |
 | `isConsumable` | Android | Set to `true` to auto-consume tokens after granting entitlement for consumables. Defaults to `false`. |
@@ -220,8 +225,8 @@ purchases.forEach((purchase) => {
 ## API quick reference
 
 - `isBillingSupported()` – check for StoreKit / Google Play availability.
-- `getProduct()` / `getProducts()` – fetch price, localized title, description, intro offers.
-- `purchaseProduct()` – initiate StoreKit 2 or Billing client purchase flow.
+- `getProduct()` / `getProducts()` – fetch price, localized title, description, intro offers, and supported iOS pricing terms.
+- `purchaseProduct()` – initiate StoreKit 2 or Billing client purchase flow, including iOS monthly commitment billing plans.
 - `restorePurchases()` – replay historical purchases and sync to current device.
 - `getPurchases()` – list all iOS transactions or Play Billing purchases.
 - `manageSubscriptions()` – open the native subscription management UI.

--- a/apps/docs/src/content/docs/docs/plugins/native-purchases/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-purchases/index.mdx
@@ -26,10 +26,11 @@ In-app Subscriptions Made Easy.
 
 ## Core Capabilities
 
-- `restorePurchases` - Restores a user's previous and links their appUserIDs to any user's also using those .
-- `getAppTransaction` - Gets the App Transaction information, which provides details about when the user originally downloaded or purchased the app.
-- `isEntitledToOldBusinessModel` - Compares the original app version from the App Transaction against a target version to determine if the user is entitled to features from an earlier business model.
-- `purchaseProduct` - Started purchase process for the given product.
+- Native in-app purchases and subscriptions with StoreKit 2 and Google Play Billing.
+- Product metadata loaded directly from the stores, including localized titles and prices.
+- iOS StoreKit pricing terms for monthly subscriptions with 12-month commitments.
+- Purchase, restore, entitlement refresh, and native subscription management flows.
+- App Transaction helpers for migration from older business models.
 
 ## Public API
 
@@ -38,8 +39,8 @@ In-app Subscriptions Made Easy.
 | `restorePurchases` | Restores a user's previous and links their appUserIDs to any user's also using those . |
 | `getAppTransaction` | Gets the App Transaction information, which provides details about when the user originally downloaded or purchased the app. |
 | `isEntitledToOldBusinessModel` | Compares the original app version from the App Transaction against a target version to determine if the user is entitled to features from an earlier business model. |
-| `purchaseProduct` | Started purchase process for the given product. |
-| `getProducts` | Gets the product info associated with a list of product identifiers. |
+| `purchaseProduct` | Starts the native purchase flow. On supported iOS versions, pass `billingPlanType: 'monthly'` to purchase a monthly billing plan with a 12-month commitment. |
+| `getProducts` | Gets product info associated with product identifiers. On supported iOS versions, subscription products can include `pricingTerms`. |
 | `getProduct` | Gets the product info for a single product identifier. |
 | `isBillingSupported` | Check if billing is supported for the current device. |
 | `getPluginVersion` | Get the native Capacitor plugin version. |

--- a/apps/docs/src/content/docs/docs/plugins/native-purchases/ios-create-subscription.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-purchases/ios-create-subscription.mdx
@@ -209,6 +209,33 @@ if (premium?.isActive) {
 }
 ```
 
+## Monthly with 12-Month Commitment Plans
+
+If your App Store Connect subscription is configured with a monthly billing plan and 12-month commitment, StoreKit can return additional pricing terms for that product. Use those terms to show the monthly charge, total commitment price, and full commitment period before purchase.
+
+```typescript
+const yearlyProduct = products.find(
+  (product) => product.identifier === 'com.yourcompany.yourapp.premium_annual',
+);
+
+const monthlyCommitment = yearlyProduct?.pricingTerms?.find(
+  (term) => term.billingPlanType === 'monthly',
+);
+
+if (yearlyProduct && monthlyCommitment) {
+  console.log('Monthly charge:', monthlyCommitment.billingDisplayPrice);
+  console.log('Total commitment:', monthlyCommitment.commitmentInfo?.priceString);
+
+  await NativePurchases.purchaseProduct({
+    productIdentifier: yearlyProduct.identifier,
+    productType: PURCHASE_TYPE.SUBS,
+    billingPlanType: 'monthly',
+  });
+}
+```
+
+For the full paywall and entitlement flow, see [iOS monthly commitment billing plans](/docs/plugins/native-purchases/ios-monthly-commitment/).
+
 ## Best Practices
 
 ### Pricing Strategy
@@ -302,6 +329,7 @@ Free App + Premium Subscription
 ## Next Steps
 
 - [Create an introductory offer](/docs/plugins/native-purchases/ios-introductory-offer/) to attract new subscribers
+- [Merchandise monthly commitment billing plans](/docs/plugins/native-purchases/ios-monthly-commitment/) for supported annual subscription offers
 - [Configure sandbox testing](/docs/plugins/native-purchases/ios-sandbox-testing/) to test your subscriptions
 - Set up promotional offers for win-back and retention
 - Implement subscription analytics tracking

--- a/apps/docs/src/content/docs/docs/plugins/native-purchases/ios-monthly-commitment.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-purchases/ios-monthly-commitment.mdx
@@ -1,0 +1,127 @@
+---
+title: iOS Monthly Commitment Billing Plans
+description: Learn how to merchandise and purchase StoreKit monthly subscriptions with a 12-month commitment using @capgo/native-purchases.
+sidebar:
+  order: 9
+---
+
+Apple supports subscriptions that bill monthly while committing the customer to a longer 12-month term. When StoreKit and the running OS support this billing plan, `@capgo/native-purchases` exposes the pricing terms, lets you select the monthly billing plan during purchase, and returns commitment metadata on transactions and renewal info.
+
+Use this for annual subscription offers where users prefer monthly payments but you still want the retention and predictability of a committed annual term.
+
+## Requirements
+
+- Configure the monthly with 12-month commitment billing plan in App Store Connect or in StoreKit Testing in Xcode.
+- Build the iOS app with an Xcode SDK that contains StoreKit `pricingTerms` and `billingPlanType`.
+- Run on an iOS version that supports StoreKit commitment billing plans.
+- Keep a standard billing option available for devices or storefronts that do not return commitment pricing terms.
+
+:::note
+The JavaScript API is safe to call on all platforms. Unsupported platforms simply will not return `pricingTerms`, and Android ignores `billingPlanType`.
+:::
+
+## Load and Display Pricing Terms
+
+Call `getProducts()` as usual. For supported iOS subscription products, each product can include `pricingTerms`.
+
+```typescript
+import { NativePurchases, PURCHASE_TYPE } from '@capgo/native-purchases';
+
+const { products } = await NativePurchases.getProducts({
+  productIdentifiers: ['com.example.app.premium.yearly'],
+  productType: PURCHASE_TYPE.SUBS,
+});
+
+const premiumYearly = products.find(
+  (product) => product.identifier === 'com.example.app.premium.yearly',
+);
+const monthlyCommitment = premiumYearly?.pricingTerms?.find(
+  (term) => term.billingPlanType === 'monthly',
+);
+```
+
+Render the store-provided values instead of hardcoded pricing:
+
+| Field | Use it for |
+| --- | --- |
+| `billingDisplayPrice` | The recurring billing amount shown to the user, for example the monthly charge. |
+| `billingPeriod` | The billing cadence for the displayed billing price. |
+| `commitmentInfo.priceString` | The total commitment price formatted for the user's storefront. |
+| `commitmentInfo.period` | The full commitment period. |
+| `subscriptionOffers` | Introductory or promotional offers attached to the pricing term. |
+
+Example paywall copy:
+
+```typescript
+function commitmentLabel(term: NonNullable<typeof monthlyCommitment>) {
+  const total = term.commitmentInfo?.priceString;
+  return total
+    ? `${term.billingDisplayPrice} billed monthly, ${total} total commitment`
+    : term.billingDisplayPrice;
+}
+```
+
+## Purchase the Monthly Commitment Plan
+
+When the user selects the monthly commitment plan, pass `billingPlanType: 'monthly'`.
+
+```typescript
+const transaction = await NativePurchases.purchaseProduct({
+  productIdentifier: 'com.example.app.premium.yearly',
+  productType: PURCHASE_TYPE.SUBS,
+  billingPlanType: 'monthly',
+  appAccountToken: userStoreUuid,
+});
+```
+
+Use `billingPlanType: 'upFront'` only when you need to explicitly select the standard up-front billing plan. If you omit `billingPlanType`, StoreKit uses its default purchase behavior for the product.
+
+:::tip
+Keep your paywall state tied to the pricing term the user tapped. If `pricingTerms` is missing, hide the commitment option and show the regular subscription purchase button.
+:::
+
+## Read Commitment Metadata
+
+Transactions include the billing plan and commitment progress when StoreKit provides it:
+
+```typescript
+if (transaction.billingPlanType === 'monthly') {
+  console.log('Current billing period:', transaction.commitmentInfo?.billingPeriodNumber);
+  console.log('Total billing periods:', transaction.commitmentInfo?.totalBillingPeriods);
+  console.log('Commitment ends:', transaction.commitmentInfo?.expirationDate);
+  console.log('Commitment total:', transaction.commitmentInfo?.price);
+}
+```
+
+Renewal info can include the next commitment state:
+
+```typescript
+const { purchases } = await NativePurchases.getPurchases({
+  productType: PURCHASE_TYPE.SUBS,
+  onlyCurrentEntitlements: true,
+});
+
+for (const purchase of purchases) {
+  const commitment = purchase.renewalInfo?.commitmentInfo;
+  if (!commitment) continue;
+
+  console.log('Renews into another commitment:', commitment.willAutoRenew);
+  console.log('Next billing plan:', commitment.renewalBillingPlanType);
+  console.log('Next renewal date:', commitment.renewalDate);
+}
+```
+
+Use the top-level `expirationDate` and `isActive` fields for entitlement decisions. Use `commitmentInfo.expirationDate` to explain the full commitment timeline to the customer.
+
+## App Store Review Notes
+
+- Show both the recurring billing price and the total commitment price before purchase.
+- Make the commitment length explicit near the purchase button.
+- Use `product.title`, `product.priceString`, `pricingTerms[].billingDisplayPrice`, and `pricingTerms[].commitmentInfo.priceString` from StoreKit instead of hardcoded prices.
+- Provide restore purchases and manage subscription actions on the paywall or account screen.
+
+## Related Guides
+
+- [Create iOS subscriptions](/docs/plugins/native-purchases/ios-create-subscription/)
+- [Configure iOS sandbox testing](/docs/plugins/native-purchases/ios-sandbox-testing/)
+- [iOS App Store review guidelines](/docs/plugins/native-purchases/ios-app-store-review/)

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -45,7 +45,7 @@ const actionDefinitionRows =
 @capgo/capacitor-navigation-bar|github.com/Cap-go|Customize Android navigation bar color and visibility for immersive UI experiences|https://github.com/Cap-go/capacitor-navigation-bar/|Navigation Bar
 @capgo/ivs-player|github.com/Cap-go|Stream ultra-low latency live video using Amazon Interactive Video Service (IVS)|https://github.com/Cap-go/capacitor-ivs-player/|IVS Player
 @capgo/home-indicator|github.com/Cap-go|Hide or show iOS home indicator for fullscreen and immersive app experiences|https://github.com/Cap-go/capacitor-home-indicator/|Indicator
-@capgo/native-purchases|github.com/Cap-go|Implement native in-app purchases and subscriptions for iOS and Android with simple API|https://github.com/Cap-go/capacitor-native-purchases/|Native Purchases
+@capgo/native-purchases|github.com/Cap-go|Implement native in-app purchases, subscriptions, and iOS StoreKit commitment billing plans with a simple API|https://github.com/Cap-go/capacitor-native-purchases/|Native Purchases
 @capgo/capacitor-data-storage-sqlite|github.com/Cap-go|Store data locally using SQLite database with simple key-value API and encryption support|https://github.com/Cap-go/capacitor-data-storage-sqlite/|Data Storage
 @capgo/capacitor-android-usagestatsmanager|github.com/Cap-go|Access Android usage statistics to track app usage time and screen time analytics|https://github.com/Cap-go/capacitor-android-usagestatsmanager/|Usage Stats Manager
 @capgo/capacitor-streamcall|github.com/Cap-go|Integrate video calling and live streaming with Stream SDK for real-time communication|https://github.com/Cap-go/capacitor-streamcall/|Streamcall

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-native-purchases.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-native-purchases.md
@@ -17,7 +17,8 @@ bunx cap sync
 - `restorePurchases` - Restores a user's previous and links their appUserIDs to any user's also using those .
 - `getAppTransaction` - Gets the App Transaction information, which provides details about when the user originally downloaded or purchased the app.
 - `isEntitledToOldBusinessModel` - Compares the original app version from the App Transaction against a target version to determine if the user is entitled to features from an earlier business model.
-- `purchaseProduct` - Started purchase process for the given product.
+- `getProducts` - Loads store product metadata, including supported iOS subscription pricing terms.
+- `purchaseProduct` - Starts the purchase process for the selected product and billing plan.
 
 ## Example Usage
 
@@ -68,23 +69,54 @@ if (result.isOlderVersion) {
 
 ### `purchaseProduct`
 
-Started purchase process for the given product.
+Start the purchase process for the given product. For Android subscriptions, pass the Google Play base plan ID as `planIdentifier`. For supported iOS subscriptions that offer monthly billing with a 12-month commitment, pass `billingPlanType: 'monthly'`.
 
 ```typescript
-import { NativePurchases } from '@capgo/native-purchases';
+import { NativePurchases, PURCHASE_TYPE } from '@capgo/native-purchases';
 
-await NativePurchases.purchaseProduct({} as {
-    productIdentifier: string;
-    planIdentifier?: string;
-    productType?: PURCHASE_TYPE;
-    quantity?: number;
-    appAccountToken?: string;
-    isConsumable?: boolean;
-    autoAcknowledgePurchases?: boolean;
+await NativePurchases.purchaseProduct({
+  productIdentifier: 'com.example.premium.monthly',
+  planIdentifier: 'monthly-plan',
+  productType: PURCHASE_TYPE.SUBS,
+});
+```
+
+### iOS monthly commitment subscriptions
+
+On supported iOS versions, StoreKit can expose a monthly billing plan with a 12-month commitment through `pricingTerms`. Show these terms on your paywall before purchase:
+
+```typescript
+import { NativePurchases, PURCHASE_TYPE } from '@capgo/native-purchases';
+
+const { products } = await NativePurchases.getProducts({
+  productIdentifiers: ['com.example.premium.yearly'],
+  productType: PURCHASE_TYPE.SUBS,
+});
+
+const yearlyProduct = products.find(
+  (product) => product.identifier === 'com.example.premium.yearly',
+);
+const monthlyCommitment = yearlyProduct?.pricingTerms?.find(
+  (term) => term.billingPlanType === 'monthly',
+);
+
+if (yearlyProduct && monthlyCommitment) {
+  console.log('Monthly price:', monthlyCommitment.billingDisplayPrice);
+  console.log('Total commitment:', monthlyCommitment.commitmentInfo?.priceString);
+
+  const transaction = await NativePurchases.purchaseProduct({
+    productIdentifier: yearlyProduct.identifier,
+    productType: PURCHASE_TYPE.SUBS,
+    billingPlanType: 'monthly',
   });
+
+  console.log('Billing plan:', transaction.billingPlanType);
+  console.log('Commitment ends:', transaction.commitmentInfo?.expirationDate);
+}
 ```
 
 ## Full Reference
 
 - GitHub: https://github.com/Cap-go/capacitor-native-purchases/
 - Docs: /docs/plugins/native-purchases/
+- iOS monthly commitment guide: /docs/plugins/native-purchases/ios-monthly-commitment/


### PR DESCRIPTION
## What
- Adds a dedicated Native Purchases iOS monthly commitment billing guide.
- Links the guide from the Native Purchases docs and iOS subscription setup.
- Updates the plugin tutorial and website plugin description for StoreKit commitment billing plans.

## Why
- The native-purchases plugin now supports reading StoreKit pricing terms, purchasing monthly commitment plans, and reading commitment metadata, but the website docs/tutorials did not explain the workflow.

## How
- Added a new Starlight docs page for pricing terms, billingPlanType, transaction commitmentInfo, and renewal commitment metadata.
- Updated existing Native Purchases docs to link and summarize the feature.
- Updated the English plugin tutorial with a practical code sample.

## Testing
- `bun run check`
- `bun run build`

## Not Tested
- No live App Store Connect purchase flow; docs-only website change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for iOS StoreKit monthly subscription commitment plans, including pricing details and code examples
  * Updated native-purchases API documentation to clarify `billingPlanType: 'monthly'` option for iOS subscriptions
  * Added new navigation link and enhanced plugin descriptions for monthly commitment billing capabilities
  * Expanded pricing terms documentation for iOS products

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/681)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->