### PR TITLE
[codex] support Outrank article update webhooks

### DIFF
--- a/.github/workflows/import-outrank.yml
+++ b/.github/workflows/import-outrank.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       payload:
-        description: Raw Outrank publish_articles payload JSON for testing.
+        description: Raw Outrank publish_articles or update_article payload JSON for testing.
         required: true
         type: string
 

--- a/apps/outrank-worker/src/index.ts
+++ b/apps/outrank-worker/src/index.ts
@@ -22,12 +22,14 @@ interface OutrankPayload {
   event_type?: string
   timestamp?: string
   data?: {
+    article?: OutrankArticle
     articles?: OutrankArticle[]
   }
 }
 
 const DEFAULT_GITHUB_EVENT_TYPE = 'outrank_publish_articles'
 const MAX_REPOSITORY_DISPATCH_BYTES = 65_000
+const SUPPORTED_OUTRANK_EVENT_TYPES = new Set(['publish_articles', 'update_article'])
 const JSON_HEADERS = {
   'content-type': 'application/json; charset=utf-8',
 }
@@ -59,14 +61,26 @@ async function secureEqual(left: string, right: string): Promise<boolean> {
   return difference === 0
 }
 
+function isSupportedEventType(eventType: string | undefined): boolean {
+  return typeof eventType === 'string' && SUPPORTED_OUTRANK_EVENT_TYPES.has(eventType)
+}
+
+function payloadArticles(payload: OutrankPayload): OutrankArticle[] {
+  if (Array.isArray(payload.data?.articles)) return payload.data.articles
+  if (payload.data?.article && typeof payload.data.article === 'object') return [payload.data.article]
+  return []
+}
+
 function validatePayload(payload: unknown): payload is OutrankPayload {
   if (!payload || typeof payload !== 'object') return false
 
   const candidate = payload as OutrankPayload
-  if (candidate.event_type !== 'publish_articles') return false
-  if (!candidate.data || !Array.isArray(candidate.data.articles)) return false
+  if (!isSupportedEventType(candidate.event_type)) return false
 
-  return candidate.data.articles.every(
+  const articles = payloadArticles(candidate)
+  if (articles.length === 0) return false
+
+  return articles.every(
     (article) =>
       typeof article?.title === 'string' && article.title.trim().length > 0 && typeof article?.content_markdown === 'string' && article.content_markdown.trim().length > 0,
   )
@@ -77,7 +91,7 @@ function normalizePayload(payload: OutrankPayload): OutrankPayload {
     event_type: payload.event_type,
     timestamp: payload.timestamp,
     data: {
-      articles: (payload.data?.articles || []).map((article) => ({
+      articles: payloadArticles(payload).map((article) => ({
         id: article.id,
         title: article.title,
         content_markdown: article.content_markdown,
@@ -85,7 +99,7 @@ function normalizePayload(payload: OutrankPayload): OutrankPayload {
         created_at: article.created_at,
         image_url: article.image_url,
         slug: article.slug,
-        tags: Array.isArray(article.tags) ? article.tags.filter((tag) => typeof tag === 'string') : [],
+        tags: Array.isArray(article.tags) ? article.tags.filter((tag) => typeof tag === 'string') : undefined,
       })),
     },
   }

--- a/scripts/blogs/import_outrank.ts
+++ b/scripts/blogs/import_outrank.ts
@@ -26,9 +26,12 @@ interface OutrankPayload {
   event_type?: string
   timestamp?: string
   data?: {
+    article?: OutrankArticle
     articles?: OutrankArticle[]
   }
 }
+
+const SUPPORTED_OUTRANK_EVENT_TYPES = new Set(['publish_articles', 'update_article'])
 
 function readJson(path: string): unknown {
   return JSON.parse(readFileSync(path, 'utf8'))
@@ -70,7 +73,22 @@ function assertInsideDirectory(directory: string, filePath: string): void {
   }
 }
 
-function toDate(value: string | undefined, fallback: Date): Date {
+function isSupportedEventType(eventType: string | undefined): boolean {
+  return typeof eventType === 'string' && SUPPORTED_OUTRANK_EVENT_TYPES.has(eventType)
+}
+
+function payloadArticles(payload: OutrankPayload): OutrankArticle[] {
+  if (Array.isArray(payload.data?.articles)) return payload.data.articles
+  if (payload.data?.article) return [payload.data.article]
+  return []
+}
+
+function frontmatterString(frontmatter: Record<string, unknown>, key: string): string {
+  const value = frontmatter[key]
+  return typeof value === 'string' ? value : ''
+}
+
+function toDate(value: Date | string | undefined, fallback: Date): Date {
   const date = value ? new Date(value) : new Date(fallback)
   if (Number.isNaN(date.getTime())) return new Date(fallback)
   return date
@@ -131,16 +149,28 @@ function writeArticle(article: OutrankArticle, payloadTimestamp: Date, blogDirec
   const slug = toSlug(article.slug || title || article.id || '')
   if (!slug) throw new Error(`Outrank article "${title}" does not have a usable slug.`)
 
+  const filePath = join(blogDirectory, `${slug}.md`)
+  assertInsideDirectory(blogDirectory, filePath)
+
+  const existingContent = existsSync(filePath) ? readFileSync(filePath, 'utf8') : ''
+  const existingFrontmatter = existingContent ? (matter(existingContent).data as Record<string, unknown>) : {}
+  const existingTag = frontmatterString(existingFrontmatter, 'tag')
+  const existingKeywords = frontmatterString(existingFrontmatter, 'keywords')
   const tags = Array.isArray(article.tags)
     ? article.tags
         .filter((tag): tag is string => typeof tag === 'string')
         .map((tag) => tag.trim())
         .filter(Boolean)
-    : []
+    : existingTag
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter(Boolean)
   const markdown = normalizeMarkdown(article.content_markdown, title)
-  const createdAt = toDate(article.created_at, payloadTimestamp)
+  const createdAt = toDate(article.created_at, toDate(existingFrontmatter.created_at as Date | string | undefined, payloadTimestamp))
   const updatedAt = new Date(payloadTimestamp)
   const tag = tags.length > 0 ? tags.join(', ') : 'Development'
+  const headImage = article.image_url ? normalizeHeadImage(article.image_url) : frontmatterString(existingFrontmatter, 'head_image') || DEFAULT_HEAD_IMAGE
+  const keywords = Array.isArray(article.tags) ? tags.join(', ') : existingKeywords || tags.join(', ')
 
   const frontmatter = {
     slug,
@@ -151,20 +181,16 @@ function writeArticle(article: OutrankArticle, payloadTimestamp: Date, blogDirec
     author_url: process.env.OUTRANK_BLOG_AUTHOR_URL || DEFAULT_AUTHOR_URL,
     created_at: createdAt,
     updated_at: updatedAt,
-    head_image: normalizeHeadImage(article.image_url),
+    head_image: headImage,
     head_image_alt: title,
-    keywords: tags.join(', '),
+    keywords,
     tag,
     published: true,
     locale: 'en',
     next_blog: '',
   }
 
-  const filePath = join(blogDirectory, `${slug}.md`)
-  assertInsideDirectory(blogDirectory, filePath)
-
   const content = matter.stringify(markdown, frontmatter, { lineWidth: -1 })
-  const existingContent = existsSync(filePath) ? readFileSync(filePath, 'utf8') : ''
   if (existingContent === content) return ''
 
   writeFileSync(filePath, content, 'utf8')
@@ -173,11 +199,11 @@ function writeArticle(article: OutrankArticle, payloadTimestamp: Date, blogDirec
 
 function main(): void {
   const payload = loadPayload()
-  if (payload.event_type !== 'publish_articles') {
-    throw new Error(`Unsupported Outrank event_type "${payload.event_type}". Expected "publish_articles".`)
+  if (!isSupportedEventType(payload.event_type)) {
+    throw new Error(`Unsupported Outrank event_type "${payload.event_type}". Expected one of: ${Array.from(SUPPORTED_OUTRANK_EVENT_TYPES).join(', ')}.`)
   }
 
-  const articles = payload.data?.articles || []
+  const articles = payloadArticles(payload)
   if (articles.length === 0) throw new Error('Outrank payload does not contain any articles.')
 
   const payloadTimestamp = toDate(payload.timestamp, new Date())


### PR DESCRIPTION
## Summary
- accept Outrank `update_article` webhook events in addition to `publish_articles`
- normalize both `data.articles[]` and single `data.article` payloads before dispatch/import
- upsert updated articles by slug while preserving existing created date, image, and tags when update payloads omit them
- update the manual workflow input description to mention both supported event types

## Root cause
Outrank article improvements send `update_article`, but the webhook worker and importer only allowed `publish_articles`, so update requests would be rejected before reaching the existing slug-based write path.

## Validation
- temp publish + update import sequence with `update_article` and single `data.article`
- `bun run ci:verify:outrank`
- `bun run ci:verify:web`

The dashboard doc URL redirects to sign-in from this environment, but the public webhook docs confirm the article payload fields used by this implementation: https://www.outrank.so/docs/webhook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Outrank importer now supports the `update_article` event type in addition to `publish_articles`
  * Webhook accepts both single-article and batch-article payload formats

* **Improvements**
  * Enhanced article metadata preservation during updates, with fallback to existing tags, creation dates, and images when not provided in incoming payloads

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->