### PR TITLE
Fix Senja testimonial background bleed

### DIFF
--- a/apps/web/src/components/Testimonials.astro
+++ b/apps/web/src/components/Testimonials.astro
@@ -1,107 +1,5 @@
 ---
 import m from '@/copy/messages'
-
-const testimonials = [
-  {
-    name: 'Mikołaj Wilczek',
-    role: 'Principal Mobile Platform Engineer',
-    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/avatar/cd659df9-70a5-43f5-bbfd-c11f5c6cec7e_avatar.png',
-    text: 'We originally discovered Capgo through its plugins, and that turned out to be a great entry point into a platform that now supports a much more efficient release process for our team.',
-    rating: 5,
-    date: '2026-04-15T18:52:19.322Z',
-  },
-  {
-    name: 'Michael Haberler',
-    role: 'nethead emeritors',
-    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/avatar/f79c80c6-8a49-4972-88b4-7ec68ea92822_avatar.png',
-    text: 'working on a app for iOS and Android called Montgolfiere to support hot air ballooning\n\nthis requires location, pressure sensor and BLE advertisement scanning for BLE sensors - so capacitor was the way to go\n\ngreat job on the updater plugin - works flawlessly for me!\n\nI hope to get the base app through review and the appstores sooon - I dont have a showcase yet as my web experience is pretty slim but I will get there\n\nlive updates are a super accelerator for quick testing turaround!',
-    rating: 5,
-    date: '2025-07-03T07:24:41.233Z',
-  },
-  {
-    name: 'Sergiu S',
-    role: 'Lead Developer',
-    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/avatar/98496c09-8f14-45ec-a8fc-21c2f76bf2ca_photo_2024-04-28_17-25-58.jpg',
-    text: "We've been using the Capgo Capacitor Updater plugin, and it completely transformed how we ship updates. What used to take days now takes just minutes - our users get the latest changes almost instantly. The plugin is solid, easy to integrate, and the support team is absolutely fantastic - responsive, knowledgeable, and with a genuine willingness to assist. We also really appreciate the self-hosted version, which gave us full control over the update process while still benefiting from all the powerful features. Highly recommended for teams that care about fast, smooth deployments.",
-    rating: 5,
-    date: '2025-06-23T17:51:09.235Z',
-  },
-  {
-    name: 'jermaine',
-    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/b370d927-f56a-4ae9-9f14-a6d80e80e1f2_fa02717a-5755-431e-9ea5-f582309bace9_avatar-male-2.webp',
-    text: 'Jumped over to @Capgo after @AppFlow hit us with a $5000 bill for the year to continue.\n\nLoving CapoGo so far. Thanks for @Capgo, it is a great product.',
-    rating: 5,
-    date: '2025-05-28T20:16:34.402Z',
-  },
-  {
-    name: 'SP-CMingay',
-    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/033e3f55-e917-4e1f-b593-6701970b3383_43a49cb8-f8f0-4cbf-b02f-df9aec52da57_avatar-male-3.webp',
-    text: "I've got self hosted updates working with very little work on my part!\n\nI've proposed with my bosses that we consider @Capgo app for automated updates as well so I will begin giving that a go now too.",
-    date: '2025-05-28T20:14:25.020Z',
-  },
-  {
-    name: 'Simon Flack',
-    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/550975b2-0b6e-4b9d-a100-764e29f399eb_0d120971-15c9-4976-bc91-ce08a0fd5444_simon%20%281%29.webp',
-    text: 'We are currently giving a try to @Capgo since Appcenter stopped live updates support on hybrid apps and @AppFlow is far too expensive.',
-    rating: 5,
-    date: '2025-05-28T20:13:21.712Z',
-  },
-  {
-    name: 'jaythegeek',
-    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/13d16cb5-7164-4574-83ee-d2ed4c0c7354_2568ba88-8a8d-4c93-81a4-0ddf67f8ffe8_jaythegeek%20%281%29.webp',
-    text: 'Did set up @Capgo and tested out this fantastic replacement for @AppFlow!\n\nThank you for the hard work, it has been easy so far. About to release to the app stores',
-    rating: 5,
-    date: '2025-05-28T20:12:24.734Z',
-  },
-  {
-    name: "NASA's OSIRIS-REx",
-    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/46c36vfKUgSbvgoA2y5wCcKe.webp',
-    text: '@Capgo is a smart way to make hot code pushes, and not for all the money in the world like with @AppFlow.',
-    date: '2025-05-28T19:26:23.094Z',
-  },
-  {
-    name: 'Lincoln Baxter',
-    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/NtTFULS7sRUbAd0eluEIf2q7.webp',
-    text: 'The community needed this and @Capgo is doing something really important!',
-    date: '2025-05-28T19:26:23.094Z',
-  },
-  {
-    name: 'Andrew Peacock',
-    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/lGgR7oiCLu9yITbeUHzkoH2W.webp',
-    text: "Here's my view: React-native: Too many moving parts that eventually broke. Flutterflow: new language, stumbled on first attempt to add a plugin. Now: @Capacitor + @vue or @react + @VoltBuilder + @Capgo",
-    date: '2025-05-28T19:26:23.094Z',
-  },
-  {
-    name: 'Rodrigo Mantica',
-    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/nVGm8acVUZWhIllsr6KwAWXG.webp',
-    text: 'We practice agile development and @Capgo is mission-critical in delivering continuously to our users! Thanks @martindonadieu for your hard work and I will definitely be supporting this community as well.',
-    date: '2025-05-28T19:26:23.094Z',
-  },
-  {
-    name: 'Bessie Cooper',
-    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/jrAviBV1S9JqkTQOTwxjXPHQ.webp',
-    text: 'Capgo is a must have tool for developers who want to be more productive. Avoiding review for bugfix is golden.',
-    date: '2025-05-28T19:26:23.094Z',
-  },
-  {
-    name: 'Mallats',
-    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/8HignOyfLSlxKBPnlvHisqOQ.webp',
-    text: 'We really appreciate @Capgo, will be supporting this project from the Mallats team. Awaiting approval from the App Stores.',
-    date: '2025-05-28T19:26:23.094Z',
-  },
-  {
-    name: 'LeVar Berry',
-    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/PqiQhNTE6LfiWyhT7fRbAT9M.webp',
-    text: 'Cancelled my @Appflow subscription after 4 years. Code-Push never seemed to work well, hopefully @CapGO has it figured out.',
-    date: '2025-05-28T19:26:23.094Z',
-  },
-]
-
-const dateFormatter = new Intl.DateTimeFormat(Astro.locals.locale || 'en', {
-  month: 'short',
-  day: 'numeric',
-  year: 'numeric',
-})
 ---
 
 <section class="relative isolate bg-[#1a1a1a] pt-24 pb-32 sm:pt-32">
