### PR TITLE
[codex] Add Semver tester internal links

### DIFF
--- a/apps/docs/src/content/docs/docs/cli/commands.mdx
+++ b/apps/docs/src/content/docs/docs/cli/commands.mdx
@@ -405,14 +405,14 @@ First, figure out what channel is failing. You can do that by looking at the `mi
 Then go to the failing channel and click on `Bundle number`. This should take you to the bundle page.
 <img src="/fail-channel-show.webp" alt="Locate failing channel"/>
 
-Once there fill the `Minimal update version` field. This should be a [semver](https://devhints.io/semver/).\
+Once there fill the `Minimal update version` field. This should be a [semver](/semver_tester/).\
 If the value you pass is not a semver you will get an error, but if everything goes correctly you should see something like this:
 <img src="/set-min-update-version.webp" alt="Set min version"/>
 
 Now, you likely do not want to set this data manually every time you update. Fortunately, the CLI will prevent you from sending an update without this metadata
 <img src="/cli-fail-no-metadata.webp" alt="CLI fail no metadata"/>
 
-To properly upload a bundle when using the `metadata` option you need to pass the `--min-update-version` with the valid semver. Something like this:
+To properly upload a bundle when using the `metadata` option you need to pass the `--min-update-version` with the [valid semver](/semver_tester/). Something like this:
 <img src="/cli-upload-with-metadata.webp" alt="CLI upload with metadata"/>
 
 The `--min-update-version` is not the ONLY way to do compatibility.

--- a/apps/docs/src/content/docs/docs/live-updates/channels.mdx
+++ b/apps/docs/src/content/docs/docs/live-updates/channels.mdx
@@ -119,7 +119,7 @@ Use this to restrict which kinds of updates the channel will automatically deliv
 - minor: Block cross‑minor updates (e.g., 1.1.0 → 1.2.0) and majors. Patch updates still allowed. Note: does not block 0.1.0 → 1.1.0.
 - patch: Very strict. Allows only increasing patch versions within the same major and minor. Examples: 0.0.311 → 0.0.314 ✅, 0.1.312 → 0.0.314 ❌, 1.0.312 → 0.0.314 ❌.
 - metadata: Require a minimum update version metadata on each bundle. Configure via CLI using `--min-update-version` or `--auto-min-update-version`. If missing, the channel is marked misconfigured and updates will be rejected until set.
-- none: Allow all updates according to semver compatibility.
+- none: Allow all updates according to [semver compatibility](/semver_tester/).
 
 Learn more details and examples in Disable updates strategy at /docs/cli/commands/#disable-updates-strategy.
 
@@ -196,7 +196,7 @@ You can also assign builds to channels from the "Bundles" section of the Capgo d
 
 It's important to note that bundles in Capgo are global to your app, not specific to individual channels. The same bundle can be assigned to multiple channels.
 
-When versioning your bundles, we recommend using semantic versioning [semver](https://semver.org/) with pre-release identifiers for channel-specific builds. For example, a beta release might be versioned as `1.2.3-beta.1`.
+When versioning your bundles, we recommend using [semantic versioning with Capgo's Semver Tester](/semver_tester/) and pre-release identifiers for channel-specific builds. For example, a beta release might be versioned as `1.2.3-beta.1`.
 
 This approach has several benefits:
 
@@ -211,7 +211,7 @@ Here's an example of how you might align your bundle versions with a typical cha
 - `Staging` channel: `1.2.3-rc.1`, `1.2.3-rc.2`, etc.
 - `Production` channel: `1.2.3`, `1.2.4`, etc.
 
-Using semver with pre-release identifiers is a recommended approach, but not strictly required. The key is to find a versioning scheme that clearly communicates the relationships between your builds and aligns with your team's development process.
+Using [semver with pre-release identifiers](/semver_tester/) is a recommended approach, but not strictly required. The key is to find a versioning scheme that clearly communicates the relationships between your builds and aligns with your team's development process.
 
 ## Rolling Back a Live Update
 

--- a/apps/docs/src/content/docs/docs/live-updates/update-types.mdx
+++ b/apps/docs/src/content/docs/docs/live-updates/update-types.mdx
@@ -64,7 +64,7 @@ The `kill` condition triggers after the first kill event, not the next backgroun
 
 ## Version Blocking (Channel Policy)
 
-Controls which **semver updates** a channel will auto-deliver. Set via `--disable-auto-update` on channels.
+Controls which [**semver updates**](/semver_tester/) a channel will auto-deliver. Set via `--disable-auto-update` on channels.
 
 | Strategy | Blocks | Allows | Use Case |
 |----------|--------|--------|----------|

--- a/apps/docs/src/content/docs/docs/live-updates/version-targeting.mdx
+++ b/apps/docs/src/content/docs/docs/live-updates/version-targeting.mdx
@@ -170,7 +170,7 @@ npx @capgo/cli bundle upload --channel v3
 
 ## Strategy 2: Semantic Versioning Controls
 
-Use Capgo's built-in semantic versioning controls to prevent updates across version boundaries.
+Use Capgo's built-in [semantic versioning controls](/semver_tester/) to prevent updates across version boundaries.
 
 ### Disable Auto-Update Across Major Versions
 
@@ -198,7 +198,7 @@ npx @capgo/cli channel set stable --disable-auto-update none
 ```
 
 <Aside type="caution" title="Semantic Versioning Required">
