### PR TITLE
[codex] market WebView crash auto restart

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: "Install @capgo/capacitor-webview-crash, enable native WebView restart, and handle recovered crash or scheduled restart markers."
+description: "Install @capgo/capacitor-webview-crash, enable native WebView restart, manually replace the WebView from JavaScript, and handle recovered crash or restart markers."
 sidebar:
   order: 2
 ---
@@ -69,9 +69,19 @@ const config: CapacitorConfig = {
 export default config;
 ```
 
-Use `restartIntervalMs` for always-on apps where users may keep the same WebView open for days: kiosk screens, control-room dashboards, warehouse scanners, POS terminals, fleet tablets, and digital signage. Scheduled restarts write a pending marker with `reason: 'periodicRestart'`, then Android recreates the host activity and iOS reloads the `WKWebView` from native code.
+Use `restartIntervalMs` for always-on apps where users may keep the same WebView open for days: kiosk screens, control-room dashboards, warehouse scanners, POS terminals, fleet tablets, and digital signage. Scheduled restarts write a pending marker with `reason: 'periodicRestart'`, then Android recreates the host activity and iOS rebuilds the Capacitor bridge view so a new `WKWebView` is created from native code.
 
 Choose an interval your product can tolerate. A restart creates a fresh JavaScript runtime, so persist queued events, unsaved form state, and current navigation state before using aggressive intervals.
+
+## Manual native restart
+
+Call `restartWebView()` when the current JavaScript runtime decides the native WebView should be replaced proactively, for example after a memory-heavy workflow or before entering a long unattended session:
+
+```typescript
+await WebViewCrash.restartWebView();
+```
+
+The method writes a pending marker with `reason: 'manualRestart'`, resolves the current call, then asks native code to create a fresh WebView. Android recreates the host activity. iOS rebuilds the Capacitor bridge view so a new `WKWebView` is created instead of reloading the current page.
 
 ## API overview
 
@@ -103,11 +113,20 @@ const simulated = await WebViewCrash.simulateCrashRecovery();
 console.log(simulated.value);
 ```
 
+### `restartWebView`
+
+Stores a manual restart marker and asks native code to create a fresh WebView.
+
+```typescript
+await WebViewCrash.restartWebView();
+```
+
 ## Platform notes
 
 - Android stores crash metadata from `onRenderProcessGone`, including `didCrash` and `rendererPriorityAtExit` when the platform provides them.
 - iOS stores crash metadata from `webViewWebContentProcessDidTerminate` and adds the current application state when available.
-- Scheduled restarts use `reason: 'periodicRestart'`.
+- Manual and scheduled restarts create a fresh WebView. Android recreates the host activity; iOS rebuilds the Capacitor bridge view.
+- Scheduled restarts use `reason: 'periodicRestart'`; manual restarts use `reason: 'manualRestart'`.
 - Web does not detect real renderer crashes. The web implementation only simulates the behavior with local storage.
 
 ## Type reference
@@ -182,6 +201,7 @@ export type WebViewCrashReason =
   | 'renderProcessGone'
   | 'webContentProcessDidTerminate'
   | 'periodicRestart'
+  | 'manualRestart'
   | 'simulated';
 ```
 

--- a/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
@@ -56,11 +56,8 @@ const webViewCrash: WebViewCrashPluginConfig = {
   // Enabled by default. Keep this on for long-running apps.
   restartOnCrash: true,
 
-  // Use a fixed interval instead of cron by setting this above 0.
-  restartIntervalMs: 0,
-
   // Use a 5-field cron schedule in the device local timezone.
-  // When set, restartCron takes precedence over restartIntervalMs.
+  // Do not combine restartCron with an active restartIntervalMs.
   restartCron: '0 3 * * *',
 
   // Optional delay before restarting after a crash.
@@ -78,7 +75,7 @@ export default config;
 
 Use `restartIntervalMs` for always-on apps where users may keep the same WebView open for days: kiosk screens, control-room dashboards, warehouse scanners, POS terminals, fleet tablets, and digital signage. Use `restartCron` for wall-clock restarts such as `0 3 * * *` for a daily 03:00 restart in the device local timezone. Scheduled restarts write a pending marker with `reason: 'periodicRestart'`, then Android recreates the host activity and iOS rebuilds the Capacitor bridge view so a new `WKWebView` is created from native code.
 
-Choose an interval or cron schedule your product can tolerate. `restartCron` supports `*`, lists, ranges, and steps, and takes precedence over `restartIntervalMs` when both are set. A restart creates a fresh JavaScript runtime, so persist queued events, unsaved form state, and current navigation state before using aggressive schedules.
+Choose an interval or cron schedule your product can tolerate. `restartCron` supports `*`, lists, ranges, and steps. Do not configure both schedules at once: native initialization throws a fatal config error when `restartCron` is set and `restartIntervalMs` is greater than `0`. A restart creates a fresh JavaScript runtime, so persist queued events, unsaved form state, and current navigation state before using aggressive schedules.
 
 ## Manual native restart
 
@@ -163,7 +160,8 @@ export interface WebViewCrashPluginConfig {
   /**
    * Fixed native interval, in milliseconds, for proactively replacing long-running WebViews.
    *
-   * Set to `0` to disable scheduled restarts.
+   * Set to `0` to disable interval restarts. Do not combine an active interval
+   * with `restartCron`; native initialization fails fast when both schedules are configured.
    *
    * @default 0
    */
@@ -179,7 +177,8 @@ export interface WebViewCrashPluginConfig {
    * - `0 3 * * *` restarts every day at 03:00.
    * - `0,30 * * * *` restarts every 30 minutes.
    *
-   * When set, this takes precedence over `restartIntervalMs`.
+   * Do not combine this with an active `restartIntervalMs`; native initialization
+   * fails fast when both schedules are configured.
    */
   restartCron?: string;
 

--- a/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
@@ -56,8 +56,12 @@ const webViewCrash: WebViewCrashPluginConfig = {
   // Enabled by default. Keep this on for long-running apps.
   restartOnCrash: true,
 
-  // Recycle the WebView every hour. Set to 0 to disable scheduled restarts.
-  restartIntervalMs: 60 * 60 * 1000,
+  // Use a fixed interval instead of cron by setting this above 0.
+  restartIntervalMs: 0,
+
+  // Use a 5-field cron schedule in the device local timezone.
+  // When set, restartCron takes precedence over restartIntervalMs.
+  restartCron: '0 3 * * *',
 
   // Optional delay before restarting after a crash.
   restartAfterCrashDelayMs: 0,
@@ -72,9 +76,9 @@ const config: CapacitorConfig = {
 export default config;
 ```
 
-Use `restartIntervalMs` for always-on apps where users may keep the same WebView open for days: kiosk screens, control-room dashboards, warehouse scanners, POS terminals, fleet tablets, and digital signage. Scheduled restarts write a pending marker with `reason: 'periodicRestart'`, then Android recreates the host activity and iOS rebuilds the Capacitor bridge view so a new `WKWebView` is created from native code.
+Use `restartIntervalMs` for always-on apps where users may keep the same WebView open for days: kiosk screens, control-room dashboards, warehouse scanners, POS terminals, fleet tablets, and digital signage. Use `restartCron` for wall-clock restarts such as `0 3 * * *` for a daily 03:00 restart in the device local timezone. Scheduled restarts write a pending marker with `reason: 'periodicRestart'`, then Android recreates the host activity and iOS rebuilds the Capacitor bridge view so a new `WKWebView` is created from native code.
 
-Choose an interval your product can tolerate. A restart creates a fresh JavaScript runtime, so persist queued events, unsaved form state, and current navigation state before using aggressive intervals.
+Choose an interval or cron schedule your product can tolerate. `restartCron` supports `*`, lists, ranges, and steps, and takes precedence over `restartIntervalMs` when both are set. A restart creates a fresh JavaScript runtime, so persist queued events, unsaved form state, and current navigation state before using aggressive schedules.
 
 ## Manual native restart
 
@@ -164,6 +168,20 @@ export interface WebViewCrashPluginConfig {
    * @default 0
    */
   restartIntervalMs?: number;
+
+  /**
+   * Cron schedule for proactively replacing long-running WebViews.
+   *
+   * Uses standard 5-field cron syntax in the device local timezone:
+   * `minute hour day-of-month month day-of-week`.
+   *
+   * Examples:
+   * - `0 3 * * *` restarts every day at 03:00.
+   * - `0,30 * * * *` restarts every 30 minutes.
+   *
+   * When set, this takes precedence over `restartIntervalMs`.
+   */
+  restartCron?: string;
 
   /**
    * Delay, in milliseconds, before restarting after a crash.

--- a/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
@@ -50,19 +50,22 @@ Set restart options in `capacitor.config.ts` so the decision stays in native cod
 
 ```typescript
 import type { CapacitorConfig } from '@capacitor/cli';
+import type { WebViewCrashPluginConfig } from '@capgo/capacitor-webview-crash';
+
+const webViewCrash: WebViewCrashPluginConfig = {
+  // Enabled by default. Keep this on for long-running apps.
+  restartOnCrash: true,
+
+  // Recycle the WebView every hour. Set to 0 to disable scheduled restarts.
+  restartIntervalMs: 60 * 60 * 1000,
+
+  // Optional delay before restarting after a crash.
+  restartAfterCrashDelayMs: 0,
+};
 
 const config: CapacitorConfig = {
   plugins: {
-    WebViewCrash: {
-      // Enabled by default. Keep this on for long-running apps.
-      restartOnCrash: true,
-
-      // Recycle the WebView every hour. Set to 0 to disable scheduled restarts.
-      restartIntervalMs: 60 * 60 * 1000,
-
-      // Optional delay before restarting after a crash.
-      restartAfterCrashDelayMs: 0,
-    },
+    WebViewCrash: webViewCrash,
   },
 };
 
@@ -139,6 +142,35 @@ export interface PendingCrashInfoResult {
    * Stored crash or restart metadata, or `null` when no marker is pending.
    */
   value: WebViewCrashInfo | null;
+}
+```
+
+### `WebViewCrashPluginConfig`
+
+```typescript
+export interface WebViewCrashPluginConfig {
+  /**
+   * Restart the WebView from native code when the renderer process dies.
+   *
+   * @default true
+   */
+  restartOnCrash?: boolean;
+
+  /**
+   * Fixed native interval, in milliseconds, for proactively replacing long-running WebViews.
+   *
+   * Set to `0` to disable scheduled restarts.
+   *
+   * @default 0
+   */
+  restartIntervalMs?: number;
+
+  /**
+   * Delay, in milliseconds, before restarting after a crash.
+   *
+   * @default 0
+   */
+  restartAfterCrashDelayMs?: number;
 }
 ```
 

--- a/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: "Install @capgo/capacitor-webview-crash and handle recovered WebView crashes in your Capacitor app startup flow."
+description: "Install @capgo/capacitor-webview-crash, enable native WebView restart, and handle recovered crash or scheduled restart markers."
 sidebar:
   order: 2
 ---
@@ -8,8 +8,8 @@ sidebar:
 ## Install
 
 ```bash
-bun add @capgo/capacitor-webview-crash
-bunx cap sync
+npm install @capgo/capacitor-webview-crash
+npx cap sync
 ```
 
 ## Import
@@ -20,7 +20,7 @@ import { WebViewCrash } from '@capgo/capacitor-webview-crash';
 
 ## Recommended recovery flow
 
-Attach the listener as early as possible in your app startup so the recovered runtime can react before users continue navigating:
+Attach listeners as early as possible in your app startup so the recovered runtime can react before users continue navigating:
 
 ```typescript
 import { WebViewCrash } from '@capgo/capacitor-webview-crash';
@@ -32,18 +32,52 @@ await WebViewCrash.addListener('webViewRestoredAfterCrash', async (info) => {
   await WebViewCrash.clearPendingCrashInfo();
 });
 
+await WebViewCrash.addListener('webViewRestoredAfterRestart', async (info) => {
+  console.log('Recovered after a native WebView restart', info);
+  await WebViewCrash.clearPendingCrashInfo();
+});
+
 const pending = await WebViewCrash.getPendingCrashInfo();
 // Note: the listener callback may have already cleared the pending marker.
 if (pending.value) {
-  console.log('Pending crash marker', pending.value);
+  console.log('Pending crash or restart marker', pending.value);
 }
 ```
+
+## Native auto restart
+
+Set restart options in `capacitor.config.ts` so the decision stays in native code even when the JavaScript runtime has crashed or has not loaded yet:
+
+```typescript
+import type { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  plugins: {
+    WebViewCrash: {
+      // Enabled by default. Keep this on for long-running apps.
+      restartOnCrash: true,
+
+      // Recycle the WebView every hour. Set to 0 to disable scheduled restarts.
+      restartIntervalMs: 60 * 60 * 1000,
+
+      // Optional delay before restarting after a crash.
+      restartAfterCrashDelayMs: 0,
+    },
+  },
+};
+
+export default config;
+```
+
+Use `restartIntervalMs` for always-on apps where users may keep the same WebView open for days: kiosk screens, control-room dashboards, warehouse scanners, POS terminals, fleet tablets, and digital signage. Scheduled restarts write a pending marker with `reason: 'periodicRestart'`, then Android recreates the host activity and iOS reloads the `WKWebView` from native code.
+
+Choose an interval your product can tolerate. A restart creates a fresh JavaScript runtime, so persist queued events, unsaved form state, and current navigation state before using aggressive intervals.
 
 ## API overview
 
 ### `getPendingCrashInfo`
 
-Returns the stored native crash marker, or `null` when nothing is pending.
+Returns the stored native crash or restart marker, or `null` when nothing is pending.
 
 ```typescript
 const pending = await WebViewCrash.getPendingCrashInfo();
@@ -54,7 +88,7 @@ if (pending.value) {
 
 ### `clearPendingCrashInfo`
 
-Clears the stored crash marker after your recovery handling is finished.
+Clears the stored marker after your recovery handling is finished.
 
 ```typescript
 await WebViewCrash.clearPendingCrashInfo();
@@ -73,6 +107,7 @@ console.log(simulated.value);
 
 - Android stores crash metadata from `onRenderProcessGone`, including `didCrash` and `rendererPriorityAtExit` when the platform provides them.
 - iOS stores crash metadata from `webViewWebContentProcessDidTerminate` and adds the current application state when available.
+- Scheduled restarts use `reason: 'periodicRestart'`.
 - Web does not detect real renderer crashes. The web implementation only simulates the behavior with local storage.
 
 ## Type reference
@@ -82,7 +117,7 @@ console.log(simulated.value);
 ```typescript
 export interface PendingCrashInfoResult {
   /**
-   * Stored crash metadata, or `null` when no marker is pending.
+   * Stored crash or restart metadata, or `null` when no marker is pending.
    */
   value: WebViewCrashInfo | null;
 }
@@ -93,12 +128,12 @@ export interface PendingCrashInfoResult {
 ```typescript
 export interface WebViewCrashInfo {
   /**
-   * Platform that detected and stored the crash marker.
+   * Platform that detected and stored the marker.
    */
   platform: WebViewCrashPlatform;
 
   /**
-   * Unix timestamp in milliseconds for when the crash marker was written.
+   * Unix timestamp in milliseconds for when the marker was written.
    */
   timestamp: number;
 
@@ -108,12 +143,12 @@ export interface WebViewCrashInfo {
   timestampISO: string;
 
   /**
-   * Platform-specific reason for the crash marker.
+   * Platform-specific reason for the crash or restart marker.
    */
   reason: WebViewCrashReason;
 
   /**
-   * Last known WebView URL when the crash marker was written.
+   * Last known WebView URL when the marker was written.
    */
   url?: string;
 
@@ -143,7 +178,11 @@ export type WebViewCrashPlatform = 'android' | 'ios' | 'web';
 ### `WebViewCrashReason`
 
 ```typescript
-export type WebViewCrashReason = 'renderProcessGone' | 'webContentProcessDidTerminate' | 'simulated';
+export type WebViewCrashReason =
+  | 'renderProcessGone'
+  | 'webContentProcessDidTerminate'
+  | 'periodicRestart'
+  | 'simulated';
 ```
 
 ### `WebViewCrashAppState`

--- a/apps/docs/src/content/docs/docs/plugins/webview-crash/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-crash/index.mdx
@@ -22,12 +22,12 @@ hero:
 
 ## Overview
 
-This plugin stores a native marker when the previous Capacitor WebView process dies or is recycled, then exposes that marker to the next JavaScript runtime after the app recovers. It can also restart the WebView from native code after a crash, on a fixed interval, or when JavaScript explicitly requests `restartWebView()`, which helps kiosk, POS, dashboard, scanner, and signage apps avoid memory buildup during long sessions.
+This plugin stores a native marker when the previous Capacitor WebView process dies or is recycled, then exposes that marker to the next JavaScript runtime after the app recovers. It can also restart the WebView from native code after a crash, on a fixed interval, on a cron schedule, or when JavaScript explicitly requests `restartWebView()`, which helps kiosk, POS, dashboard, scanner, and signage apps avoid memory buildup during long sessions.
 
 ## Core Capabilities
 
 - Native crash restart - Restarts the WebView from iOS or Android when the renderer process dies.
-- Scheduled restart - Recycles long-running WebViews on a native timer using `restartIntervalMs`.
+- Scheduled restart - Recycles long-running WebViews on a native timer using `restartIntervalMs` or a wall-clock `restartCron`.
 - Manual native restart - Lets JavaScript request a fresh native WebView with `restartWebView()` without doing a page reload.
 - Typed Capacitor config - Exposes `WebViewCrashPluginConfig` for `plugins.WebViewCrash` in `capacitor.config.ts`.
 - `getPendingCrashInfo` - Returns the stored native crash or restart marker, or `null` when nothing is pending.
@@ -54,6 +54,7 @@ The plugin augments Capacitor's `PluginsConfig` with a typed `WebViewCrash` conf
 export interface WebViewCrashPluginConfig {
   restartOnCrash?: boolean;
   restartIntervalMs?: number;
+  restartCron?: string;
   restartAfterCrashDelayMs?: number;
 }
 ```
@@ -62,7 +63,8 @@ export interface WebViewCrashPluginConfig {
 
 - This plugin detects recovery after a WebView crash. It does not prevent the underlying crash.
 - The recovered JavaScript runtime is new, so any in-memory state from the previous WebView is already gone when this API fires.
-- Scheduled restarts write `reason: 'periodicRestart'`; manual restarts write `reason: 'manualRestart'`. Persist unsaved state before enabling short restart intervals or calling `restartWebView()`.
+- Scheduled restarts write `reason: 'periodicRestart'`; manual restarts write `reason: 'manualRestart'`. Persist unsaved state before enabling short restart intervals, cron schedules, or calling `restartWebView()`.
+- `restartCron` uses 5-field cron syntax in the device local timezone, for example `0 3 * * *` for a daily 03:00 restart. When both `restartCron` and `restartIntervalMs` are set, `restartCron` takes precedence.
 - On Android, extra fields such as `didCrash` and `rendererPriorityAtExit` may be available.
 - On iOS, the plugin records `appState` when the terminated WebView process is observed. Manual and scheduled restarts rebuild the Capacitor bridge view so a new `WKWebView` is created.
 

--- a/apps/docs/src/content/docs/docs/plugins/webview-crash/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-crash/index.mdx
@@ -64,7 +64,7 @@ export interface WebViewCrashPluginConfig {
 - This plugin detects recovery after a WebView crash. It does not prevent the underlying crash.
 - The recovered JavaScript runtime is new, so any in-memory state from the previous WebView is already gone when this API fires.
 - Scheduled restarts write `reason: 'periodicRestart'`; manual restarts write `reason: 'manualRestart'`. Persist unsaved state before enabling short restart intervals, cron schedules, or calling `restartWebView()`.
-- `restartCron` uses 5-field cron syntax in the device local timezone, for example `0 3 * * *` for a daily 03:00 restart. When both `restartCron` and `restartIntervalMs` are set, `restartCron` takes precedence.
+- `restartCron` uses 5-field cron syntax in the device local timezone, for example `0 3 * * *` for a daily 03:00 restart. Do not configure both schedules at once: native initialization throws a fatal config error when `restartCron` is set and `restartIntervalMs` is greater than `0`.
 - On Android, extra fields such as `didCrash` and `rendererPriorityAtExit` may be available.
 - On iOS, the plugin records `appState` when the terminated WebView process is observed. Manual and scheduled restarts rebuild the Capacitor bridge view so a new `WKWebView` is created.
 

--- a/apps/docs/src/content/docs/docs/plugins/webview-crash/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-crash/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "@capgo/capacitor-webview-crash"
-description: "Capacitor plugin for detecting recovered WebView crashes and exposing the pending crash marker to the next JavaScript runtime."
+description: "Detect recovered WebView crashes, restart dead WebViews natively, and recycle long-running WebViews on a fixed interval before memory pressure turns into an OOM."
 tableOfContents: false
 next: false
 prev: false
@@ -8,7 +8,7 @@ sidebar:
   order: 1
   label: "Introduction"
 hero:
-  tagline: "Detect recovered WebView crashes and handle lost in-memory state after the WebView restarts."
+  tagline: "Native WebView crash recovery and scheduled WebView recycling for long-running Capacitor apps."
   actions:
     - text: Get started
       link: /docs/plugins/webview-crash/getting-started/
@@ -22,29 +22,32 @@ hero:
 
 ## Overview
 
-This plugin stores a native crash marker when the previous Capacitor WebView process dies, then exposes that marker to the next JavaScript runtime after the app recovers.
+This plugin stores a native marker when the previous Capacitor WebView process dies or is recycled, then exposes that marker to the next JavaScript runtime after the app recovers. It can also restart the WebView from native code after a crash or on a fixed interval, which helps kiosk, POS, dashboard, scanner, and signage apps avoid memory buildup during long sessions.
 
 ## Core Capabilities
 
-- `getPendingCrashInfo` - Returns the stored native crash marker, or `null` when nothing is pending.
-- `clearPendingCrashInfo` - Clears the stored crash marker after your app has restored its state.
+- Native crash restart - Restarts the WebView from iOS or Android when the renderer process dies.
+- Scheduled restart - Recycles long-running WebViews on a native timer using `restartIntervalMs`.
+- `getPendingCrashInfo` - Returns the stored native crash or restart marker, or `null` when nothing is pending.
+- `clearPendingCrashInfo` - Clears the stored marker after your app has restored its state.
 - `simulateCrashRecovery` - Creates a fake crash marker so recovery flows can be tested locally.
-- `addListener` - Fires `webViewRestoredAfterCrash` when a listener attaches and a crash marker is still pending.
+- `addListener` - Fires `webViewRestoredAfterCrash` for crash markers and `webViewRestoredAfterRestart` for any native restart marker.
 
 ## Public API
 
 | Method | Description |
 | --- | --- |
-| `getPendingCrashInfo` | Returns the stored native crash marker, or `null` when nothing is pending. |
-| `clearPendingCrashInfo` | Clears the stored crash marker after your app has restored its state. |
+| `getPendingCrashInfo` | Returns the stored native crash or restart marker, or `null` when nothing is pending. |
+| `clearPendingCrashInfo` | Clears the stored marker after your app has restored its state. |
 | `simulateCrashRecovery` | Creates a fake crash marker so recovery flows can be tested locally. |
-| `addListener` | Fires `webViewRestoredAfterCrash` when a listener attaches and a crash marker is still pending. |
+| `addListener` | Fires `webViewRestoredAfterCrash` or `webViewRestoredAfterRestart` when a listener attaches and a matching marker is still pending. |
 | `removeAllListeners` | Removes all plugin listeners. |
 
 ## Notes
 
 - This plugin detects recovery after a WebView crash. It does not prevent the underlying crash.
 - The recovered JavaScript runtime is new, so any in-memory state from the previous WebView is already gone when this API fires.
+- Scheduled restarts write `reason: 'periodicRestart'`. Persist unsaved state before enabling short restart intervals.
 - On Android, extra fields such as `didCrash` and `rendererPriorityAtExit` may be available.
 - On iOS, the plugin records `appState` when the terminated WebView process is observed.
 

--- a/apps/docs/src/content/docs/docs/plugins/webview-crash/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-crash/index.mdx
@@ -29,6 +29,7 @@ This plugin stores a native marker when the previous Capacitor WebView process d
 - Native crash restart - Restarts the WebView from iOS or Android when the renderer process dies.
 - Scheduled restart - Recycles long-running WebViews on a native timer using `restartIntervalMs`.
 - Manual native restart - Lets JavaScript request a fresh native WebView with `restartWebView()` without doing a page reload.
+- Typed Capacitor config - Exposes `WebViewCrashPluginConfig` for `plugins.WebViewCrash` in `capacitor.config.ts`.
 - `getPendingCrashInfo` - Returns the stored native crash or restart marker, or `null` when nothing is pending.
 - `clearPendingCrashInfo` - Clears the stored marker after your app has restored its state.
 - `simulateCrashRecovery` - Creates a fake crash marker so recovery flows can be tested locally.
@@ -44,6 +45,18 @@ This plugin stores a native marker when the previous Capacitor WebView process d
 | `restartWebView` | Writes `reason: 'manualRestart'` and asks native code to create a fresh WebView. |
 | `addListener` | Fires `webViewRestoredAfterCrash` or `webViewRestoredAfterRestart` when a listener attaches and a matching marker is still pending. |
 | `removeAllListeners` | Removes all plugin listeners. |
+
+## Config Type
+
+The plugin augments Capacitor's `PluginsConfig` with a typed `WebViewCrash` config entry:
+
+```typescript
+export interface WebViewCrashPluginConfig {
+  restartOnCrash?: boolean;
+  restartIntervalMs?: number;
+  restartAfterCrashDelayMs?: number;
+}
+```
 
 ## Notes
 

--- a/apps/docs/src/content/docs/docs/plugins/webview-crash/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-crash/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "@capgo/capacitor-webview-crash"
-description: "Detect recovered WebView crashes, restart dead WebViews natively, and recycle long-running WebViews on a fixed interval before memory pressure turns into an OOM."
+description: "Detect recovered WebView crashes, restart dead WebViews natively, recycle long-running WebViews on a fixed interval, and let JavaScript request a native WebView replacement before memory pressure turns into an OOM."
 tableOfContents: false
 next: false
 prev: false
@@ -8,7 +8,7 @@ sidebar:
   order: 1
   label: "Introduction"
 hero:
-  tagline: "Native WebView crash recovery and scheduled WebView recycling for long-running Capacitor apps."
+  tagline: "Native WebView crash recovery, manual restart, and scheduled WebView recycling for long-running Capacitor apps."
   actions:
     - text: Get started
       link: /docs/plugins/webview-crash/getting-started/
@@ -22,12 +22,13 @@ hero:
 
 ## Overview
 
-This plugin stores a native marker when the previous Capacitor WebView process dies or is recycled, then exposes that marker to the next JavaScript runtime after the app recovers. It can also restart the WebView from native code after a crash or on a fixed interval, which helps kiosk, POS, dashboard, scanner, and signage apps avoid memory buildup during long sessions.
+This plugin stores a native marker when the previous Capacitor WebView process dies or is recycled, then exposes that marker to the next JavaScript runtime after the app recovers. It can also restart the WebView from native code after a crash, on a fixed interval, or when JavaScript explicitly requests `restartWebView()`, which helps kiosk, POS, dashboard, scanner, and signage apps avoid memory buildup during long sessions.
 
 ## Core Capabilities
 
 - Native crash restart - Restarts the WebView from iOS or Android when the renderer process dies.
 - Scheduled restart - Recycles long-running WebViews on a native timer using `restartIntervalMs`.
+- Manual native restart - Lets JavaScript request a fresh native WebView with `restartWebView()` without doing a page reload.
 - `getPendingCrashInfo` - Returns the stored native crash or restart marker, or `null` when nothing is pending.
 - `clearPendingCrashInfo` - Clears the stored marker after your app has restored its state.
 - `simulateCrashRecovery` - Creates a fake crash marker so recovery flows can be tested locally.
@@ -40,6 +41,7 @@ This plugin stores a native marker when the previous Capacitor WebView process d
 | `getPendingCrashInfo` | Returns the stored native crash or restart marker, or `null` when nothing is pending. |
 | `clearPendingCrashInfo` | Clears the stored marker after your app has restored its state. |
 | `simulateCrashRecovery` | Creates a fake crash marker so recovery flows can be tested locally. |
+| `restartWebView` | Writes `reason: 'manualRestart'` and asks native code to create a fresh WebView. |
 | `addListener` | Fires `webViewRestoredAfterCrash` or `webViewRestoredAfterRestart` when a listener attaches and a matching marker is still pending. |
 | `removeAllListeners` | Removes all plugin listeners. |
 
@@ -47,9 +49,9 @@ This plugin stores a native marker when the previous Capacitor WebView process d
 
 - This plugin detects recovery after a WebView crash. It does not prevent the underlying crash.
 - The recovered JavaScript runtime is new, so any in-memory state from the previous WebView is already gone when this API fires.
-- Scheduled restarts write `reason: 'periodicRestart'`. Persist unsaved state before enabling short restart intervals.
+- Scheduled restarts write `reason: 'periodicRestart'`; manual restarts write `reason: 'manualRestart'`. Persist unsaved state before enabling short restart intervals or calling `restartWebView()`.
 - On Android, extra fields such as `didCrash` and `rendererPriorityAtExit` may be available.
-- On iOS, the plugin records `appState` when the terminated WebView process is observed.
+- On iOS, the plugin records `appState` when the terminated WebView process is observed. Manual and scheduled restarts rebuild the Capacitor bridge view so a new `WKWebView` is created.
 
 ## Source Of Truth
 

--- a/apps/web/public/plugins-readme.md
+++ b/apps/web/public/plugins-readme.md
@@ -1371,7 +1371,7 @@ A collection of high-quality Capacitor plugins maintained by [Capgo](https://cap
 <td align="center" width="33%">
 <h3><a href="https://github.com/Cap-go/capacitor-webview-crash/">WebView Crash</a></h3>
 <p><code>@capgo/capacitor-webview-crash</code></p>
-<p>Detect recovered WebView crashes and tell the next JavaScript runtime what happened</p>
+<p>Restart crashed WebViews natively and recycle long-running WebViews on a fixed interval</p>
 <p>
 <a href="https://www.npmjs.com/package/@capgo/capacitor-webview-crash"><img src="https://img.shields.io/npm/dw/@capgo/capacitor-webview-crash?style=flat-square&label=downloads" alt="npm downloads"></a>
 <a href="https://github.com/Cap-go/capacitor-webview-crash/"><img src="https://img.shields.io/github/stars/Cap-go/capacitor-webview-crash?style=flat-square&label=stars" alt="GitHub stars"></a>

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -127,7 +127,7 @@ const actionDefinitionRows =
 @capgo/capacitor-wifi|github.com/Cap-go|Manage WiFi connectivity for your Capacitor app|https://github.com/Cap-go/capacitor-wifi/|WiFi
 @capgo/capacitor-screen-orientation|github.com/Cap-go|Screen orientation plugin with support for bypassing orientation lock|https://github.com/Cap-go/capacitor-screen-orientation/|Screen Orientation
 @capgo/capacitor-webview-guardian|github.com/Cap-go|Detect when the WebView was killed in the background and relaunch it on foreground|https://github.com/Cap-go/capacitor-webview-guardian/|WebView Guardian
-@capgo/capacitor-webview-crash|github.com/Cap-go|Detect recovered WebView crashes and tell the next JavaScript runtime what happened|https://github.com/Cap-go/capacitor-webview-crash/|WebView Crash
+@capgo/capacitor-webview-crash|github.com/Cap-go|Restart crashed WebViews natively and recycle long-running WebViews on a fixed interval|https://github.com/Cap-go/capacitor-webview-crash/|WebView Crash
 @capgo/capacitor-webview-version-checker|github.com/Cap-go|Capacitor plugin for checking Android WebView version freshness and guiding users to native update flows|https://github.com/Cap-go/capacitor-webview-version-checker/|WebView Version Checker
 @capgo/capacitor-firebase-analytics|github.com/Cap-go|Capacitor plugin for Firebase Analytics|https://github.com/Cap-go/capacitor-firebase/tree/main/packages/analytics|Firebase Analytics
 @capgo/capacitor-firebase-app|github.com/Cap-go|Capacitor plugin for Firebase App|https://github.com/Cap-go/capacitor-firebase/tree/main/packages/app|Firebase App

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-webview-crash.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-webview-crash.md
@@ -17,6 +17,7 @@ npx cap sync
 - Native restart after WebView crashes on iOS and Android.
 - Fixed-interval native WebView restart for kiosk, POS, signage, scanner, and dashboard apps that run for days.
 - `restartWebView` - Lets JavaScript request a fresh native WebView without doing a page reload.
+- `WebViewCrashPluginConfig` - Types `plugins.WebViewCrash` options in `capacitor.config.ts`.
 - `getPendingCrashInfo` - Returns the stored native crash or restart marker, or `null` when nothing is pending.
 - `clearPendingCrashInfo` - Clears the stored marker after your app has restored its state.
 - `simulateCrashRecovery` - Creates a fake crash marker so recovery flows can be tested locally.
@@ -51,14 +52,17 @@ Configure restart behavior in `capacitor.config.ts` so it keeps working when Jav
 
 ```typescript
 import type { CapacitorConfig } from '@capacitor/cli';
+import type { WebViewCrashPluginConfig } from '@capgo/capacitor-webview-crash';
+
+const webViewCrash: WebViewCrashPluginConfig = {
+  restartOnCrash: true,
+  restartIntervalMs: 60 * 60 * 1000,
+  restartAfterCrashDelayMs: 0,
+};
 
 const config: CapacitorConfig = {
   plugins: {
-    WebViewCrash: {
-      restartOnCrash: true,
-      restartIntervalMs: 60 * 60 * 1000,
-      restartAfterCrashDelayMs: 0,
-    },
+    WebViewCrash: webViewCrash,
   },
 };
 

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-webview-crash.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-webview-crash.md
@@ -56,7 +56,6 @@ import type { WebViewCrashPluginConfig } from '@capgo/capacitor-webview-crash';
 
 const webViewCrash: WebViewCrashPluginConfig = {
   restartOnCrash: true,
-  restartIntervalMs: 0,
   restartCron: '0 3 * * *',
   restartAfterCrashDelayMs: 0,
 };
@@ -70,7 +69,7 @@ const config: CapacitorConfig = {
 export default config;
 ```
 
-Scheduled restarts write `reason: 'periodicRestart'`. Use `restartIntervalMs` for fixed intervals or `restartCron` for a 5-field cron schedule in the device local timezone, such as `0 3 * * *` for a daily 03:00 restart. When both are set, `restartCron` takes precedence. Persist critical app state before using short schedules.
+Scheduled restarts write `reason: 'periodicRestart'`. Use `restartIntervalMs` for fixed intervals or `restartCron` for a 5-field cron schedule in the device local timezone, such as `0 3 * * *` for a daily 03:00 restart. Do not configure both schedules at once: native initialization throws a fatal config error when `restartCron` is set and `restartIntervalMs` is greater than `0`. Persist critical app state before using short schedules.
 
 ## Manual Native Restart
 

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-webview-crash.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-webview-crash.md
@@ -56,7 +56,8 @@ import type { WebViewCrashPluginConfig } from '@capgo/capacitor-webview-crash';
 
 const webViewCrash: WebViewCrashPluginConfig = {
   restartOnCrash: true,
-  restartIntervalMs: 60 * 60 * 1000,
+  restartIntervalMs: 0,
+  restartCron: '0 3 * * *',
   restartAfterCrashDelayMs: 0,
 };
 
@@ -69,7 +70,7 @@ const config: CapacitorConfig = {
 export default config;
 ```
 
-Scheduled restarts write `reason: 'periodicRestart'`. Persist critical app state before using short intervals.
+Scheduled restarts write `reason: 'periodicRestart'`. Use `restartIntervalMs` for fixed intervals or `restartCron` for a 5-field cron schedule in the device local timezone, such as `0 3 * * *` for a daily 03:00 restart. When both are set, `restartCron` takes precedence. Persist critical app state before using short schedules.
 
 ## Manual Native Restart
 

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-webview-crash.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-webview-crash.md
@@ -3,21 +3,24 @@ locale: en
 ---
 # Using @capgo/capacitor-webview-crash
 
-Detect recovered WebView crashes and tell the next JavaScript runtime what happened.
+Detect recovered WebView crashes, restart dead WebViews natively, and recycle long-running WebViews on a fixed interval before memory pressure turns into an OOM.
 
 ## Install
 
 ```bash
-bun add @capgo/capacitor-webview-crash
-bunx cap sync
+npm install @capgo/capacitor-webview-crash
+npx cap sync
 ```
 
 ## What This Plugin Exposes
 
-- `getPendingCrashInfo` - Returns the stored native crash marker, or `null` when nothing is pending.
-- `clearPendingCrashInfo` - Clears the stored crash marker after your app has restored its state.
+- Native restart after WebView crashes on iOS and Android.
+- Fixed-interval native WebView restart for kiosk, POS, signage, scanner, and dashboard apps that run for days.
+- `getPendingCrashInfo` - Returns the stored native crash or restart marker, or `null` when nothing is pending.
+- `clearPendingCrashInfo` - Clears the stored marker after your app has restored its state.
 - `simulateCrashRecovery` - Creates a fake crash marker so recovery flows can be tested locally.
 - `webViewRestoredAfterCrash` - Listener event fired when a crash marker is still pending in the recovered runtime.
+- `webViewRestoredAfterRestart` - Listener event fired when any native restart marker is still pending.
 
 ## Example Usage
 
@@ -29,12 +32,39 @@ await WebViewCrash.addListener('webViewRestoredAfterCrash', async (info) => {
   await WebViewCrash.clearPendingCrashInfo();
 });
 
+await WebViewCrash.addListener('webViewRestoredAfterRestart', async (info) => {
+  console.log('Recovered after a native WebView restart', info);
+  await WebViewCrash.clearPendingCrashInfo();
+});
+
 const pending = await WebViewCrash.getPendingCrashInfo();
 // Note: the listener callback may have already cleared the pending marker.
 if (pending.value) {
-  console.log('Pending crash marker', pending.value);
+  console.log('Pending crash or restart marker', pending.value);
 }
 ```
+
+## Native Auto Restart
+
+Configure restart behavior in `capacitor.config.ts` so it keeps working when JavaScript is unavailable:
+
+```typescript
+import type { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  plugins: {
+    WebViewCrash: {
+      restartOnCrash: true,
+      restartIntervalMs: 60 * 60 * 1000,
+      restartAfterCrashDelayMs: 0,
+    },
+  },
+};
+
+export default config;
+```
+
+Scheduled restarts write `reason: 'periodicRestart'`. Persist critical app state before using short intervals.
 
 ## Full Reference
 

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-webview-crash.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-webview-crash.md
@@ -16,6 +16,7 @@ npx cap sync
 
 - Native restart after WebView crashes on iOS and Android.
 - Fixed-interval native WebView restart for kiosk, POS, signage, scanner, and dashboard apps that run for days.
+- `restartWebView` - Lets JavaScript request a fresh native WebView without doing a page reload.
 - `getPendingCrashInfo` - Returns the stored native crash or restart marker, or `null` when nothing is pending.
 - `clearPendingCrashInfo` - Clears the stored marker after your app has restored its state.
 - `simulateCrashRecovery` - Creates a fake crash marker so recovery flows can be tested locally.
@@ -65,6 +66,16 @@ export default config;
 ```
 
 Scheduled restarts write `reason: 'periodicRestart'`. Persist critical app state before using short intervals.
+
+## Manual Native Restart
+
+Call `restartWebView()` when JavaScript decides the native WebView should be replaced proactively, for example after a memory-heavy workflow:
+
+```typescript
+await WebViewCrash.restartWebView();
+```
+
+The method writes `reason: 'manualRestart'` and asks native code to create a fresh WebView. Android recreates the host activity. iOS rebuilds the Capacitor bridge view so a new `WKWebView` is created instead of reloading the current page.
 
 ## Full Reference
 


### PR DESCRIPTION
## Summary

- Reposition WebView Crash docs around native crash restart and scheduled WebView recycling
- Add configuration and recovery examples for `restartIntervalMs`, `restartOnCrash`, and `webViewRestoredAfterRestart`
- Update plugin directory and generated public plugin README copy

## Validation

- `bun run check:docs-mirror`
- `bun run check` in `apps/docs`
- `bun run check` in `apps/web`
