### PR TITLE
[codex] rename nativegeocoder docs package

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/nativegeocoder/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/nativegeocoder/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: "Install @capgo/nativegeocoder and start using its current Capacitor API."
+description: "Install @capgo/capacitor-nativegeocoder and start using its current Capacitor API."
 sidebar:
   order: 2
 ---
@@ -8,14 +8,14 @@ sidebar:
 ## Install
 
 ```bash
-bun add @capgo/nativegeocoder
-bunx cap sync
+npm install @capgo/capacitor-nativegeocoder
+npx cap sync
 ```
 
 ## Import
 
 ```typescript
-import { NativeGeocoder } from '@capgo/nativegeocoder';
+import { NativeGeocoder } from '@capgo/capacitor-nativegeocoder';
 ```
 
 ## API Overview
@@ -25,7 +25,7 @@ import { NativeGeocoder } from '@capgo/nativegeocoder';
 Convert latitude and longitude to an address
 
 ```typescript
-import { NativeGeocoder } from '@capgo/nativegeocoder';
+import { NativeGeocoder } from '@capgo/capacitor-nativegeocoder';
 
 await NativeGeocoder.reverseGeocode({} as ReverseOptions);
 ```
@@ -35,7 +35,7 @@ await NativeGeocoder.reverseGeocode({} as ReverseOptions);
 Convert an address to latitude and longitude
 
 ```typescript
-import { NativeGeocoder } from '@capgo/nativegeocoder';
+import { NativeGeocoder } from '@capgo/capacitor-nativegeocoder';
 
 await NativeGeocoder.forwardGeocode({} as ForwardOptions);
 ```

--- a/apps/docs/src/content/docs/docs/plugins/nativegeocoder/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/nativegeocoder/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "@capgo/nativegeocoder"
+title: "@capgo/capacitor-nativegeocoder"
 description: "Capacitor plugin for native forward and reverse geocoding."
 tableOfContents: false
 next: false
@@ -23,6 +23,8 @@ hero:
 ## Overview
 
 Capacitor plugin for native forward and reverse geocoding.
+
+<span title="Renamed from @capgo/nativegeocoder to @capgo/capacitor-nativegeocoder so the package name matches the Capacitor plugin repository.">Package name changed.</span>
 
 ## Core Capabilities
 

