### PR TITLE
[codex] add network diagnostics plugin docs

### DIFF
--- a/apps/docs/src/config/llmsCustomSets.ts
+++ b/apps/docs/src/config/llmsCustomSets.ts
@@ -74,6 +74,7 @@ Plugin Native Biometric|biometric authentication plugin for fingerprint and face
 Plugin Native Geocoder|native geocoding plugin for address lookup|docs/plugins/nativegeocoder/**
 Plugin Native Market|app store deep linking plugin|docs/plugins/native-market/**
 Plugin Native Navigation|native navbar, tabbar, and transition shell plugin for Capacitor WebView apps|docs/plugins/native-navigation/**
+Plugin Network Diagnostics|native network diagnostics plugin for URL reachability, TCP ports, WebSocket handshakes, speed, and packet loss checks|docs/plugins/network-diagnostics/**
 Plugin Native Purchases|in-app purchases, subscriptions, paywalls, revenue playbook, and monetization plugin|docs/plugins/native-purchases/**
 Plugin Navigation Bar|Android navigation bar customization plugin|docs/plugins/navigation-bar/**
 Plugin NFC|NFC reading and writing plugin|docs/plugins/nfc/**

--- a/apps/docs/src/config/sidebar.mjs
+++ b/apps/docs/src/config/sidebar.mjs
@@ -136,6 +136,11 @@ const pluginEntries = [
   ['Native Geocoder', 'nativegeocoder'],
   ['Native Market', 'native-market'],
   ['Native Navigation', 'native-navigation'],
+  [
+    'Network Diagnostics',
+    'network-diagnostics',
+    [linkItem('iOS setup', '/docs/plugins/network-diagnostics/ios'), linkItem('Android setup', '/docs/plugins/network-diagnostics/android')],
+  ],
   section(
     'Native Purchases',
     [

--- a/apps/docs/src/content/docs/docs/plugins/network-diagnostics/android.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/network-diagnostics/android.mdx
@@ -1,0 +1,28 @@
+---
+title: Android Setup
+description: "Android behavior and setup notes for @capgo/capacitor-network-diagnostics."
+sidebar:
+  order: 4
+---
+
+The plugin declares the required Android permissions automatically:
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+```
+
+## Native behavior
+
+- Connection status uses `ConnectivityManager` and `NetworkCapabilities`.
+- URL and download tests use native `HttpURLConnection`.
+- TCP port tests use native sockets.
+- WebSocket tests perform a native WebSocket upgrade handshake over TCP or TLS.
+
+## Captive portal and validated internet
+
+Android can expose whether the active network is internet validated or marked as captive portal capable. These flags help explain cases where the device is connected to Wi-Fi but the app cannot reach your backend.
+
+## Cleartext traffic
+
+Prefer `https://` and `wss://` targets. If you need to diagnose a plain `http://` or `ws://` endpoint on Android 9 or later, the host app may need a Network Security Config or `android:usesCleartextTraffic="true"` for that diagnostic target.

--- a/apps/docs/src/content/docs/docs/plugins/network-diagnostics/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/network-diagnostics/getting-started.mdx
@@ -1,0 +1,136 @@
+---
+title: Getting Started
+description: "Install @capgo/capacitor-network-diagnostics and run native network checks from your Capacitor app."
+sidebar:
+  order: 2
+---
+
+## Install
+
+```bash
+npm install @capgo/capacitor-network-diagnostics
+npx cap sync
+```
+
+## Import
+
+```typescript
+import { NetworkDiagnostics } from '@capgo/capacitor-network-diagnostics';
+```
+
+## Run a complete diagnostic report
+
+`runDiagnostics` is the fastest way to collect a support report for a user on a restricted network.
+
+```typescript
+const report = await NetworkDiagnostics.runDiagnostics({
+  urls: [{ url: 'https://api.example.com/health', method: 'HEAD' }],
+  ports: [{ host: 'api.example.com', port: 443 }],
+  websockets: [{ url: 'wss://ws.example.com/socket' }],
+  download: {
+    url: 'https://speed.example.com/5mb.bin',
+    maxBytes: 5 * 1024 * 1024,
+  },
+  packetLoss: {
+    mode: 'tcp',
+    host: 'api.example.com',
+    port: 443,
+    count: 10,
+  },
+});
+
+console.log(report.status.connectionType);
+console.log(report.issues);
+```
+
+## Check current network status
+
+```typescript
+const status = await NetworkDiagnostics.getNetworkStatus();
+
+console.log(status.connected);
+console.log(status.connectionType);
+console.log(status.internetReachable);
+console.log(status.captivePortal);
+```
+
+The exact flags depend on the platform. Android can report validated internet and captive portal state. iOS reports path status, interface type, expensive paths, and constrained paths through `Network.framework`.
+
+## Test API reachability
+
+```typescript
+const result = await NetworkDiagnostics.testUrl({
+  url: 'https://api.example.com/health',
+  method: 'HEAD',
+  timeoutMs: 5000,
+  followRedirects: true,
+});
+
+if (!result.reachable) {
+  console.warn(result.errorCode, result.errorMessage);
+}
+```
+
+Use a real health endpoint from your backend. A browser-only check can be hidden by WebView, CORS, proxy, or captive portal behavior, while this plugin uses native networking.
+
+## Test a TCP port
+
+```typescript
+const port = await NetworkDiagnostics.testPort({
+  host: 'api.example.com',
+  port: 443,
+  timeoutMs: 3000,
+});
+
+console.log(port.open, port.durationMs);
+```
+
+This is useful when a Wi-Fi access point blocks non-standard ports, MQTT, custom gateways, or a private backend while still allowing normal browsing.
+
+## Test WebSocket connectivity
+
+```typescript
+const socket = await NetworkDiagnostics.testWebSocket({
+  url: 'wss://ws.example.com/socket',
+  timeoutMs: 5000,
+});
+
+console.log(socket.open, socket.statusCode);
+```
+
+Use this when proxies or captive portals allow HTTPS pages but block WebSocket upgrade requests.
+
+## Measure download speed
+
+```typescript
+const speed = await NetworkDiagnostics.testDownloadSpeed({
+  url: 'https://speed.example.com/5mb.bin',
+  maxBytes: 5 * 1024 * 1024,
+  timeoutMs: 30000,
+});
+
+console.log(speed.mbps);
+```
+
+Use your own static file endpoint so the result reflects the network path your app needs.
+
+## Estimate packet loss
+
+```typescript
+const loss = await NetworkDiagnostics.testPacketLoss({
+  mode: 'tcp',
+  host: 'api.example.com',
+  port: 443,
+  count: 10,
+  timeoutMs: 3000,
+  intervalMs: 250,
+});
+
+console.log(loss.lossPercent);
+```
+
+Raw ICMP ping is not portable in App Store and Play Store apps. This method measures application-level packet loss by repeating TCP or HTTP probes.
+
+## Web fallback
+
+The web implementation is meant for development. Browsers cannot open raw TCP sockets, and URL checks may be limited by CORS. Use iOS or Android builds for real support diagnostics.

--- a/apps/docs/src/content/docs/docs/plugins/network-diagnostics/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/network-diagnostics/index.mdx
@@ -1,0 +1,56 @@
+---
+title: "@capgo/capacitor-network-diagnostics"
+description: "Capacitor plugin for native network diagnostics across URL reachability, TCP ports, WebSocket, speed, and packet loss checks."
+tableOfContents: false
+next: false
+prev: false
+sidebar:
+  order: 1
+  label: "Introduction"
+hero:
+  tagline: "Native diagnostics for blocked ports, captive portals, WebSockets, download speed, and packet loss."
+  actions:
+    - text: Get started
+      link: /docs/plugins/network-diagnostics/getting-started/
+      icon: right-arrow
+      variant: primary
+    - text: GitHub
+      link: https://github.com/Cap-go/capacitor-network-diagnostics/
+      icon: external
+      variant: minimal
+---
+
+## Overview
+
+`@capgo/capacitor-network-diagnostics` helps support teams diagnose restricted Wi-Fi, access point, carrier, firewall, captive portal, DNS, and proxy problems from the same native network stack used by the app.
+
+Use it when a user can open the app but cannot reach a specific API, TCP port, WebSocket endpoint, or download URL from a locked-down network.
+
+## Core Capabilities
+
+- `getNetworkStatus` - Read the native connection type and platform network flags.
+- `testUrl` - Check HTTP or HTTPS URL reachability with status code and latency.
+- `testPort` - Open a native TCP socket to a host and port.
+- `testWebSocket` - Validate a `ws://` or `wss://` handshake.
+- `testDownloadSpeed` - Measure native download throughput from your own test file endpoint.
+- `testPacketLoss` - Estimate application-level packet loss with repeated TCP or HTTP probes.
+- `runDiagnostics` - Run a combined diagnostic pass and return a compact issue list.
+
+Raw ICMP ping is not consistently available to App Store and Play Store apps, so packet loss uses repeated TCP or HTTP probes.
+
+## Public API
+
+| Method | Description |
+| --- | --- |
+| `getNetworkStatus` | Read the current native connection type and platform network flags. |
+| `testUrl` | Test whether an HTTP or HTTPS URL can be reached from native networking. |
+| `testPort` | Test whether a TCP host and port can be opened from native networking. |
+| `testWebSocket` | Test whether a WebSocket URL can complete its native handshake. |
+| `testDownloadSpeed` | Measure download throughput from a native HTTP request. |
+| `testPacketLoss` | Estimate application-level packet loss with repeated TCP or HTTP probes. |
+| `runDiagnostics` | Run several diagnostics and return a compact issue list. |
+| `getPluginVersion` | Return the native plugin version marker. |
+
+## Source Of Truth
+
+This reference is synced from `src/definitions.ts` in [capacitor-network-diagnostics](https://github.com/Cap-go/capacitor-network-diagnostics/).

--- a/apps/docs/src/content/docs/docs/plugins/network-diagnostics/ios.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/network-diagnostics/ios.mdx
@@ -1,0 +1,23 @@
+---
+title: iOS Setup
+description: "iOS behavior and setup notes for @capgo/capacitor-network-diagnostics."
+sidebar:
+  order: 3
+---
+
+No extra iOS permissions are required.
+
+## Native behavior
+
+- Connection status uses `Network.framework`.
+- URL and download tests use native `URLSession`.
+- TCP port tests use `NWConnection`.
+- WebSocket tests use `URLSessionWebSocketTask`.
+
+## App Transport Security
+
+Prefer `https://` and `wss://` targets. If you need to diagnose a plain `http://` or `ws://` endpoint, configure App Transport Security exceptions in the host app's `Info.plist`.
+
+## Interpreting constrained paths
+
+iOS can mark a path as constrained or expensive. Treat those flags as context for support reports, not as hard failure states. A constrained path can still pass URL, port, and WebSocket checks.

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -124,6 +124,7 @@ const actionDefinitionRows =
 @capgo/capacitor-printer|github.com/Cap-go|Capacitor plugin for printing documents, HTML, PDFs, images and web views|https://github.com/Cap-go/capacitor-printer/|Printer
 @capgo/capacitor-zip|github.com/Cap-go|A free Capacitor plugin for zipping and unzipping files on iOS, Android, and Web.|https://github.com/Cap-go/capacitor-zip/|Zip
 @capgo/capacitor-zebra-datawedge|github.com/Cap-go|Manage Zebra DataWedge profiles, notifications, queries, and scan triggers on Zebra Android devices|https://github.com/Cap-go/capacitor-zebra-datawedge/|Zebra DataWedge
+@capgo/capacitor-network-diagnostics|github.com/Cap-go|Run native network diagnostics for URL reachability, TCP ports, WebSocket handshakes, speed, and packet loss|https://github.com/Cap-go/capacitor-network-diagnostics/|Network Diagnostics
 @capgo/capacitor-wifi|github.com/Cap-go|Manage WiFi connectivity for your Capacitor app|https://github.com/Cap-go/capacitor-wifi/|WiFi
 @capgo/capacitor-screen-orientation|github.com/Cap-go|Screen orientation plugin with support for bypassing orientation lock|https://github.com/Cap-go/capacitor-screen-orientation/|Screen Orientation
 @capgo/capacitor-webview-guardian|github.com/Cap-go|Detect when the WebView was killed in the background and relaunch it on foreground|https://github.com/Cap-go/capacitor-webview-guardian/|WebView Guardian
@@ -265,6 +266,7 @@ const pluginIconsByName: Record<string, string> = {
   '@capgo/capacitor-proximity': 'Signal',
   '@capgo/capacitor-zip': 'ArchiveBox',
   '@capgo/capacitor-zebra-datawedge': 'QrCode',
+  '@capgo/capacitor-network-diagnostics': 'Signal',
   '@capgo/capacitor-wifi': 'Wifi',
   '@capgo/capacitor-screen-orientation': 'DevicePhoneMobile',
   '@capgo/capacitor-webview-guardian': 'ShieldExclamation',

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-network-diagnostics.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-network-diagnostics.md
@@ -1,0 +1,61 @@
+---
+locale: en
+---
+# Using @capgo/capacitor-network-diagnostics
+
+Native network diagnostics for Capacitor apps that need to debug restricted Wi-Fi, captive portals, blocked ports, WebSocket failures, slow downloads, and packet loss.
+
+## Install
+
+```bash
+npm install @capgo/capacitor-network-diagnostics
+npx cap sync
+```
+
+## What This Plugin Exposes
+
+- `getNetworkStatus` - Read the native connection type and platform network flags.
+- `testUrl` - Check HTTP or HTTPS URL reachability with status code and latency.
+- `testPort` - Open a native TCP socket to a host and port.
+- `testWebSocket` - Validate a `ws://` or `wss://` handshake.
+- `testDownloadSpeed` - Measure native download throughput.
+- `testPacketLoss` - Estimate application-level packet loss with repeated probes.
+- `runDiagnostics` - Run a combined diagnostic pass and return an issue list.
+
+## Example Usage
+
+```typescript
+import { NetworkDiagnostics } from '@capgo/capacitor-network-diagnostics';
+
+const report = await NetworkDiagnostics.runDiagnostics({
+  urls: [{ url: 'https://api.example.com/health' }],
+  ports: [{ host: 'api.example.com', port: 443 }],
+  websockets: [{ url: 'wss://ws.example.com/socket' }],
+  packetLoss: {
+    mode: 'tcp',
+    host: 'api.example.com',
+    port: 443,
+    count: 10,
+  },
+});
+
+console.log(report.status);
+console.log(report.issues);
+```
+
+## Support Workflow
+
+Ask the affected user to run diagnostics while connected to the problematic Wi-Fi or access point. Send results to support with:
+
+- connection type and OS network flags
+- failed URLs, ports, or WebSocket endpoints
+- download Mbps
+- packet loss percentage
+- native error codes and messages
+
+Raw ICMP ping is not portable on iOS and Android apps, so packet loss is measured with repeated TCP or HTTP probes.
+
+## Full Reference
+
+- GitHub: https://github.com/Cap-go/capacitor-network-diagnostics/
+- Docs: /docs/plugins/network-diagnostics/

--- a/apps/web/src/data/github-stars.json
+++ b/apps/web/src/data/github-stars.json
@@ -103,6 +103,7 @@
   "https://github.com/Cap-go/capacitor-printer/": 7,
   "https://github.com/Cap-go/capacitor-zip/": 3,
   "https://github.com/Cap-go/capacitor-zebra-datawedge/": 1,
+  "https://github.com/Cap-go/capacitor-network-diagnostics/": 0,
   "https://github.com/Cap-go/capacitor-wifi/": 8,
   "https://github.com/Cap-go/capacitor-screen-orientation/": 3,
   "https://github.com/Cap-go/capacitor-webview-guardian/": 7,

--- a/apps/web/src/data/github-stats.json
+++ b/apps/web/src/data/github-stats.json
@@ -1,5 +1,5 @@
 {
-  "repositoryCount": 123,
+  "repositoryCount": 124,
   "contributorCount": 540,
   "versionCount": 7673,
   "releaseCount": 3365,
@@ -934,6 +934,15 @@
       "releases": 2,
       "closedIssues": 0,
       "mergedPullRequests": 2
+    },
+    "Cap-go/capacitor-network-diagnostics": {
+      "url": "https://github.com/Cap-go/capacitor-network-diagnostics",
+      "stars": 0,
+      "contributors": 1,
+      "versionTags": 0,
+      "releases": 0,
+      "closedIssues": 0,
+      "mergedPullRequests": 0
     },
     "Cap-go/capacitor-wifi": {
       "url": "https://github.com/Cap-go/capacitor-wifi",

--- a/apps/web/src/data/npm-downloads.json
+++ b/apps/web/src/data/npm-downloads.json
@@ -103,6 +103,7 @@
   "@capgo/capacitor-printer": 27495,
   "@capgo/capacitor-zip": 2396,
   "@capgo/capacitor-zebra-datawedge": 110,
+  "@capgo/capacitor-network-diagnostics": 0,
   "@capgo/capacitor-wifi": 14977,
   "@capgo/capacitor-screen-orientation": 21560,
   "@capgo/capacitor-webview-guardian": 2631,


### PR DESCRIPTION
## Summary
- add @capgo/capacitor-network-diagnostics to plugin registry and metadata caches
- add docs pages for overview, getting started, iOS, and Android behavior
- add English plugin tutorial page

## Validation
- bun run fetch:stars
- bun run fetch:downloads
- bunx prettier --write <touched files>
- bun run check

## Notes
- metadata caches include zero values because this is a new GitHub/npm package entry.