-  This strategy only works if you follow semantic versioning (semver) for your app versions. Ensure your version numbers follow the `MAJOR.MINOR.PATCH` format.
+  This strategy only works if you follow [semantic versioning (semver)](/semver_tester/) for your app versions. Ensure your version numbers follow the `MAJOR.MINOR.PATCH` format.
 </Aside>
 
 ## Strategy 3: Native Version Constraints

--- a/apps/docs/src/content/docs/docs/plugins/updater/commonProblems.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/updater/commonProblems.mdx
@@ -109,11 +109,11 @@ Related docs:
 
 **Cause**
 
-Device baseline version is missing (`unknown`) or not valid semver.
+Device baseline version is missing (`unknown`) or not [valid semver](/semver_tester/).
 
 **Fix**
 
-- Set `plugins.CapacitorUpdater.version` to a valid semver like `1.2.3`.
+- Set `plugins.CapacitorUpdater.version` to a [valid semver](/semver_tester/) like `1.2.3`.
 - Sync and rebuild native app.
 
 Related docs:

--- a/apps/docs/src/content/docs/docs/plugins/updater/self-hosted/auto-update.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/updater/self-hosted/auto-update.mdx
@@ -70,7 +70,7 @@ In Auto-update mode the server should compare the versions and return the right 
 
 If you add "message" and "error" key, the version will not be set, and the message will be displayed in logs instead.
 