--- a/apps/web/public/plugins-readme.md
+++ b/apps/web/public/plugins-readme.md
@@ -186,10 +186,10 @@ A collection of high-quality Capacitor plugins maintained by [Capgo](https://cap
 </td>
 <td align="center" width="33%">
 <h3><a href="https://github.com/Cap-go/capacitor-nativegeocoder/">Native Geocoder</a></h3>
-<p><code>@capgo/nativegeocoder</code></p>
+<p><code>@capgo/capacitor-nativegeocoder</code></p>
 <p>Convert addresses to coordinates and coordinates to addresses using native geocoding</p>
 <p>
-<a href="https://www.npmjs.com/package/@capgo/nativegeocoder"><img src="https://img.shields.io/npm/dw/@capgo/nativegeocoder?style=flat-square&label=downloads" alt="npm downloads"></a>
+<a href="https://www.npmjs.com/package/@capgo/capacitor-nativegeocoder"><img src="https://img.shields.io/npm/dw/@capgo/capacitor-nativegeocoder?style=flat-square&label=downloads" alt="npm downloads"></a>
 <a href="https://github.com/Cap-go/capacitor-nativegeocoder/"><img src="https://img.shields.io/github/stars/Cap-go/capacitor-nativegeocoder?style=flat-square&label=stars" alt="GitHub stars"></a>
 </p>
 <p><a href="https://capgo.app/plugins/capacitor-nativegeocoder/">Docs</a> | <a href="https://github.com/Cap-go/capacitor-nativegeocoder/">GitHub</a></p>

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -37,7 +37,7 @@ const actionDefinitionRows =
 @capgo/capacitor-appsflyer|github.com/Cap-go|Add AppsFlyer attribution, analytics, deferred deep links, and OneLink support to your Capacitor app|https://github.com/Cap-go/capacitor-appsflyer/|AppsFlyer
 @capgo/capacitor-contentsquare|github.com/Cap-go|Integrate Contentsquare mobile analytics, consent gating, screen tracking, transactions, and session replay controls in Capacitor|https://github.com/Cap-go/capacitor-contentsquare/|Contentsquare
 @capgo/capacitor-facebook-analytics|github.com/Cap-go|Meta/Facebook App Events analytics with standard events, purchase logging, currency parameters, and advertiser tracking controls|https://github.com/Cap-go/capacitor-facebook-analytics/|Facebook Analytics
-@capgo/nativegeocoder|github.com/Cap-go|Convert addresses to coordinates and coordinates to addresses using native geocoding|https://github.com/Cap-go/capacitor-nativegeocoder/|Native Geocoder
+@capgo/capacitor-nativegeocoder|github.com/Cap-go|Convert addresses to coordinates and coordinates to addresses using native geocoding|https://github.com/Cap-go/capacitor-nativegeocoder/|Native Geocoder
 @capgo/inappbrowser|github.com/Cap-go|Open web pages in a customizable in-app browser without leaving your application|https://github.com/Cap-go/capacitor-inappbrowser/|In App Browser
 @capgo/capacitor-mqtt|github.com/Cap-go|MQTT support for real-time messaging across iOS, Android, and Web.|https://github.com/Cap-go/capacitor-mqtt/|MQTT
 @capgo/capacitor-mute|github.com/Cap-go|Detect device mute switch state for iOS devices to handle audio playback appropriately|https://github.com/Cap-go/capacitor-mute/|Mute
@@ -175,7 +175,7 @@ const pluginIconsByName: Record<string, string> = {
   '@capgo/capacitor-appsflyer': 'ChartBar',
   '@capgo/capacitor-contentsquare': 'ChartBar',
   '@capgo/capacitor-facebook-analytics': 'ChartBar',
-  '@capgo/nativegeocoder': 'MapPin',
+  '@capgo/capacitor-nativegeocoder': 'MapPin',
   '@capgo/inappbrowser': 'GlobeAlt',
   '@capgo/capacitor-mqtt': 'Signal',
   '@capgo/capacitor-mute': 'SpeakerXMark',

--- a/apps/web/src/content/blog/en/setup-stripe-payment-in-us-capacitor.md
+++ b/apps/web/src/content/blog/en/setup-stripe-payment-in-us-capacitor.md
@@ -437,12 +437,12 @@ This approach uses the free `ipapi.co` service to determine the user's country b
 
 ### More Accurate Location Detection with Capacitor Plugins
 
-For more accurate location detection, you can use the Capacitor Geolocation plugin along with @capgo/nativegeocoder to determine the user's country with higher precision:
+For more accurate location detection, you can use the Capacitor Geolocation plugin along with @capgo/capacitor-nativegeocoder to determine the user's country with higher precision:
 
 1. First, install the required plugins:
 
 ```bash
-npm install @capacitor/geolocation @capgo/nativegeocoder
+npm install @capacitor/geolocation @capgo/capacitor-nativegeocoder
 ```
 
 2. Configure the plugins in your Capacitor project. Add the following to your `capacitor.config.ts`:
@@ -468,7 +468,7 @@ export default config;
 ```typescript
 import { Capacitor } from '@capacitor/core';
 import { Geolocation } from '@capacitor/geolocation';
-import { NativeGeocoder } from '@capgo/nativegeocoder';
+import { NativeGeocoder } from '@capgo/capacitor-nativegeocoder';
 
 async function isUserInUSA() {
   try {

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-nativegeocoder.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-nativegeocoder.md
@@ -1,15 +1,15 @@
 ---
 locale: en
 ---
-# Using @capgo/nativegeocoder
+# Using @capgo/capacitor-nativegeocoder
 
 Capacitor plugin for native forward and reverse geocoding.
 
 ## Install
 
 ```bash
-bun add @capgo/nativegeocoder
-bunx cap sync
+npm install @capgo/capacitor-nativegeocoder
+npx cap sync
 ```
 
 ## What This Plugin Exposes
@@ -24,7 +24,7 @@ bunx cap sync
 Convert latitude and longitude to an address.
 
 ```typescript
-import { NativeGeocoder } from '@capgo/nativegeocoder';
+import { NativeGeocoder } from '@capgo/capacitor-nativegeocoder';
 
 await NativeGeocoder.reverseGeocode({} as ReverseOptions);
 ```
@@ -34,7 +34,7 @@ await NativeGeocoder.reverseGeocode({} as ReverseOptions);
 Convert an address to latitude and longitude.
 
 ```typescript
-import { NativeGeocoder } from '@capgo/nativegeocoder';
+import { NativeGeocoder } from '@capgo/capacitor-nativegeocoder';
 
 await NativeGeocoder.forwardGeocode({} as ForwardOptions);
 ```

--- a/apps/web/src/data/npm-downloads.json
+++ b/apps/web/src/data/npm-downloads.json
@@ -15,7 +15,7 @@
   "@capgo/capacitor-appsflyer": 2383,
   "@capgo/capacitor-contentsquare": 301,
   "@capgo/capacitor-facebook-analytics": 184,
-  "@capgo/nativegeocoder": 21461,
+  "@capgo/capacitor-nativegeocoder": 0,
   "@capgo/inappbrowser": 359340,
   "@capgo/capacitor-mqtt": 745,
   "@capgo/capacitor-mute": 43300,

--- a/apps/web/src/pages/plugins/[slug].astro
+++ b/apps/web/src/pages/plugins/[slug].astro
@@ -130,12 +130,14 @@ content['ldJSON'] = createSoftwareApplicationLdJson(Astro.locals.runtimeConfig.p
                       <span class="group relative inline-flex items-center">
                         <span
                           tabindex="0"
+                          aria-describedby="nativegeocoder-rename-tooltip"
                           title={packageRenameNote}
                           class="rounded-full border border-amber-300/25 bg-amber-300/10 px-3 py-1 text-sm text-amber-100 transition outline-none group-focus-within:border-amber-200/45 group-hover:border-amber-200/45"
                         >
                           Renamed
                         </span>
                         <span
+                          id="nativegeocoder-rename-tooltip"
                           role="tooltip"
                           class="pointer-events-none absolute top-full left-1/2 z-20 mt-2 w-72 -translate-x-1/2 rounded-md border border-white/10 bg-gray-950 px-3 py-2 text-xs leading-5 text-gray-200 opacity-0 shadow-xl transition group-focus-within:opacity-100 group-hover:opacity-100"
                         >

--- a/apps/web/src/pages/plugins/[slug].astro
+++ b/apps/web/src/pages/plugins/[slug].astro
@@ -74,6 +74,10 @@ const { slug: id } = Astro.params
 const { title, description, githubStars, npmDownloads, href, name, tutorial, icon, author } = plugin as Plugin
 
 const npmHref = name ? `https://www.npmjs.com/package/${name}` : `https://www.npmjs.com/search?q=${encodeURIComponent(title)}`
+const packageRenameNote =
+  name === '@capgo/capacitor-nativegeocoder'
+    ? 'Renamed from @capgo/nativegeocoder to @capgo/capacitor-nativegeocoder so the package name matches the Capacitor plugin repository.'
+    : undefined
 const docsHref = docsSlug ? getRelativeLocaleUrl(docsLocale, `docs/plugins/${docsSlug}/`) : getRelativeLocaleUrl(locale, 'docs/plugins/')
 
 const content: { title?: string; description?: string; image?: string; author?: string; ldJSON?: Object } = {}
@@ -113,14 +117,33 @@ content['ldJSON'] = createSoftwareApplicationLdJson(Astro.locals.runtimeConfig.p
             <div class="flex flex-wrap items-center gap-3">
               {
                 name && (
-                  <a
-                    href={npmHref}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="cursor-pointer rounded-full border border-blue-400/20 bg-blue-400/10 px-3 py-1 text-sm text-blue-100 transition hover:border-blue-300/40 hover:bg-blue-400/15"
-                  >
-                    {name}
-                  </a>
+                  <>
+                    <a
+                      href={npmHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="cursor-pointer rounded-full border border-blue-400/20 bg-blue-400/10 px-3 py-1 text-sm text-blue-100 transition hover:border-blue-300/40 hover:bg-blue-400/15"
+                    >
+                      {name}
+                    </a>
+                    {packageRenameNote && (
+                      <span class="group relative inline-flex items-center">
+                        <span
+                          tabindex="0"
+                          title={packageRenameNote}
+                          class="rounded-full border border-amber-300/25 bg-amber-300/10 px-3 py-1 text-sm text-amber-100 transition outline-none group-focus-within:border-amber-200/45 group-hover:border-amber-200/45"
+                        >
+                          Renamed
+                        </span>
+                        <span
+                          role="tooltip"
+                          class="pointer-events-none absolute top-full left-1/2 z-20 mt-2 w-72 -translate-x-1/2 rounded-md border border-white/10 bg-gray-950 px-3 py-2 text-xs leading-5 text-gray-200 opacity-0 shadow-xl transition group-focus-within:opacity-100 group-hover:opacity-100"
+                        >
+                          {packageRenameNote}
+                        </span>
+                      </span>
+                    )}
+                  </>
                 )
               }
               <div class="rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-sm text-gray-300">Tutorial</div>


### PR DESCRIPTION
## What
- Update the Native Geocoder docs and website registry to use `@capgo/capacitor-nativegeocoder`.
- Add a visible rename tooltip on the plugin detail page and a title tooltip note in the docs page.
- Update the generated public plugin README entry and related blog/tutorial references.

## Why
The package is being renamed from `@capgo/nativegeocoder` to `@capgo/capacitor-nativegeocoder` so the website matches the corrected Capacitor package name.

## How
- Updated plugin registry data, icon mapping, npm package link, and docs/tutorial install/import snippets.
- Added a small `Renamed` badge with hover/focus tooltip on the plugin page for the renamed package.
- Set the new npm downloads key to `0` because the renamed package is not published yet.

## Testing
- `bun run check`
- `bun run build:docs`
- `bun run build:web`

## Not Tested
- Live production deploy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Native Geocoder docs, tutorials, and install guides to the new package name and adjusted code examples; install instructions now use npm.
  * Added a visible "Renamed" badge on the plugin page to highlight the package rename.

* **Chores**
  * Updated site plugin metadata and package listings (including displayed package identifier and related badge/metrics) to reflect the rename.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->