### PR TITLE
Update pricing plan features

### DIFF
--- a/apps/shared/copy/messages.ts
+++ b/apps/shared/copy/messages.ts
@@ -1761,6 +1761,7 @@ const messages = {
   mau: 'MAU',
   mau_counting_explanation:
     'We count MAU (Monthly Active Users) by tracking unique users who open your app within a 30-day period. Each user is counted once, regardless of how many times they engage with the app.',
+  mcp_server: 'MCP Server',
   mention_issue_before_working: 'When you work on an issue, mention so in the issue comments <em>before</em> you start working on the issue.',
   migration_guide: 'Migration Guide',
   monitor_adoption_and_performance: 'Monitor adoption and performance metrics',
@@ -2447,6 +2448,7 @@ const messages = {
   seamless_integration_with_your_capgo_account: 'Seamless integration with your Capgo account',
   seamless_third_party_sdk: 'Wrap third-party SDKs in clean Capacitor APIs with TypeScript definitions, documentation, examples, and long-term maintenance.',
   security_and_compliance: 'Security & Compliance',
+  security_questionnaires: 'Security questionnaires',
   security_closing:
     'We strive to resolve all problems as quickly as possible, and we would like to play an active role in the ultimate publication on the problem after it is resolved.',
   security_compliance: 'Security & Compliance',

--- a/apps/web/src/components/pricing/ComparePlans.astro
+++ b/apps/web/src/components/pricing/ComparePlans.astro
@@ -96,7 +96,7 @@ const rows: CompareSection[] = [
         value: () => true,
       },
       {
-        label: 'MCP Server',
+        label: m.mcp_server({}, { locale: Astro.locals.locale }),
         value: () => true,
       },
     ],
@@ -269,7 +269,7 @@ const rows: CompareSection[] = [
         value: (plan: Database['public']['Tables']['plans']['Row']) => plan.name === 'Enterprise',
       },
       {
-        label: 'Security questionnaires',
+        label: m.security_questionnaires({}, { locale: Astro.locals.locale }),
         value: (plan: Database['public']['Tables']['plans']['Row']) => plan.name === 'Enterprise',
       },
     ],

--- a/apps/web/src/components/pricing/ComparePlans.astro
+++ b/apps/web/src/components/pricing/ComparePlans.astro
@@ -95,6 +95,10 @@ const rows: CompareSection[] = [
         label: 'Audit logs',
         value: () => true,
       },
+      {
+        label: 'MCP Server',
+        value: () => true,
+      },
     ],
   },
   {
@@ -262,6 +266,10 @@ const rows: CompareSection[] = [
       },
       {
         label: 'Signed NDAs & DPAs',
+        value: (plan: Database['public']['Tables']['plans']['Row']) => plan.name === 'Enterprise',
+      },
+      {
+        label: 'Security questionnaires',
         value: (plan: Database['public']['Tables']['plans']['Row']) => plan.name === 'Enterprise',
       },
     ],

--- a/apps/web/src/components/pricing/Plans.astro
+++ b/apps/web/src/components/pricing/Plans.astro
@@ -32,7 +32,7 @@ function planHighlights(plan: Database['public']['Tables']['plans']['Row']) {
     `${numberWithSpaces(plan.bandwidth)}${plan.name === 'Enterprise' ? '+' : ''} GiB/${m.month({}, { locale: Astro.locals.locale })} ${m.of_bandwidth({}, { locale: Astro.locals.locale })}`,
     `${numberWithSpaces(plan.storage)}${plan.name === 'Enterprise' ? '+' : ''} GiB storage`,
     m.unlimited_live_updates({}, { locale: Astro.locals.locale }),
-    'MCP Server',
+    m.mcp_server({}, { locale: Astro.locals.locale }),
   ]
 
   if (plan.build_time_unit && plan.build_time_unit > 0) {
@@ -40,7 +40,7 @@ function planHighlights(plan: Database['public']['Tables']['plans']['Row']) {
   }
 
   if (plan.name === 'Enterprise') {
-    highlights.push('Security questionnaires')
+    highlights.push(m.security_questionnaires({}, { locale: Astro.locals.locale }))
   }
 
   return highlights

--- a/apps/web/src/components/pricing/Plans.astro
+++ b/apps/web/src/components/pricing/Plans.astro
@@ -32,10 +32,15 @@ function planHighlights(plan: Database['public']['Tables']['plans']['Row']) {
     `${numberWithSpaces(plan.bandwidth)}${plan.name === 'Enterprise' ? '+' : ''} GiB/${m.month({}, { locale: Astro.locals.locale })} ${m.of_bandwidth({}, { locale: Astro.locals.locale })}`,
     `${numberWithSpaces(plan.storage)}${plan.name === 'Enterprise' ? '+' : ''} GiB storage`,
     m.unlimited_live_updates({}, { locale: Astro.locals.locale }),
+    'MCP Server',
   ]
 
   if (plan.build_time_unit && plan.build_time_unit > 0) {
     highlights.push(`${buildTimeDisplay(plan.build_time_unit)}${plan.name === 'Enterprise' ? '+' : ''}`)
+  }
+
+  if (plan.name === 'Enterprise') {
+    highlights.push('Security questionnaires')
   }
 
   return highlights


### PR DESCRIPTION
## Summary
- Add MCP Server to every pricing plan card and comparison table
- Add Security questionnaires as an Enterprise-only pricing feature

## Test
- NODE_OPTIONS=--max-old-space-size=16384 bunx astro check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP Server is now shown as available across all pricing plans in the plan comparison and plan highlights.
  * Security questionnaires are now listed as a feature only for the Enterprise plan in comparisons and highlights.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/697)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->