-`version` key should be in [`semver`](https://semver.org/) format.
+`version` key should be in [`semver`](/semver_tester/) format.
 
 The zip should have `index.html` as a file at the root, or only one folder at the root with `index.html` inside.
 

--- a/apps/docs/src/content/docs/docs/plugins/updater/self-hosted/handling-updates.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/updater/self-hosted/handling-updates.mdx
@@ -100,7 +100,7 @@ And if no update or error, add the `message` key and optionally an `error`:
 
 - **`checksum`**: SHA256 hash of your bundle zip file for integrity verification
 - **`session_key`**: Required only for encrypted bundles - this is the `ivSessionKey` returned by the encrypt command
-- **`version`**: Version identifier in semver format
+- **`version`**: Version identifier in [semver format](/semver_tester/)
 - **`url`**: HTTPS URL where the bundle can be downloaded
 
 ## Bundle Creation

--- a/apps/docs/src/content/docs/docs/public-api/bundles.mdx
+++ b/apps/docs/src/content/docs/docs/public-api/bundles.mdx
@@ -10,7 +10,7 @@ Bundles are the core update packages in Capgo. Each bundle contains the web asse
 ## Understanding Bundles
 
 A bundle represents a specific bundle (version) of your app's web content and includes:
-- **Bundle (version)**: Semantic version number for the bundle
+- **Bundle (version)**: [Semantic version number](/semver_tester/) for the bundle
 - **Checksum**: Unique hash to verify bundle integrity
 - **Storage Info**: Details about where and how the bundle is stored
 - **Native Requirements**: Minimum native app version requirements
@@ -205,7 +205,7 @@ async function registerWithCapgo(appId, version, bundleUrl, checksum, apiKey) {
 | Parameter | Description | Required |
 |-----------|-------------|----------|
 | `app_id` | Your app identifier | Yes |
-| `version` | Bundle (version) semantic version (e.g., "1.2.3") | Yes |
+| `version` | Bundle (version) [semantic version](/semver_tester/) (e.g., "1.2.3") | Yes |
 | `external_url` | **Publicly accessible** HTTPS URL where bundle can be downloaded (no auth required) | Yes |
 | `checksum` | SHA256 checksum of the zip file | Yes |
 
@@ -336,7 +336,7 @@ main();
 
 ## Best Practices
 
-1. **Bundle (version) Management**: Use semantic versioning consistently
+1. **Bundle (version) Management**: Use [semantic versioning](/semver_tester/) consistently
 2. **Storage Optimization**: Remove unused bundles periodically
 3. **Bundle (version) Compatibility**: Set appropriate minimum native version requirements
 4. **Backup Strategy**: Maintain backups of critical bundles (versions)

--- a/apps/docs/src/content/docs/docs/public-api/channels.mdx
+++ b/apps/docs/src/content/docs/docs/public-api/channels.mdx
@@ -31,7 +31,7 @@ A channel represents a distribution track for your app updates. Each channel can
 1. **Testing Channel**: Maintain a testing channel for internal validation
 2. **Staged Rollout**: Use multiple channels for gradual update deployment
 3. **Platform Separation**: Create separate channels for iOS, Android, and Electron when needed
-4. **Bundle (version) Control**: Use semantic versioning for clear update paths
+4. **Bundle (version) Control**: Use [semantic versioning](/semver_tester/) for clear update paths
 
 ## Endpoints
 

--- a/apps/docs/src/content/docs/docs/webapp/logs.mdx
+++ b/apps/docs/src/content/docs/docs/webapp/logs.mdx
@@ -164,7 +164,7 @@ These codes come from the `stats_action` enum used by the dashboard API (`capgo/
 
 | Code(s) | Why the update was blocked |
 |---------|---------------------------|
-| `disableAutoUpdate`, `disableAutoUpdateToMajor`, `disableAutoUpdateToMinor`, `disableAutoUpdateToPatch`, `disableAutoUpdateMetadata`, `disableAutoUpdateUnderNative` | Channel strategy forbids this semver jump |
+| `disableAutoUpdate`, `disableAutoUpdateToMajor`, `disableAutoUpdateToMinor`, `disableAutoUpdateToPatch`, `disableAutoUpdateMetadata`, `disableAutoUpdateUnderNative` | Channel strategy forbids this [semver jump](/semver_tester/) |
 | `disablePlatformIos`, `disablePlatformAndroid` | Platform is disabled on the channel |
 | `disableDevBuild`, `disableEmulator` | Dev builds or emulators not allowed |
 | `cannotUpdateViaPrivateChannel`, `NoChannelOrOverride`, `channelMisconfigured` | Channel selection or override failed |

--- a/apps/web/src/components/landing/UpdateTypesSection.astro
+++ b/apps/web/src/components/landing/UpdateTypesSection.astro
@@ -21,7 +21,7 @@ const locale = Astro.locals.locale
       >
         <div class="mb-4 flex items-center gap-4">
           <div class="flex h-12 w-12 items-center justify-center transition-transform duration-300 group-hover:scale-110">
-            <svg class="h-8 w-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <svg class="h-8 w-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
             </svg>
           </div>
@@ -40,7 +40,7 @@ const locale = Astro.locals.locale
       >
         <div class="mb-4 flex items-center gap-4">
           <div class="flex h-12 w-12 items-center justify-center transition-transform duration-300 group-hover:scale-110">
-            <svg class="h-8 w-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <svg class="h-8 w-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
             </svg>
           </div>
@@ -59,7 +59,7 @@ const locale = Astro.locals.locale
       >
         <div class="mb-4 flex items-center gap-4">
           <div class="flex h-12 w-12 items-center justify-center transition-transform duration-300 group-hover:scale-110">
-            <svg class="h-8 w-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <svg class="h-8 w-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
               <path
                 stroke-linecap="round"
                 stroke-linejoin="round"
@@ -84,7 +84,7 @@ const locale = Astro.locals.locale
       >
         <div class="mb-4 flex items-center gap-4">
           <div class="flex h-12 w-12 items-center justify-center transition-transform duration-300 group-hover:scale-110">
-            <svg class="h-8 w-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <svg class="h-8 w-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
               ></path>
             </svg>
@@ -104,7 +104,7 @@ const locale = Astro.locals.locale
         class="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-6 py-3 text-base font-semibold text-white transition-all duration-200 hover:bg-blue-700 focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:outline-none"
       >
         Explore all update types
-        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
         </svg>
       </a>

--- a/apps/web/src/components/landing/UpdateTypesSection.astro
+++ b/apps/web/src/components/landing/UpdateTypesSection.astro
@@ -4,74 +4,89 @@ import { getRelativeLocaleUrl } from 'astro:i18n'
 const locale = Astro.locals.locale
 ---
 
-<section class="py-24 sm:py-32 bg-[#0d0d0d]">
-  <div class="px-6 mx-auto max-w-7xl lg:px-8">
+<section class="bg-[#0d0d0d] py-24 sm:py-32">
+  <div class="mx-auto max-w-7xl px-6 lg:px-8">
     <!-- Header -->
     <div class="mx-auto mb-16 max-w-2xl text-center">
-      <h2 class="text-sm font-semibold tracking-wide leading-7 uppercase text-[#44BCFF]">What's Possible</h2>
-      <p class="mt-2 text-3xl font-bold tracking-tight text-white sm:text-4xl">
-        Flexible update control
-      </p>
-      <p class="mt-6 text-lg leading-8 text-gray-400">
-        Choose the right combination of update types for your app's needs
-      </p>
+      <h2 class="text-sm leading-7 font-semibold tracking-wide text-[#44BCFF] uppercase">What's Possible</h2>
+      <p class="mt-2 text-3xl font-bold tracking-tight text-white sm:text-4xl">Flexible update control</p>
+      <p class="mt-6 text-lg leading-8 text-gray-400">Choose the right combination of update types for your app's needs</p>
     </div>
 
     <!-- 4 Category Cards -->
-    <div class="grid grid-cols-1 gap-8 mx-auto max-w-5xl md:grid-cols-2">
-      
+    <div class="mx-auto grid max-w-5xl grid-cols-1 gap-8 md:grid-cols-2">
       <!-- Apply Timing -->
-      <div class="flex flex-col p-8 rounded-2xl border transition-all duration-300 bg-[#1c1c1c] border-white/5 group hover:border-blue-500/30 hover:shadow-[0_0_30px_-10px_rgba(59,130,246,0.3)]">
-        <div class="flex items-center gap-4 mb-4">
-          <div class="flex justify-center items-center w-12 h-12 transition-transform duration-300 group-hover:scale-110">
-            <svg class="w-8 h-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+      <div
+        class="group flex flex-col rounded-2xl border border-white/5 bg-[#1c1c1c] p-8 transition-all duration-300 hover:border-blue-500/30 hover:shadow-[0_0_30px_-10px_rgba(59,130,246,0.3)]"
+      >
+        <div class="mb-4 flex items-center gap-4">
+          <div class="flex h-12 w-12 items-center justify-center transition-transform duration-300 group-hover:scale-110">
+            <svg class="h-8 w-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
             </svg>
           </div>
           <h3 class="text-xl font-semibold text-white">Apply timing</h3>
         </div>
         <p class="text-sm leading-relaxed text-gray-400">
-          Control when updates are applied: <span class="text-gray-300">default</span> (background), <span class="text-gray-300">atInstall</span>, <span class="text-gray-300">onLaunch</span>, or <span class="text-gray-300">always</span>
+          Control when updates are applied: <span class="text-gray-300">default</span> (background), <span class="text-gray-300">atInstall</span>, <span class="text-gray-300"
+            >onLaunch</span
+          >, or <span class="text-gray-300">always</span>
         </p>
       </div>
 
       <!-- Delay Conditions -->
-      <div class="flex flex-col p-8 rounded-2xl border transition-all duration-300 bg-[#1c1c1c] border-white/5 group hover:border-blue-500/30 hover:shadow-[0_0_30px_-10px_rgba(59,130,246,0.3)]">
-        <div class="flex items-center gap-4 mb-4">
-          <div class="flex justify-center items-center w-12 h-12 transition-transform duration-300 group-hover:scale-110">
-            <svg class="w-8 h-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      <div
+        class="group flex flex-col rounded-2xl border border-white/5 bg-[#1c1c1c] p-8 transition-all duration-300 hover:border-blue-500/30 hover:shadow-[0_0_30px_-10px_rgba(59,130,246,0.3)]"
+      >
+        <div class="mb-4 flex items-center gap-4">
+          <div class="flex h-12 w-12 items-center justify-center transition-transform duration-300 group-hover:scale-110">
+            <svg class="h-8 w-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
             </svg>
           </div>
           <h3 class="text-xl font-semibold text-white">Delay conditions</h3>
         </div>
         <p class="text-sm leading-relaxed text-gray-400">
-          Wait for specific conditions: <span class="text-gray-300">date</span>, <span class="text-gray-300">background</span>, <span class="text-gray-300">nativeVersion</span>, or <span class="text-gray-300">kill</span> event
+          Wait for specific conditions: <span class="text-gray-300">date</span>, <span class="text-gray-300">background</span>, <span class="text-gray-300">nativeVersion</span>, or <span
+            class="text-gray-300">kill</span
+          > event
         </p>
       </div>
 
       <!-- Version Blocking -->
-      <div class="flex flex-col p-8 rounded-2xl border transition-all duration-300 bg-[#1c1c1c] border-white/5 group hover:border-blue-500/30 hover:shadow-[0_0_30px_-10px_rgba(59,130,246,0.3)]">
-        <div class="flex items-center gap-4 mb-4">
-          <div class="flex justify-center items-center w-12 h-12 transition-transform duration-300 group-hover:scale-110">
-            <svg class="w-8 h-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z" />
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6z" />
+      <div
+        class="group flex flex-col rounded-2xl border border-white/5 bg-[#1c1c1c] p-8 transition-all duration-300 hover:border-blue-500/30 hover:shadow-[0_0_30px_-10px_rgba(59,130,246,0.3)]"
+      >
+        <div class="mb-4 flex items-center gap-4">
+          <div class="flex h-12 w-12 items-center justify-center transition-transform duration-300 group-hover:scale-110">
+            <svg class="h-8 w-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z"
+              ></path>
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6z"></path>
             </svg>
           </div>
           <h3 class="text-xl font-semibold text-white">Version blocking</h3>
         </div>
         <p class="text-sm leading-relaxed text-gray-400">
-          Control semver updates: <span class="text-gray-300">none</span>, <span class="text-gray-300">major</span>, <span class="text-gray-300">minor</span>, <span class="text-gray-300">patch</span>, or <span class="text-gray-300">metadata</span>
+          Control <a href={getRelativeLocaleUrl(locale, 'semver_tester')} class="text-gray-200 underline decoration-gray-500 underline-offset-4 transition hover:text-white"
+            >semver updates</a
+          >: <span class="text-gray-300">none</span>, <span class="text-gray-300">major</span>, <span class="text-gray-300">minor</span>, <span class="text-gray-300">patch</span>,
+          or <span class="text-gray-300">metadata</span>
         </p>
       </div>
 
       <!-- Delivery Types -->
-      <div class="flex flex-col p-8 rounded-2xl border transition-all duration-300 bg-[#1c1c1c] border-white/5 group hover:border-blue-500/30 hover:shadow-[0_0_30px_-10px_rgba(59,130,246,0.3)]">
-        <div class="flex items-center gap-4 mb-4">
-          <div class="flex justify-center items-center w-12 h-12 transition-transform duration-300 group-hover:scale-110">
-            <svg class="w-8 h-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+      <div
+        class="group flex flex-col rounded-2xl border border-white/5 bg-[#1c1c1c] p-8 transition-all duration-300 hover:border-blue-500/30 hover:shadow-[0_0_30px_-10px_rgba(59,130,246,0.3)]"
+      >
+        <div class="mb-4 flex items-center gap-4">
+          <div class="flex h-12 w-12 items-center justify-center transition-transform duration-300 group-hover:scale-110">
+            <svg class="h-8 w-8 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+              ></path>
             </svg>
           </div>
           <h3 class="text-xl font-semibold text-white">Delivery types</h3>
@@ -80,18 +95,17 @@ const locale = Astro.locals.locale
           <span class="text-gray-300">Full bundle</span> (entire JS bundle) or <span class="text-gray-300">Delta/manifest</span> (only changed files for faster updates)
         </p>
       </div>
-
     </div>
 
     <!-- CTA -->
-    <div class="flex justify-center mt-12">
+    <div class="mt-12 flex justify-center">
       <a
         href={getRelativeLocaleUrl(locale, 'docs/live-updates/update-types')}
-        class="inline-flex items-center gap-2 py-3 px-6 text-base font-semibold text-white rounded-lg transition-all duration-200 bg-blue-600 hover:bg-blue-700 focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:outline-none"
+        class="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-6 py-3 text-base font-semibold text-white transition-all duration-200 hover:bg-blue-700 focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:outline-none"
       >
         Explore all update types
-        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
         </svg>
       </a>
     </div>

--- a/apps/web/src/content/blog/en/capacitor-ota-updates-versioning-best-practices.md
+++ b/apps/web/src/content/blog/en/capacitor-ota-updates-versioning-best-practices.md
@@ -47,7 +47,7 @@ Managing Capacitor OTA updates requires a clear version control strategy. Here's
 
 ### Semantic Versioning Basics
 
-Semantic Versioning (SemVer) is a widely-used method for version numbering, structured as MAJOR.MINOR.PATCH. Each part has a specific role:
+[Semantic Versioning (SemVer)](/semver_tester/) is a widely-used method for version numbering, structured as MAJOR.MINOR.PATCH. Each part has a specific role:
 
 | **Version Component** | **Purpose** | **When to Update** |
 | --- | --- | --- |

--- a/apps/web/src/content/blog/en/how-to-use-semantic-versioning-with-capgo-ota-updates.md
+++ b/apps/web/src/content/blog/en/how-to-use-semantic-versioning-with-capgo-ota-updates.md
@@ -16,7 +16,7 @@ locale: en
 next_blog: ''
 ---
 
-**Want to simplify [app updates](https://capgo.app/plugins/capacitor-updater/) and version control?** Semantic Versioning (SemVer) combined with [Capgo](https://capgo.app/)'s Over-The-Air (OTA) updates makes managing [Capacitor](https://capacitorjs.com/) apps easier and faster. Here's how:
+**Want to simplify [app updates](https://capgo.app/plugins/capacitor-updater/) and version control?** [Semantic Versioning (SemVer)](/semver_tester/) combined with [Capgo](https://capgo.app/)'s Over-The-Air (OTA) updates makes managing [Capacitor](https://capacitorjs.com/) apps easier and faster. Here's how:
 
 -   **Semantic Versioning Basics:** Versions use the format `MAJOR.MINOR.PATCH`:
     

--- a/apps/web/src/content/blog/en/how-version-work-in-capgo.md
+++ b/apps/web/src/content/blog/en/how-version-work-in-capgo.md
@@ -31,7 +31,7 @@ All versions choices are decided server side by Capgo.
 
 ## Versioning system
 
-To manage version Capgo use the SemVer system, read more about it [here](https://semver.org/).
+To manage version Capgo use the SemVer system. Read the [SemVer specification](https://semver.org/) or check Capgo update compatibility with the [Semver Tester](/semver_tester/).
 ### Versions
 
 Where Capgo find the version to compare

--- a/apps/web/src/content/blog/en/version-control-tips-for-mobile-ci-cd.md
+++ b/apps/web/src/content/blog/en/version-control-tips-for-mobile-ci-cd.md
@@ -83,7 +83,7 @@ The right strategy depends on your team’s size, workflow, and goals. Whichever
 
 ### Version Numbering System
 
-Pair your branch management strategy with a clear version numbering system. The widely-used **semantic versioning** format (MAJOR.MINOR.PATCH) works well for mobile apps:
+Pair your branch management strategy with a clear version numbering system. The widely-used [**semantic versioning** format](/semver_tester/) (MAJOR.MINOR.PATCH) works well for mobile apps:
 
 -   **MAJOR**: For breaking API changes.
 -   **MINOR**: For backward-compatible feature updates.

--- a/apps/web/src/content/blog/en/version-tagging-in-capacitor-apps.md
+++ b/apps/web/src/content/blog/en/version-tagging-in-capacitor-apps.md
@@ -109,7 +109,7 @@ Keeping your Capacitor CLI updated ensures compatibility with version-specific f
 
 ### Semantic Version Basics
 
-Semantic Versioning (SemVer) uses the format **MAJOR.MINOR.PATCH**, where each part indicates a specific type of change:
+[Semantic Versioning (SemVer)](/semver_tester/) uses the format **MAJOR.MINOR.PATCH**, where each part indicates a specific type of change:
 
 | Version Component | Purpose |
 | --- | --- |


### PR DESCRIPTION
## What changed

- Added contextual links to `/semver_tester/` from core live-update docs, CLI/API docs, updater troubleshooting docs, and selected blog posts that already discuss SemVer or versioning.
- Added a homepage marketing link from the update type/version blocking section.

## Why

The Semver Tester page already exists, but it was only lightly connected from relevant content. These links make the tool easier to discover when readers are learning about Capgo versioning behavior.

## Validation

- `bunx prettier --write <touched files>`
- `bun run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Unified semantic versioning references across all guides and blog posts to point to an internal semver tester tool for improved navigation.
  * Converted plain-text semver mentions into hyperlinks throughout documentation for easier access to versioning guidance.
  * Clarified baseline version requirements in troubleshooting guides.

* **Style**
  * Updated landing page layout styling for better visual presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->