### PR TITLE
Add Outrank webhook import flow

### DIFF
--- a/.github/workflows/deploy-outrank-worker.yml
+++ b/.github/workflows/deploy-outrank-worker.yml
@@ -41,7 +41,26 @@ jobs:
 
       - run: bun install --frozen-lockfile
       - run: bun run ci:verify:outrank
-      - run: bun run deploy:outrank
+
+      - name: Write Worker secrets
+        env:
+          OUTRANK_ACCESS_TOKEN: ${{ secrets.OUTRANK_ACCESS_TOKEN }}
+          OUTRANK_SECRETS_FILE: ${{ runner.temp }}/outrank-worker-secrets.json
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: |
+          bun --eval 'const secrets = {
+            OUTRANK_ACCESS_TOKEN: process.env.OUTRANK_ACCESS_TOKEN,
+            PERSONAL_ACCESS_TOKEN: process.env.PERSONAL_ACCESS_TOKEN,
+          }
+
+          for (const [key, value] of Object.entries(secrets)) {
+            if (!value) throw new Error(`${key} is required`)
+          }
+
+          await Bun.write(process.env.OUTRANK_SECRETS_FILE, JSON.stringify(secrets))'
+
+      - run: cd apps/outrank-worker && bunx wrangler deploy --secrets-file "$OUTRANK_SECRETS_FILE"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          OUTRANK_SECRETS_FILE: ${{ runner.temp }}/outrank-worker-secrets.json

--- a/apps/outrank-worker/src/index.ts
+++ b/apps/outrank-worker/src/index.ts
@@ -1,6 +1,6 @@
 interface Env {
   OUTRANK_ACCESS_TOKEN?: string
-  GITHUB_DISPATCH_TOKEN?: string
+  PERSONAL_ACCESS_TOKEN?: string
   GITHUB_OWNER: string
   GITHUB_REPO: string
   GITHUB_EVENT_TYPE?: string
@@ -102,7 +102,7 @@ async function parsePayload(request: Request): Promise<OutrankPayload | undefine
 }
 
 async function dispatchToGithub(env: Env, payload: OutrankPayload): Promise<Response> {
-  if (!env.GITHUB_DISPATCH_TOKEN) return jsonResponse({ error: 'missing_github_dispatch_token' }, 500)
+  if (!env.PERSONAL_ACCESS_TOKEN) return jsonResponse({ error: 'missing_personal_access_token' }, 500)
 
   const dispatchBody = JSON.stringify({
     event_type: env.GITHUB_EVENT_TYPE || DEFAULT_GITHUB_EVENT_TYPE,
@@ -118,7 +118,7 @@ async function dispatchToGithub(env: Env, payload: OutrankPayload): Promise<Resp
       method: 'POST',
       headers: {
         accept: 'application/vnd.github+json',
-        authorization: `Bearer ${env.GITHUB_DISPATCH_TOKEN}`,
+        authorization: `Bearer ${env.PERSONAL_ACCESS_TOKEN}`,
         'content-type': 'application/json',
         'user-agent': 'capgo-outrank-webhook',
         'x-github-api-version': '2022-11-28',


### PR DESCRIPTION
## Summary
- add a Cloudflare Worker webhook receiver for Outrank publish events
- use the existing `PERSONAL_ACCESS_TOKEN` binding for GitHub repository dispatch
- trigger a GitHub Actions import flow through repository_dispatch
- convert Outrank articles into existing Astro blog Markdown and open an import PR
- add CI and deploy workflow coverage for the Outrank Worker

## Validation
- bun install --frozen-lockfile
- bun run ci:verify:outrank
- bun run check
- Worker smoke test for valid and invalid Bearer tokens
- importer smoke test for repository_dispatch payload conversion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration for improved secrets management
  * Updated authentication mechanism for GitHub integration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/690)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->