### PR TITLE
Show audit log retention in pricing

### DIFF
--- a/apps/web/src/components/pricing/ComparePlans.astro
+++ b/apps/web/src/components/pricing/ComparePlans.astro
@@ -93,7 +93,7 @@ const rows: CompareSection[] = [
       },
       {
         label: 'Audit logs',
-        value: () => true,
+        value: () => '90 days',
       },
       {
         label: m.mcp_server({}, { locale: Astro.locals.locale }),


### PR DESCRIPTION
## Summary
- Change the pricing comparison Audit logs value from an included checkmark to 90 days

## Test
- NODE_OPTIONS=--max-old-space-size=16384 bunx astro check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pricing comparison now displays specific audit logs retention limits (90 days) instead of generic availability indicators for clearer plan differentiation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/698)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->