### PR TITLE
[codex] fix hero stat order

### DIFF
--- a/apps/web/src/components/Hero.astro
+++ b/apps/web/src/components/Hero.astro
@@ -298,8 +298,8 @@ const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. $
                 ></path>
               </svg>
               <div class="flex items-center gap-1">
-                <span class="text-gray-400">{m.companies_logo_stat_companies_label({}, { locale: Astro.locals.locale })}</span>
                 <span class="font-semibold text-white">{m.companies_logo_stat_companies_value({}, { locale: Astro.locals.locale })}</span>
+                <span class="text-gray-400">{m.companies_logo_stat_companies_label({}, { locale: Astro.locals.locale })}</span>
               </div>
             </div>
 
@@ -309,8 +309,8 @@ const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. $
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
               </svg>
               <div class="flex items-center gap-1">
-                <span class="text-gray-400">{m.companies_logo_stat_devices_label({}, { locale: Astro.locals.locale })}</span>
                 <span class="font-semibold text-white">{m.companies_logo_stat_devices_value({}, { locale: Astro.locals.locale })}</span>
+                <span class="text-gray-400">{m.companies_logo_stat_devices_label({}, { locale: Astro.locals.locale })}</span>
               </div>
             </div>
 
@@ -320,10 +320,10 @@ const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. $
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
               </svg>
               <div class="flex items-center gap-1">
-                <span class="text-gray-400">{m.companies_logo_stat_uptime_label({}, { locale: Astro.locals.locale })}</span>
                 <a href="https://status.capgo.app" target="_blank" rel="noopener noreferrer" class="font-semibold text-white transition-colors hover:text-blue-400">
                   {m.companies_logo_stat_uptime_value({}, { locale: Astro.locals.locale })}
                 </a>
+                <span class="text-gray-400">{m.companies_logo_stat_uptime_label({}, { locale: Astro.locals.locale })}</span>
               </div>
             </div>
 
@@ -333,8 +333,8 @@ const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. $
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
               </svg>
               <div class="flex items-center gap-1">
-                <span class="text-gray-400">{m.active_users_up_to_date({}, { locale: Astro.locals.locale })}</span>
                 <span class="font-semibold text-white">95%</span>
+                <span class="text-gray-400">{m.active_users_up_to_date({}, { locale: Astro.locals.locale })}</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Fixes the homepage hero stats bar so every metric renders as value first, label second.

## Root cause

The row used the same label-before-value ordering for every metric. That made the update adoption copy read as `of active users receive updates within 24 hours 95%` instead of `95% of active users receive updates within 24 hours`.

## Impact

The hero stats now read correctly:

- `3500+ Companies`
- `50M+ Devices tracked`
- `99.9% Uptime`
- `95% of active users receive updates within 24 hours`

## Validation

- `bunx prettier --write apps/web/src/components/Hero.astro`
- `NODE_OPTIONS=--max-old-space-size=16384 bunx astro check` from `apps/web`
- Headless homepage load at `http://127.0.0.1:3000/` confirmed the rendered stat text order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered Stats Bar elements to display metric values before labels across multiple metrics, including companies, devices, uptime, and update adoption statistics, for improved visual hierarchy and presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/695)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->