@@ -169,33 +67,19 @@ const dateFormatter = new Intl.DateTimeFormat(Astro.locals.locale || 'en', {
       </p>
     </div>
 
-    <div class="mx-auto mt-16 max-w-6xl columns-1 gap-5 sm:columns-2 lg:mt-20 lg:columns-3">
-      {
-        testimonials.map((testimonial) => (
-          <article class="mb-5 break-inside-avoid rounded-lg border border-white/10 bg-slate-700/95 p-6 shadow-xl ring-1 shadow-black/20 ring-white/5">
-            <div class="flex items-center gap-4">
-              <img class="h-12 w-12 rounded-full object-cover" src={testimonial.avatar} alt={`${testimonial.name} avatar`} loading="lazy" decoding="async" />
-              <div>
-                <h3 class="text-base font-semibold text-white">{testimonial.name}</h3>
-                {testimonial.role && <p class="text-sm leading-5 text-white/75">{testimonial.role}</p>}
-              </div>
-            </div>
-            {testimonial.rating && (
-              <div class="mt-5 flex gap-1 text-yellow-300" aria-label={`${testimonial.rating} out of 5 stars`}>
-                {Array.from({ length: testimonial.rating }).map(() => (
-                  <svg class="size-5 fill-current" viewBox="0 0 20 20" aria-hidden="true">
-                    <path d="M9.05 2.93c.3-.92 1.6-.92 1.9 0l1.18 3.63a1 1 0 0 0 .95.69h3.82c.96 0 1.36 1.23.58 1.8l-3.09 2.24a1 1 0 0 0-.36 1.12l1.18 3.63c.3.92-.76 1.68-1.54 1.12l-3.09-2.24a1 1 0 0 0-1.18 0l-3.09 2.24c-.78.56-1.84-.2-1.54-1.12l1.18-3.63a1 1 0 0 0-.36-1.12L2.5 9.05c-.78-.57-.38-1.8.58-1.8H6.9a1 1 0 0 0 .95-.69z" />
-                  </svg>
-                ))}
-              </div>
-            )}
-            <p class="mt-5 text-base leading-7 font-medium whitespace-pre-line text-white/90">{testimonial.text}</p>
-            <time class="mt-4 block text-sm font-medium text-white/55" datetime={testimonial.date}>
-              {dateFormatter.format(new Date(testimonial.date))}
-            </time>
-          </article>
-        ))
-      }
-    </div>
+    <iframe
+      id="wall-of-love-eEqRvoc"
+      src="https://senja.io/p/capgo/love-embed?hideNavigation=true&embed=true&v=transparent-bg-20260521"
+      title="Customer testimonials and reviews for Capgo"
+      aria-label="Wall of Love - Customer testimonials"
+      allowtransparency="true"
+      class="block bg-transparent"
+      style="overflow: hidden; background-color: transparent;"
+      width="100%"></iframe>
+    <script is:inline>
+      document.addEventListener('DOMContentLoaded', function () {
+        iFrameResize({ log: false, checkOrigin: false }, '#wall-of-love-eEqRvoc')
+      })
+    </script>
   </div>
 </section>

--- a/apps/web/src/components/Testimonials.astro
+++ b/apps/web/src/components/Testimonials.astro
@@ -2,7 +2,7 @@
 import m from '@/copy/messages'
 ---
 
-<section class="relative isolate bg-[#1a1a1a] pt-24 pb-32 sm:pt-32">
+<section class="relative isolate pt-24 pb-32 sm:pt-32">
   <!-- Background effects -->
   <div class="absolute inset-x-0 top-1/2 -z-10 -translate-y-1/2 transform-gpu overflow-hidden opacity-30 blur-3xl" aria-hidden="true">
     <div

--- a/apps/web/src/components/Testimonials.astro
+++ b/apps/web/src/components/Testimonials.astro
@@ -1,5 +1,107 @@
 ---
 import m from '@/copy/messages'
+
+const testimonials = [
+  {
+    name: 'Mikołaj Wilczek',
+    role: 'Principal Mobile Platform Engineer',
+    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/avatar/cd659df9-70a5-43f5-bbfd-c11f5c6cec7e_avatar.png',
+    text: 'We originally discovered Capgo through its plugins, and that turned out to be a great entry point into a platform that now supports a much more efficient release process for our team.',
+    rating: 5,
+    date: '2026-04-15T18:52:19.322Z',
+  },
+  {
+    name: 'Michael Haberler',
+    role: 'nethead emeritors',
+    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/avatar/f79c80c6-8a49-4972-88b4-7ec68ea92822_avatar.png',
+    text: 'working on a app for iOS and Android called Montgolfiere to support hot air ballooning\n\nthis requires location, pressure sensor and BLE advertisement scanning for BLE sensors - so capacitor was the way to go\n\ngreat job on the updater plugin - works flawlessly for me!\n\nI hope to get the base app through review and the appstores sooon - I dont have a showcase yet as my web experience is pretty slim but I will get there\n\nlive updates are a super accelerator for quick testing turaround!',
+    rating: 5,
+    date: '2025-07-03T07:24:41.233Z',
+  },
+  {
+    name: 'Sergiu S',
+    role: 'Lead Developer',
+    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/avatar/98496c09-8f14-45ec-a8fc-21c2f76bf2ca_photo_2024-04-28_17-25-58.jpg',
+    text: "We've been using the Capgo Capacitor Updater plugin, and it completely transformed how we ship updates. What used to take days now takes just minutes - our users get the latest changes almost instantly. The plugin is solid, easy to integrate, and the support team is absolutely fantastic - responsive, knowledgeable, and with a genuine willingness to assist. We also really appreciate the self-hosted version, which gave us full control over the update process while still benefiting from all the powerful features. Highly recommended for teams that care about fast, smooth deployments.",
+    rating: 5,
+    date: '2025-06-23T17:51:09.235Z',
+  },
+  {
+    name: 'jermaine',
+    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/b370d927-f56a-4ae9-9f14-a6d80e80e1f2_fa02717a-5755-431e-9ea5-f582309bace9_avatar-male-2.webp',
+    text: 'Jumped over to @Capgo after @AppFlow hit us with a $5000 bill for the year to continue.\n\nLoving CapoGo so far. Thanks for @Capgo, it is a great product.',
+    rating: 5,
+    date: '2025-05-28T20:16:34.402Z',
+  },
+  {
+    name: 'SP-CMingay',
+    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/033e3f55-e917-4e1f-b593-6701970b3383_43a49cb8-f8f0-4cbf-b02f-df9aec52da57_avatar-male-3.webp',
+    text: "I've got self hosted updates working with very little work on my part!\n\nI've proposed with my bosses that we consider @Capgo app for automated updates as well so I will begin giving that a go now too.",
+    date: '2025-05-28T20:14:25.020Z',
+  },
+  {
+    name: 'Simon Flack',
+    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/550975b2-0b6e-4b9d-a100-764e29f399eb_0d120971-15c9-4976-bc91-ce08a0fd5444_simon%20%281%29.webp',
+    text: 'We are currently giving a try to @Capgo since Appcenter stopped live updates support on hybrid apps and @AppFlow is far too expensive.',
+    rating: 5,
+    date: '2025-05-28T20:13:21.712Z',
+  },
+  {
+    name: 'jaythegeek',
+    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/13d16cb5-7164-4574-83ee-d2ed4c0c7354_2568ba88-8a8d-4c93-81a4-0ddf67f8ffe8_jaythegeek%20%281%29.webp',
+    text: 'Did set up @Capgo and tested out this fantastic replacement for @AppFlow!\n\nThank you for the hard work, it has been easy so far. About to release to the app stores',
+    rating: 5,
+    date: '2025-05-28T20:12:24.734Z',
+  },
+  {
+    name: "NASA's OSIRIS-REx",
+    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/46c36vfKUgSbvgoA2y5wCcKe.webp',
+    text: '@Capgo is a smart way to make hot code pushes, and not for all the money in the world like with @AppFlow.',
+    date: '2025-05-28T19:26:23.094Z',
+  },
+  {
+    name: 'Lincoln Baxter',
+    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/NtTFULS7sRUbAd0eluEIf2q7.webp',
+    text: 'The community needed this and @Capgo is doing something really important!',
+    date: '2025-05-28T19:26:23.094Z',
+  },
+  {
+    name: 'Andrew Peacock',
+    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/lGgR7oiCLu9yITbeUHzkoH2W.webp',
+    text: "Here's my view: React-native: Too many moving parts that eventually broke. Flutterflow: new language, stumbled on first attempt to add a plugin. Now: @Capacitor + @vue or @react + @VoltBuilder + @Capgo",
+    date: '2025-05-28T19:26:23.094Z',
+  },
+  {
+    name: 'Rodrigo Mantica',
+    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/nVGm8acVUZWhIllsr6KwAWXG.webp',
+    text: 'We practice agile development and @Capgo is mission-critical in delivering continuously to our users! Thanks @martindonadieu for your hard work and I will definitely be supporting this community as well.',
+    date: '2025-05-28T19:26:23.094Z',
+  },
+  {
+    name: 'Bessie Cooper',
+    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/jrAviBV1S9JqkTQOTwxjXPHQ.webp',
+    text: 'Capgo is a must have tool for developers who want to be more productive. Avoiding review for bugfix is golden.',
+    date: '2025-05-28T19:26:23.094Z',
+  },
+  {
+    name: 'Mallats',
+    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/8HignOyfLSlxKBPnlvHisqOQ.webp',
+    text: 'We really appreciate @Capgo, will be supporting this project from the Mallats team. Awaiting approval from the App Stores.',
+    date: '2025-05-28T19:26:23.094Z',
+  },
+  {
+    name: 'LeVar Berry',
+    avatar: 'https://senja-io.s3.us-west-1.amazonaws.com/public/media/PqiQhNTE6LfiWyhT7fRbAT9M.webp',
+    text: 'Cancelled my @Appflow subscription after 4 years. Code-Push never seemed to work well, hopefully @CapGO has it figured out.',
+    date: '2025-05-28T19:26:23.094Z',
+  },
+]
+
+const dateFormatter = new Intl.DateTimeFormat(Astro.locals.locale || 'en', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+})
 ---
 
 <section class="relative isolate bg-[#1a1a1a] pt-24 pb-32 sm:pt-32">
@@ -67,19 +169,33 @@ import m from '@/copy/messages'
       </p>
     </div>
 
-    <iframe
-      id="wall-of-love-eEqRvoc"
-      src="https://senja.io/p/capgo/love-embed?hideNavigation=true&embed=true"
-      title="Customer testimonials and reviews for Capgo"
-      aria-label="Wall of Love - Customer testimonials"
-      allowtransparency="true"
-      class="block bg-transparent"
-      style="overflow: hidden; background-color: transparent;"
-      width="100%"></iframe>
-    <script is:inline>
-      document.addEventListener('DOMContentLoaded', function () {
-        iFrameResize({ log: false, checkOrigin: false }, '#wall-of-love-eEqRvoc')
-      })
-    </script>
+    <div class="mx-auto mt-16 max-w-6xl columns-1 gap-5 sm:columns-2 lg:mt-20 lg:columns-3">
+      {
+        testimonials.map((testimonial) => (
+          <article class="mb-5 break-inside-avoid rounded-lg border border-white/10 bg-slate-700/95 p-6 shadow-xl ring-1 shadow-black/20 ring-white/5">
+            <div class="flex items-center gap-4">
+              <img class="h-12 w-12 rounded-full object-cover" src={testimonial.avatar} alt="" loading="lazy" decoding="async" />
+              <div>
+                <h3 class="text-base font-semibold text-white">{testimonial.name}</h3>
+                {testimonial.role && <p class="text-sm leading-5 text-white/75">{testimonial.role}</p>}
+              </div>
+            </div>
+            {testimonial.rating && (
+              <div class="mt-5 flex gap-1 text-yellow-300" aria-label={`${testimonial.rating} out of 5 stars`}>
+                {Array.from({ length: testimonial.rating }).map(() => (
+                  <svg class="size-5 fill-current" viewBox="0 0 20 20" aria-hidden="true">
+                    <path d="M9.05 2.93c.3-.92 1.6-.92 1.9 0l1.18 3.63a1 1 0 0 0 .95.69h3.82c.96 0 1.36 1.23.58 1.8l-3.09 2.24a1 1 0 0 0-.36 1.12l1.18 3.63c.3.92-.76 1.68-1.54 1.12l-3.09-2.24a1 1 0 0 0-1.18 0l-3.09 2.24c-.78.56-1.84-.2-1.54-1.12l1.18-3.63a1 1 0 0 0-.36-1.12L2.5 9.05c-.78-.57-.38-1.8.58-1.8H6.9a1 1 0 0 0 .95-.69z" />
+                  </svg>
+                ))}
+              </div>
+            )}
+            <p class="mt-5 text-base leading-7 font-medium whitespace-pre-line text-white/90">{testimonial.text}</p>
+            <time class="mt-4 block text-sm font-medium text-white/55" datetime={testimonial.date}>
+              {dateFormatter.format(new Date(testimonial.date))}
+            </time>
+          </article>
+        ))
+      }
+    </div>
   </div>
 </section>

--- a/apps/web/src/components/Testimonials.astro
+++ b/apps/web/src/components/Testimonials.astro
@@ -174,7 +174,7 @@ const dateFormatter = new Intl.DateTimeFormat(Astro.locals.locale || 'en', {
         testimonials.map((testimonial) => (
           <article class="mb-5 break-inside-avoid rounded-lg border border-white/10 bg-slate-700/95 p-6 shadow-xl ring-1 shadow-black/20 ring-white/5">
             <div class="flex items-center gap-4">
-              <img class="h-12 w-12 rounded-full object-cover" src={testimonial.avatar} alt="" loading="lazy" decoding="async" />
+              <img class="h-12 w-12 rounded-full object-cover" src={testimonial.avatar} alt={`${testimonial.name} avatar`} loading="lazy" decoding="async" />
               <div>
                 <h3 class="text-base font-semibold text-white">{testimonial.name}</h3>
                 {testimonial.role && <p class="text-sm leading-5 text-white/75">{testimonial.role}</p>}


### PR DESCRIPTION
## Summary
- keep the Senja iframe embed and transparency attributes
- cache-bust the Senja iframe URL so updated Senja CSS is loaded
- remove the hard testimonials section background so the page glow can continue behind the transparent iframe

## Verified
- edited prod live in browser: removing the section background fixed the visible crop
- forced the live iframe to reload with a cache-busted URL
- bunx prettier --write apps/web/src/components/Testimonials.astro
- NODE_OPTIONS=--max-old-space-size=16384 bunx astro check (apps/web)
- bun run build (apps/web)

## Senja CSS that must stay
The embed itself must remain transparent inside Senja. Keep transparent backgrounds on html, body, .sj-wol-container, .sj-wol-main, .sj-wol-header, and .sj-wol-testimonials, all with !important. Keep .sj-card background-color #314158.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Testimonials section styling with a cleaner background appearance.
  * Enhanced the embedded testimonials display to feature a transparent background for improved visual integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->