### PR TITLE
Polish plugin directory UI

### DIFF
--- a/apps/shared/copy/messages.ts
+++ b/apps/shared/copy/messages.ts
@@ -583,6 +583,7 @@ const messages = {
   centralized_management: 'Centralized Management',
   channel_management: 'Channel management',
   chat: 'Chat',
+  choose_an_order: 'Choose an order',
   choose_from_your_capgo_projects: 'Choose from your Capgo projects',
   ci_cd_integration: 'Mobile CI/CD',
   cities_worldwide: 'Cities worldwide',
@@ -2482,6 +2483,8 @@ const messages = {
   security_reporting_guidelines_1: 'Submit your findings through our GitHub Security Advisory:',
   security_reporting_guidelines_2: 'Do provide sufficient information to reproduce the problem, so we will be able to resolve it as quickly as possible.',
   security_reporting_guidelines_title: 'Reporting guidelines:',
+  search_plugins_by_name_or_description: 'Search plugins by name or description',
+  search_plugins_by_name_or_description_placeholder: 'Search plugins by name or description...',
   security_testing_guidelines_1:
     "Do not run automated scanners on other customer projects. Running automated scanners can run up costs for our users. Aggressively configured scanners might inadvertently disrupt services, exploit vulnerabilities, lead to system instability or breaches and violate Terms of Service from our upstream providers. Our own security systems won't be able to distinguish hostile reconnaissance from whitehat research. If you wish to run an automated scanner, notify us at security@capgo.app and only run it on your own Capgo project. Do NOT attack projects of other customers.",
   security_testing_guidelines_2:
@@ -3681,6 +3684,8 @@ const messages = {
   somebody_developed_an_app_for_you_but_it_doesn_t_meet_your_expectations_and_the_quality_of_the_final_product_is_really_low:
     "Somebody developed an app for you but it doesn't meet your expectations and the quality of the final product is really low.",
   something_doesn_t_work_but_you_don_t_know_why: "Something doesn't work but you don't know why",
+  sort_by_prefix: 'Sort:',
+  sort_plugins_by: 'Sort plugins by',
   source_code_protection_1: "As an open source project, Capgo's code is publicly available on",
   source_code_protection_2: 'The code is continuously audited by: ',
   source_code_protection_3: ', with critical issues blocked from production.',

--- a/apps/web/src/pages/plugins.astro
+++ b/apps/web/src/pages/plugins.astro
@@ -214,7 +214,7 @@ const content = {
             >
               <span class="flex min-w-0 items-center gap-2">
                 <span class="shrink-0 text-gray-400">{m.sort_by_prefix({}, { locale })}</span>
-                <span id="plugin-sort-current-label" class="block truncate font-semibold text-white">
+                <span id="plugin-sort-current-label" class="block truncate font-semibold text-white" aria-live="polite" aria-atomic="true">
                   {defaultSortOption.label}
                 </span>
               </span>
@@ -350,9 +350,9 @@ const content = {
           {plugins.length}+ {m.plugins({}, { locale: Astro.locals.locale })} available
         </div>
 
-        <h1 class="font-pj pb-6 text-5xl font-bold text-white md:text-7xl">
+        <h2 class="font-pj pb-6 text-5xl font-bold text-white md:text-7xl">
           {m.supercharge_your_app({}, { locale: Astro.locals.locale })}
-        </h1>
+        </h2>
 
         <p class="mx-auto mb-12 max-w-3xl text-xl leading-relaxed text-gray-300 md:text-2xl">
           {m.powerful_app_plugins_description({}, { locale: Astro.locals.locale })}

--- a/apps/web/src/pages/plugins.astro
+++ b/apps/web/src/pages/plugins.astro
@@ -145,7 +145,7 @@ const content = {
 <Layout content={content}>
   <div class="relative min-h-screen">
     <!-- Plugins Directory -->
-    <section class="px-6 py-12 lg:px-8 lg:py-16">
+    <section class="px-6 pt-12 pb-8 lg:px-8 lg:pt-16 lg:pb-8">
       <div class="mx-auto max-w-7xl">
         <div class="mb-12">
           <div class="mb-6 inline-flex items-center rounded-full border border-gray-600/40 bg-gray-800/40 px-4 py-2 text-sm font-medium text-gray-200">
@@ -158,12 +158,12 @@ const content = {
           </h1>
           <p class="mt-4 max-w-2xl text-gray-300">{m.plugins_directory_description({}, { locale })}</p>
         </div>
-        <div class="mb-8 grid grid-cols-1 gap-4 text-sm text-gray-300 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-gray-800 bg-gray-800/80 text-gray-300 sm:grid-cols-3 lg:grid-cols-6">
           {
             directoryStats.map((stat) => (
-              <div class="flex min-h-14 items-center justify-between gap-4 rounded-xl border border-gray-700 bg-gray-900/40 px-4 py-3">
-                <span class="min-w-0 text-gray-400">{stat.label}</span>
-                <span class="shrink-0 font-semibold text-white">{stat.value}</span>
+              <div class="min-h-24 bg-gray-950/70 px-4 py-4">
+                <span class="block text-2xl font-semibold text-white tabular-nums">{stat.value}</span>
+                <span class="mt-1 block text-sm leading-snug text-gray-400">{stat.label}</span>
               </div>
             ))
           }
@@ -172,9 +172,9 @@ const content = {
     </section>
 
     <!-- Plugins Grid -->
-    <section id="plugins" class="py-20">
+    <section id="plugins" class="pt-4 pb-20">
       <div class="mx-auto max-w-7xl px-6 lg:px-8">
-        <div class="mb-16 text-center">
+        <div class="mb-10 text-center">
           <h2 class="font-pj mb-6 text-4xl font-bold text-white">{m.browse_plugin_library({}, { locale: Astro.locals.locale })}</h2>
           <p class="mx-auto max-w-2xl text-xl text-gray-300">
             {m.discover_ready_plugins({}, { locale: Astro.locals.locale })}
@@ -182,14 +182,14 @@ const content = {
         </div>
 
         <!-- Search and Sort Controls -->
-        <div class="mx-auto mb-8 flex max-w-3xl flex-col items-center justify-center gap-4 sm:flex-row">
+        <div class="mx-auto mb-8 flex max-w-4xl flex-col gap-3 sm:flex-row sm:items-center">
           <div class="relative w-full flex-1">
             <input
               type="text"
               id="plugin-search"
-              aria-label="Search plugins by name or description"
-              placeholder="Search plugins by name or description..."
-              class="w-full rounded-xl border border-gray-700 bg-white/5 px-6 py-4 text-white placeholder-gray-400 backdrop-blur-sm transition-all duration-200 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 focus:outline-none"
+              aria-label={m.search_plugins_by_name_or_description({}, { locale })}
+              placeholder={m.search_plugins_by_name_or_description_placeholder({}, { locale })}
+              class="h-12 w-full rounded-lg border border-gray-700/80 bg-gray-950/60 pr-11 pl-4 text-base text-white placeholder-gray-500 transition-colors duration-200 focus:border-blue-400 focus:ring-2 focus:ring-blue-400/20 focus:outline-none"
             />
             <svg
               aria-hidden="true"
@@ -201,27 +201,27 @@ const content = {
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
             </svg>
           </div>
-          <div id="plugin-sort-dropdown" class="relative w-full sm:w-auto">
+          <div id="plugin-sort-dropdown" class="relative w-full sm:w-60">
             <button
               type="button"
               id="plugin-sort-button"
               aria-haspopup="true"
               aria-expanded="false"
               aria-controls="plugin-sort-menu"
-              aria-label="Sort plugins by"
+              aria-label={m.sort_plugins_by({}, { locale })}
               data-sort-value={defaultSortOption.value}
-              class="group flex w-full items-center justify-between gap-4 rounded-2xl border border-blue-400/30 bg-linear-to-b from-[#111827] to-[#0f172a] px-5 py-4 text-left shadow-[0_18px_40px_rgba(15,23,42,0.35)] transition-all duration-200 hover:border-blue-300/50 hover:shadow-[0_20px_50px_rgba(37,99,235,0.18)] focus-visible:border-blue-300 focus-visible:ring-2 focus-visible:ring-blue-400/30 focus-visible:outline-none sm:w-72"
+              class="group flex h-12 w-full items-center justify-between gap-3 rounded-lg border border-gray-700/80 bg-gray-950/70 px-4 text-left text-sm text-white transition-colors duration-200 hover:border-blue-400/50 hover:bg-gray-900/80 focus-visible:border-blue-300 focus-visible:ring-2 focus-visible:ring-blue-400/30 focus-visible:outline-none"
             >
-              <span class="min-w-0">
-                <span class="block text-[11px] font-semibold tracking-[0.28em] text-blue-200/70 uppercase">Sort plugins</span>
-                <span id="plugin-sort-current-label" class="mt-1 block truncate text-base font-semibold text-white sm:text-lg">
+              <span class="flex min-w-0 items-center gap-2">
+                <span class="shrink-0 text-gray-400">{m.sort_by_prefix({}, { locale })}</span>
+                <span id="plugin-sort-current-label" class="block truncate font-semibold text-white">
                   {defaultSortOption.label}
                 </span>
               </span>
               <span
-                class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 text-slate-300 transition-colors duration-200 group-hover:border-blue-300/30 group-hover:text-white"
+                class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-white/10 bg-white/5 text-slate-300 transition-colors duration-200 group-hover:border-blue-300/30 group-hover:text-white"
               >
-                <svg id="plugin-sort-chevron" aria-hidden="true" class="h-5 w-5 transition-transform duration-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg id="plugin-sort-chevron" aria-hidden="true" class="h-4 w-4 transition-transform duration-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
                 </svg>
               </span>
@@ -229,16 +229,16 @@ const content = {
             <div
               id="plugin-sort-menu"
               aria-hidden="true"
-              class="pointer-events-none invisible absolute inset-x-0 top-[calc(100%+0.75rem)] z-40 translate-y-2 rounded-2xl border border-blue-400/20 bg-slate-950/95 p-2 opacity-0 shadow-[0_28px_80px_rgba(2,6,23,0.75)] ring-1 ring-white/10 backdrop-blur-xl transition-all duration-200 sm:left-auto sm:min-w-80"
+              class="pointer-events-none invisible absolute inset-x-0 top-[calc(100%+0.5rem)] z-40 translate-y-2 rounded-lg border border-gray-700 bg-slate-950/95 p-1 opacity-0 shadow-xl ring-1 ring-white/10 backdrop-blur-xl transition-all duration-200 sm:left-auto sm:min-w-64"
             >
-              <div class="px-3 pt-2 pb-1 text-[11px] font-semibold tracking-[0.28em] text-slate-500 uppercase">Choose an order</div>
+              <div class="px-3 py-2 text-xs font-medium text-slate-400">{m.choose_an_order({}, { locale })}</div>
               <div class="mt-1 space-y-1">
                 {
                   sortOptions.map((option) => (
                     <button
                       type="button"
                       class:list={[
-                        'flex w-full items-center justify-between rounded-xl border px-4 py-3 text-left transition-all duration-200 focus-visible:ring-2 focus-visible:ring-blue-400/30 focus-visible:outline-none',
+                        'flex w-full items-center justify-between rounded-md border px-3 py-2.5 text-left transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-blue-400/30 focus-visible:outline-none',
                         option.value === defaultSortOption.value
                           ? 'border-blue-400/40 bg-blue-500/15 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]'
                           : 'border-transparent text-slate-200 hover:border-white/10 hover:bg-white/5 hover:text-white',
@@ -275,7 +275,7 @@ const content = {
           {
             plugins.map((item) => (
               <div
-                class="plugin-card group relative rounded-2xl border border-gray-700 bg-white/5 p-6 backdrop-blur-sm transition-all duration-300 hover:scale-[1.02] hover:border-gray-500/50 hover:bg-white/10"
+                class="plugin-card group relative rounded-lg border border-gray-700/80 bg-gray-950/45 p-5 transition-colors duration-200 hover:border-gray-500/70 hover:bg-gray-900/65"
                 data-title={item.title.toLowerCase()}
                 data-description={item.description.toLowerCase()}
                 data-author={item.author.toLowerCase()}
@@ -283,7 +283,7 @@ const content = {
                 data-stars={item.githubStars ?? 0}
               >
                 <div class="relative">
-                  {item.icon && <PluginIcon icon={item.icon} name={item.title} className="mb-4 transition-transform duration-300 group-hover:scale-110" />}
+                  {item.icon && <PluginIcon icon={item.icon} name={item.title} className="mb-4" />}
                   <h3 class="font-pj mb-3 text-xl font-bold text-white transition-colors duration-300 group-hover:text-gray-200">{item.title}</h3>
                   <div class="mb-4 line-clamp-3 leading-relaxed text-gray-300" set:html={item.description} />
                   <div class="mb-4 flex items-center justify-between">
@@ -486,7 +486,7 @@ const content = {
       let currentSort = sortButton?.dataset.sortValue || 'downloads'
 
       const activeSortClasses = ['border-blue-400/40', 'bg-blue-500/15', 'text-white', 'shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]']
-      const inactiveSortClasses = ['border-transparent', 'text-slate-200']
+      const inactiveSortClasses = ['border-transparent', 'text-slate-200', 'hover:border-white/10', 'hover:bg-white/5', 'hover:text-white']
 
       function isSortMenuOpen() {
         return sortButton?.getAttribute('aria-expanded') === 'true'


### PR DESCRIPTION
## Summary
- Convert plugin directory metrics into a compact stats strip
- Normalize search and sort controls to the same height and cleaner sizing
- Simplify plugin card styling and dropdown states

## Screenshot
![Plugin directory screenshot](https://gist.githubusercontent.com/riderx/4c81efa57f8d76378b4837a49faba2c8/raw/pr-691-plugin-page.svg)

## Tests
- bunx prettier --write apps/web/src/pages/plugins.astro apps/shared/copy/messages.ts
- cd apps/web && bun run check
- bun run check
- Headless Playwright desktop/mobile render checks for /plugins/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new UI text for ordering, plugin search labels/placeholders, and plugin sorting labels.

* **Improvements**
  * Redesigned plugins directory layout and stats display with compact card/grid styling.
  * Restyled plugin cards, updated header/spacing and search input, adjusted sort controls and accessibility labels.
  * Minor heading level and interactive hover behavior refinements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/691)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
