### PR TITLE
[codex] fix testimonials iframe background

### DIFF
--- a/apps/web/src/components/Testimonials.astro
+++ b/apps/web/src/components/Testimonials.astro
@@ -72,8 +72,9 @@ import m from '@/copy/messages'
       src="https://senja.io/p/capgo/love-embed?hideNavigation=true&embed=true"
       title="Customer testimonials and reviews for Capgo"
       aria-label="Wall of Love - Customer testimonials"
+      allowtransparency="true"
       class="block bg-transparent"
-      style="overflow: hidden;"
+      style="overflow: hidden; background-color: transparent;"
       width="100%"></iframe>
     <script is:inline>
       document.addEventListener('DOMContentLoaded', function () {

--- a/apps/web/src/components/Testimonials.astro
+++ b/apps/web/src/components/Testimonials.astro
@@ -72,9 +72,8 @@ import m from '@/copy/messages'
       src="https://senja.io/p/capgo/love-embed?hideNavigation=true&embed=true"
       title="Customer testimonials and reviews for Capgo"
       aria-label="Wall of Love - Customer testimonials"
-      allowtransparency="true"
       class="block bg-transparent"
-      style="overflow: hidden; background-color: transparent;"
+      style="overflow: hidden;"
       width="100%"></iframe>
     <script is:inline>
       document.addEventListener('DOMContentLoaded', function () {

--- a/apps/web/src/components/Testimonials.astro
+++ b/apps/web/src/components/Testimonials.astro
@@ -72,7 +72,9 @@ import m from '@/copy/messages'
       src="https://senja.io/p/capgo/love-embed?hideNavigation=true&embed=true"
       title="Customer testimonials and reviews for Capgo"
       aria-label="Wall of Love - Customer testimonials"
-      style="overflow: hidden;"
+      allowtransparency="true"
+      class="block bg-transparent"
+      style="overflow: hidden; background-color: transparent;"
       width="100%"></iframe>
     <script is:inline>
       document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
## Summary

Fixes the homepage testimonial embed background in dark mode by allowing the Senja iframe to remain transparent instead of painting a white iframe canvas.

## Root cause

The Senja Wall of Love content uses transparent embed styling, but the host iframe itself did not declare a transparent background/allow transparency. In dark mode, the iframe surface could render as white around the cards.

## Validation

- `bunx prettier --write apps/web/src/components/Testimonials.astro`
- `NODE_OPTIONS=--max-old-space-size=16384 bunx astro check`
- Headless browser smoke test of the homepage testimonial section confirmed the white block is gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Testimonials "Wall of Love" embed so the testimonial frame displays with a transparent background and block layout, and allows transparency for more consistent rendering—reducing visual glitches and ensuring a cleaner, more seamless appearance across browsers and devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->