### PR TITLE
fix: remove double comma in Appflow shutdown heading

### DIFF
--- a/apps/web/src/components/AppflowShutdown.astro
+++ b/apps/web/src/components/AppflowShutdown.astro
@@ -15,7 +15,7 @@ import { getRelativeLocaleUrl } from 'astro:i18n'
       </div>
 
       <h2 class="mx-auto mb-8 max-w-5xl text-4xl leading-tight font-bold text-white sm:text-5xl xl:text-6xl">
-        {m.home_appflow_shutdown_heading({}, { locale: Astro.locals.locale })},<br />
+        {m.home_appflow_shutdown_heading({}, { locale: Astro.locals.locale })}<br />
         <span class="underline decoration-2 underline-offset-8">
           {m.home_capgo_here_to_stay({}, { locale: Astro.locals.locale })}
         </span>


### PR DESCRIPTION
## Summary
- The Appflow shutdown hero heading rendered "Ionic Appflow is shutting down,," with a double comma.
- Root cause: the translatable message `home_appflow_shutdown_heading` already ends with a comma (`apps/shared/copy/messages.ts:1407`), and the template in `apps/web/src/components/AppflowShutdown.astro:18` added a second literal comma.
- Fix: drop the hardcoded comma in the template so punctuation stays inside the translatable string (correct for the runtime translation worker).

## Test plan
- [ ] Visual check of the homepage Appflow shutdown section: heading should read "Ionic Appflow is shutting down," / "Capgo is here to stay" with a single comma.

https://claude.ai/code/session_01SFKuhKJwPVBqLhacXGb8gt

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFKuhKJwPVBqLhacXGb8gt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the text formatting in the Appflow shutdown message heading for improved readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->