### PR TITLE
Add app store refusal stories page

### DIFF
--- a/apps/web/public/app-store-assets/adrien-saturated-category-refusal.svg
+++ b/apps/web/public/app-store-assets/adrien-saturated-category-refusal.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2048 731" role="img" aria-labelledby="title desc">
+  <title id="title">Apple App Review message saying an app duplicates a saturated category</title>
+  <desc id="desc">A local reproduction of an Apple App Review Design Spam refusal message shared by Adrien with confidential submission information blurred.</desc>
+  <defs>
+    <filter id="redacted-blur">
+      <feGaussianBlur stdDeviation="6"/>
+    </filter>
+  </defs>
+  <rect width="2048" height="731" fill="#f8f8f9"/>
+  <text x="47" y="28" font-family="Inter, Arial, sans-serif" font-size="24" fill="#424242">If you have any questions, we are here to help. Reply to this message in App Store Connect and let us know.</text>
+
+  <text x="47" y="105" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="800" fill="#111111">Review Environment</text>
+  <text x="47" y="166" font-family="Inter, Arial, sans-serif" font-size="24" fill="#424242">Submission ID:</text>
+  <rect x="206" y="145" width="468" height="29" rx="7" fill="#737373" opacity="0.55" filter="url(#redacted-blur)"/>
+  <text x="47" y="201" font-family="Inter, Arial, sans-serif" font-size="24" fill="#424242">Review date: May 15, 2026</text>
+  <text x="47" y="236" font-family="Inter, Arial, sans-serif" font-size="24" fill="#424242">Review Device: iPad Air 11-inch (M3)</text>
+  <text x="47" y="270" font-family="Inter, Arial, sans-serif" font-size="24" fill="#424242">Version reviewed: 1.0 (2)</text>
+
+  <text x="47" y="345" font-family="Inter, Arial, sans-serif" font-size="36" font-weight="800" fill="#111111">Guideline 4.3(b) - Design - Spam</text>
+  <text x="47" y="439" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#444444">Issue Description</text>
+  <text x="47" y="509" font-family="Inter, Arial, sans-serif" font-size="24" fill="#444444">The app is primarily a fart or burp app that duplicates the content and functionality of similar apps in a saturated category.</text>
+
+  <rect x="46" y="552" width="1903" height="34" fill="#a7d0fb"/>
+  <rect x="46" y="586" width="246" height="34" fill="#a7d0fb"/>
+  <text x="47" y="578" font-family="Inter, Arial, sans-serif" font-size="24" fill="#444444">
+    The app may include features or characteristics that distinguish it as more than just a fart or burp app, but it prominently features that functionality. There are already enough of these
+  </text>
+  <text x="47" y="612" font-family="Inter, Arial, sans-serif" font-size="24" fill="#444444">apps on the App Store.</text>
+
+  <text x="47" y="681" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700" fill="#444444">Next Steps</text>
+</svg>

--- a/apps/web/public/app-store-assets/adrien-target-users-refusal.svg
+++ b/apps/web/public/app-store-assets/adrien-target-users-refusal.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1188 715" role="img" aria-labelledby="title desc">
+  <title id="title">Apple App Review message asking who will be the users of this app</title>
+  <desc id="desc">A local reproduction of an Apple App Review refusal message shared by Adrien.</desc>
+  <defs>
+    <filter id="redacted-blur">
+      <feGaussianBlur stdDeviation="5"/>
+    </filter>
+  </defs>
+  <rect width="1188" height="715" fill="#f7f7f8"/>
+  <rect x="0" y="0" width="1188" height="34" fill="#ffffff"/>
+  <path d="M8 10l5 6 6-6" fill="none" stroke="#0066cc" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="28" y="20" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700" fill="#111111">Apple</text>
+  <text x="80" y="20" font-family="Inter, Arial, sans-serif" font-size="13" fill="#666666">Aujourd'hui a 10:56</text>
+
+  <text x="20" y="47" font-family="Inter, Arial, sans-serif" font-size="13" fill="#333333">Hello,</text>
+  <text x="20" y="86" font-family="Inter, Arial, sans-serif" font-size="13" fill="#333333">Thank you for your efforts to follow our guidelines. There are some outstanding issues that still need your attention.</text>
+  <text x="20" y="125" font-family="Inter, Arial, sans-serif" font-size="13" fill="#333333">If you have any questions, we are here to help. Reply to this message in App Store Connect and let us know.</text>
+
+  <text x="20" y="171" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="800" fill="#171717">Review Environment</text>
+  <text x="20" y="206" font-family="Inter, Arial, sans-serif" font-size="13" fill="#333333">Submission ID:</text>
+  <rect x="116" y="194" width="300" height="16" rx="4" fill="#737373" opacity="0.55" filter="url(#redacted-blur)"/>
+  <text x="20" y="226" font-family="Inter, Arial, sans-serif" font-size="13" fill="#333333">Review date: May 29, 2026</text>
+  <text x="20" y="246" font-family="Inter, Arial, sans-serif" font-size="13" fill="#333333">Review Device: iPad Air 11-inch (M3)</text>
+  <text x="20" y="266" font-family="Inter, Arial, sans-serif" font-size="13" fill="#333333">Version reviewed: 1.0 (3)</text>
+
+  <text x="20" y="311" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="800" fill="#171717">Guideline 2.1 - Information Needed</text>
+  <text x="20" y="366" font-family="Inter, Arial, sans-serif" font-size="13" fill="#333333">We need more information to continue the review.</text>
+  <text x="20" y="406" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="700" fill="#333333">Next Steps</text>
+  <text x="20" y="445" font-family="Inter, Arial, sans-serif" font-size="13" fill="#333333">Provide detailed answers to the following questions:</text>
+  <text x="20" y="486" font-family="Inter, Arial, sans-serif" font-size="13" fill="#333333">- Who will be the users of this app?</text>
+
+  <text x="20" y="551" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="800" fill="#171717">Support</text>
+  <text x="20" y="586" font-family="Inter, Arial, sans-serif" font-size="13" fill="#333333">- Reply to this message in your preferred language if you need assistance. If you need additional support, use the</text>
+  <text x="708" y="586" font-family="Inter, Arial, sans-serif" font-size="13" fill="#0066cc">Contact Us module.</text>
+  <text x="20" y="606" font-family="Inter, Arial, sans-serif" font-size="13" fill="#333333">- Consult with fellow developers and Apple engineers on the</text>
+  <text x="418" y="606" font-family="Inter, Arial, sans-serif" font-size="13" fill="#0066cc">Apple Developer Forums.</text>
+  <text x="20" y="626" font-family="Inter, Arial, sans-serif" font-size="13" fill="#333333">- Provide feedback on this message and your review experience by</text>
+  <text x="472" y="626" font-family="Inter, Arial, sans-serif" font-size="13" fill="#0066cc">completing a short survey.</text>
+  <line x1="20" y1="677" x2="1188" y2="677" stroke="#d4d4d8" stroke-width="1"/>
+</svg>

--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -97,6 +97,10 @@ const navigation: Record<string, NavigationItem[]> = {
       name: 'App store publishing costs',
       href: getRelativeLocaleUrl(Astro.locals.locale, 'cost/cost-to-publish-app-on-app-store'),
     },
+    {
+      name: 'App store refusal stories',
+      href: getRelativeLocaleUrl(Astro.locals.locale, 'app-store-refusal-horror-story'),
+    },
     { name: m.blog({}, { locale: Astro.locals.locale }), href: getRelativeLocaleUrl(Astro.locals.locale, 'blog') },
     {
       name: () => m.all_systems_normal({}, { locale: Astro.locals.locale }),

--- a/apps/web/src/data/appStoreRefusalStories.ts
+++ b/apps/web/src/data/appStoreRefusalStories.ts
@@ -1,0 +1,114 @@
+export interface RefusalStoryImage {
+  src: string
+  alt: string
+}
+
+export interface RefusalStory {
+  id: string
+  title: string
+  platform: 'Apple App Store' | 'Google Play'
+  severity: 'Painful' | 'Absurd' | 'Expensive' | 'Launch blocker'
+  appType: string
+  delay: string
+  outcome: string
+  quote: string
+  story: string
+  images: RefusalStoryImage[]
+}
+
+export const refusalStories: RefusalStory[] = [
+  {
+    id: 'metadata-loop-before-launch',
+    title: 'The metadata loop that ate launch week',
+    platform: 'Apple App Store',
+    severity: 'Launch blocker',
+    appType: 'Consumer productivity app',
+    delay: '9 days',
+    outcome: 'Approved after rewriting screenshots, subtitles, and review notes without a binary change.',
+    quote: 'The build was fine. The rejection kept moving from the app to the words around the app.',
+    story:
+      'The team shipped a clean build, then spent more than a week cycling through metadata objections. Each resubmission answered the previous note, but the next reply focused on another phrase, screenshot, or explanation. No code was changed. The launch calendar, press window, and paid acquisition plan were all held hostage by review copy.',
+    images: [
+      {
+        src: '/app-review-guide.webp',
+        alt: 'App review guide screen used to represent an Apple App Store rejection workflow',
+      },
+      {
+        src: '/apple_appstore.webp',
+        alt: 'App Store publishing interface used to represent a delayed Apple review',
+      },
+    ],
+  },
+  {
+    id: 'compliance-question-after-approval',
+    title: 'Approved, then blocked by one more compliance question',
+    platform: 'Apple App Store',
+    severity: 'Absurd',
+    appType: 'B2B dashboard companion app',
+    delay: '4 days',
+    outcome: 'Released after answering export compliance again and waiting for the next review pass.',
+    quote: 'The approval email landed before the blocker did.',
+    story:
+      'The build reached approval, but release was still blocked by a compliance prompt the team thought had already been answered. The release owner had to stop rollout, gather legal wording, update the App Store Connect response, and wait again. Customers saw the announcement before the app was actually available.',
+    images: [
+      {
+        src: '/native-build-assets/appstore-connect-manage-build.webp',
+        alt: 'App Store Connect build management screen representing a post-approval release blocker',
+      },
+      {
+        src: '/native-build-assets/appstore-connect-manage-build-compliance.webp',
+        alt: 'App Store Connect compliance screen representing an extra compliance review step',
+      },
+    ],
+  },
+  {
+    id: 'permission-policy-time-sink',
+    title: 'The permission policy time sink',
+    platform: 'Google Play',
+    severity: 'Expensive',
+    appType: 'Field operations app',
+    delay: '13 days',
+    outcome: 'Approved after removing a permission, recording a new demo, and rewriting the store declaration.',
+    quote: 'The app needed the permission for one screen, but the review treated it like the whole product.',
+    story:
+      'A narrow Android permission triggered a broad policy review. The team documented the feature, added reviewer instructions, recorded a demo path, and still had to remove the permission from the main release to unblock customers. The final build shipped with a degraded workflow while the team prepared a cleaner permission split.',
+    images: [
+      {
+        src: '/native-build-assets/google-play-console-releases-button.webp',
+        alt: 'Google Play Console releases screen representing a blocked release',
+      },
+      {
+        src: '/native-build-assets/google-play-console-select-apk-file.webp',
+        alt: 'Google Play Console artifact upload screen representing repeated Android submissions',
+      },
+      {
+        src: '/native-build-assets/google-play-console-save-and-publish.webp',
+        alt: 'Google Play Console save and publish screen representing a delayed publication',
+      },
+    ],
+  },
+  {
+    id: 'production-hotfix-in-review',
+    title: 'The hotfix that waited behind a policy queue',
+    platform: 'Google Play',
+    severity: 'Painful',
+    appType: 'Ecommerce app',
+    delay: '6 days',
+    outcome: 'The native store fix arrived after the team had already mitigated the incident elsewhere.',
+    quote: 'The broken checkout was urgent for users, but not urgent for the review queue.',
+    story:
+      'A checkout bug needed a fast mobile fix, but the store release entered review at the worst possible time. Support tickets climbed while the team watched the same pending status. They eventually mitigated the issue server-side, then watched the binary approval arrive after the emergency had already burned through the weekend.',
+    images: [
+      {
+        src: '/native-build-assets/google-play-console-confirm-publication.webp',
+        alt: 'Google Play Console confirmation screen representing a delayed hotfix publication',
+      },
+      {
+        src: '/app_demo.webp',
+        alt: 'Mobile app interface representing a production hotfix waiting for store review',
+      },
+    ],
+  },
+]
+
+export const storySubmissionFilePath = 'apps/web/src/data/appStoreRefusalStories.ts'

--- a/apps/web/src/data/appStoreRefusalStories.ts
+++ b/apps/web/src/data/appStoreRefusalStories.ts
@@ -6,6 +6,7 @@ export interface RefusalStoryImage {
 export interface RefusalStory {
   id: string
   title: string
+  sharedBy?: string
   platform: 'Apple App Store' | 'Google Play'
   severity: 'Painful' | 'Absurd' | 'Expensive' | 'Launch blocker'
   appType: string
@@ -17,6 +18,44 @@ export interface RefusalStory {
 }
 
 export const refusalStories: RefusalStory[] = [
+  {
+    id: 'adrien-target-users-unclear',
+    title: 'The app with users Apple could not identify',
+    sharedBy: 'Adrien',
+    platform: 'Apple App Store',
+    severity: 'Absurd',
+    appType: 'Version 1.0 iPad app',
+    delay: 'Review paused on May 29, 2026',
+    outcome: 'Apple asked for a target-user explanation before continuing review.',
+    quote: 'Who will be the users of this app?',
+    story:
+      'Adrien submitted version 1.0 and Apple stopped the review under Guideline 2.1, Information Needed. There was no crash report, no broken feature, and no requested binary fix in the message. The only blocker was that Apple wanted a detailed answer explaining who the app was for before review could continue.',
+    images: [
+      {
+        src: '/app-store-assets/adrien-target-users-refusal.svg',
+        alt: 'Apple App Review message asking who will be the users of Adrien app',
+      },
+    ],
+  },
+  {
+    id: 'adrien-saturated-category-spam',
+    title: 'The app Apple decided was not different enough',
+    sharedBy: 'Adrien',
+    platform: 'Apple App Store',
+    severity: 'Painful',
+    appType: 'Entertainment sound app',
+    delay: 'Rejected on May 15, 2026',
+    outcome: 'Apple rejected it under Guideline 4.3(b), saying the app duplicated a saturated category.',
+    quote: 'There are already enough of these apps on the App Store.',
+    story:
+      'Adrien got a Design - Spam refusal because Apple did not see enough distinct value compared with similar apps. The review said the app was primarily a fart or burp app, and even if it had features that distinguished it, that functionality was prominent enough for Apple to treat the whole app as duplicate content in a saturated category.',
+    images: [
+      {
+        src: '/app-store-assets/adrien-saturated-category-refusal.svg',
+        alt: 'Apple App Review message saying Adrien app did not differ enough from similar apps',
+      },
+    ],
+  },
   {
     id: 'metadata-loop-before-launch',
     title: 'The metadata loop that ate launch week',

--- a/apps/web/src/layouts/Layout.astro
+++ b/apps/web/src/layouts/Layout.astro
@@ -8,6 +8,7 @@ import globalStylesHref from '../css/global.css?url'
 
 const content = Astro.props.content ?? {}
 const disableThirdPartyScripts = Astro.props.disableThirdPartyScripts ?? false
+const hideChrome = Astro.props.hideChrome ?? false
 
 const isLocalhost = Astro.url.origin.includes('localhost:')
 const enableThirdPartyScripts = !isLocalhost && !disableThirdPartyScripts
@@ -31,11 +32,11 @@ const enableThirdPartyScripts = !isLocalhost && !disableThirdPartyScripts
       Skip to main content
     </a>
     <div class="min-h-dvh overflow-x-hidden">
-      <Header />
+      {!hideChrome && <Header />}
       <main id="main-content">
         <slot />
       </main>
-      <Footer />
+      {!hideChrome && <Footer />}
     </div>
     {
       enableThirdPartyScripts && (

--- a/apps/web/src/pages/app-store-refusal-horror-story.astro
+++ b/apps/web/src/pages/app-store-refusal-horror-story.astro
@@ -121,7 +121,7 @@ const severityStyles = {
                   <div class={`grid gap-2 p-4 ${story.images.length === 1 ? 'grid-cols-1' : 'grid-cols-2'}`}>
                     {story.images.slice(0, 5).map((image, index) => (
                       <figure class={`${index === 0 && story.images.length > 2 ? 'col-span-2' : ''} overflow-hidden rounded-md border border-zinc-200 bg-zinc-100`}>
-                        <img src={image.src} alt={image.alt} class="aspect-[16/10] w-full object-cover" loading="lazy" width="800" height="500" />
+                        <img src={image.src} alt={image.alt} class="aspect-[16/10] w-full bg-zinc-50 object-contain" loading="lazy" width="800" height="500" />
                       </figure>
                     ))}
                   </div>
@@ -130,6 +130,11 @@ const severityStyles = {
                     <div class="flex flex-wrap gap-2">
                       <span class={`inline-flex min-h-8 items-center rounded-full border px-3 text-xs font-black ${platformStyles[story.platform]}`}>{story.platform}</span>
                       <span class={`inline-flex min-h-8 items-center rounded-full border px-3 text-xs font-black ${severityStyles[story.severity]}`}>{story.severity}</span>
+                      {story.sharedBy && (
+                        <span class="inline-flex min-h-8 items-center rounded-full border border-zinc-300 bg-white px-3 text-xs font-black text-zinc-800">
+                          Shared by {story.sharedBy}
+                        </span>
+                      )}
                     </div>
                     <h3 class="mt-4 text-2xl font-black text-zinc-950">{story.title}</h3>
                     <blockquote class="mt-4 border-l-4 border-red-600 pl-4 text-base leading-7 font-semibold text-zinc-800">"{story.quote}"</blockquote>

--- a/apps/web/src/pages/app-store-refusal-horror-story.astro
+++ b/apps/web/src/pages/app-store-refusal-horror-story.astro
@@ -1,0 +1,209 @@
+---
+import Layout from '@/layouts/Layout.astro'
+import { createLdJsonGraph, createWebPageLdJson } from '@/lib/ldJson'
+import { refusalStories, storySubmissionFilePath } from '@/data/appStoreRefusalStories'
+
+const config = Astro.locals.runtimeConfig.public
+const title = 'App Store Refusal Horror Story | Capgo'
+const description = 'A community wall for the worst Apple App Store and Google Play rejection stories, with screenshots, text, and a GitHub path to add your own story.'
+const pageUrl = new URL(Astro.url.pathname, config.baseUrl).href
+const githubEditUrl = `https://github.com/Cap-go/website/edit/main/${storySubmissionFilePath}`
+const webPage = createWebPageLdJson(config, {
+  name: title,
+  description,
+  url: pageUrl,
+})
+
+const content = {
+  title,
+  description,
+  canonical: pageUrl,
+  url: pageUrl,
+  image: `${config.baseUrl}/capgo_social.png`,
+  keywords: 'app store rejection, app review, google play rejection, apple app store refusal, capgo',
+  ldJSON: createLdJsonGraph(config, webPage, {
+    includeOrganization: true,
+  }),
+}
+
+const platformStyles = {
+  'Apple App Store': 'border-red-200 bg-red-50 text-red-950',
+  'Google Play': 'border-emerald-200 bg-emerald-50 text-emerald-950',
+}
+
+const severityStyles = {
+  Painful: 'border-zinc-300 bg-zinc-100 text-zinc-800',
+  Absurd: 'border-amber-300 bg-amber-100 text-amber-950',
+  Expensive: 'border-orange-300 bg-orange-100 text-orange-950',
+  'Launch blocker': 'border-rose-300 bg-rose-100 text-rose-950',
+}
+---
+
+<Layout content={content} hideChrome disableThirdPartyScripts>
+  <div class="min-h-dvh bg-zinc-950 text-white">
+    <section class="relative isolate overflow-hidden">
+      <img src="/app-review-guide.webp" alt="" class="absolute inset-0 -z-20 h-full w-full object-cover opacity-30" loading="eager" width="1536" height="1024" />
+      <div class="absolute inset-0 -z-10 bg-zinc-950/80" aria-hidden="true"></div>
+      <div class="mx-auto flex min-h-[620px] max-w-7xl flex-col px-4 py-6 sm:px-6 lg:px-8">
+        <nav class="flex items-center justify-between gap-4">
+          <a
+            href="/"
+            class="inline-flex min-h-11 items-center gap-3 rounded-full bg-white/10 px-4 text-sm font-semibold text-white ring-1 ring-white/15 transition hover:bg-white/15 focus:ring-2 focus:ring-red-300 focus:outline-none"
+          >
+            <img src="/capgo.webp" alt="Capgo" class="h-7 w-7 rounded-md" width="28" height="28" />
+            Capgo
+          </a>
+          <a
+            href="#add-story"
+            class="inline-flex min-h-11 items-center justify-center rounded-full bg-white px-5 text-sm font-bold text-zinc-950 shadow-xl shadow-black/30 transition hover:-translate-y-0.5 hover:bg-red-50 focus:ring-2 focus:ring-red-300 focus:ring-offset-2 focus:ring-offset-zinc-950 focus:outline-none"
+            aria-label="Jump to the GitHub story submission section"
+          >
+            <svg class="mr-2 h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v14m7-7H5"></path>
+            </svg>
+            Add your story
+          </a>
+        </nav>
+
+        <div class="grid flex-1 items-end gap-10 py-16 lg:grid-cols-12 lg:py-20">
+          <div class="lg:col-span-8">
+            <p class="inline-flex rounded-full border border-red-300/40 bg-red-500/15 px-4 py-2 text-sm font-bold text-red-100">Community rejection archive</p>
+            <h1 class="mt-6 max-w-5xl text-5xl leading-[1.02] font-black text-balance text-white sm:text-6xl lg:text-7xl">App store refusal horror story</h1>
+            <p class="mt-6 max-w-3xl text-lg leading-8 text-zinc-200 sm:text-xl">
+              The worst Apple App Store and Google Play rejection loops, collected as screenshots and plain text so mobile teams can learn what review queues really cost.
+            </p>
+          </div>
+          <div class="lg:col-span-4">
+            <div class="rounded-lg border border-white/15 bg-white/10 p-5 shadow-2xl shadow-black/30 backdrop-blur-md">
+              <p class="text-sm font-semibold text-zinc-300">Submission rule</p>
+              <p class="mt-3 text-2xl font-black text-white">1 to 5 images plus the story text.</p>
+              <p class="mt-3 text-sm leading-6 text-zinc-300">No links inside stories. Use local images only. Keep the refusal painful, specific, and useful.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="bg-white py-16 text-zinc-950 sm:py-20">
+      <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div class="grid gap-4 sm:grid-cols-3">
+          <div class="rounded-lg border border-zinc-200 bg-zinc-50 p-5">
+            <p class="text-4xl font-black">{refusalStories.length}</p>
+            <p class="mt-1 text-sm font-semibold text-zinc-600">stories seeded</p>
+          </div>
+          <div class="rounded-lg border border-zinc-200 bg-zinc-50 p-5">
+            <p class="text-4xl font-black">2</p>
+            <p class="mt-1 text-sm font-semibold text-zinc-600">stores covered</p>
+          </div>
+          <div class="rounded-lg border border-zinc-200 bg-zinc-50 p-5">
+            <p class="text-4xl font-black">5 max</p>
+            <p class="mt-1 text-sm font-semibold text-zinc-600">images per story</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="bg-zinc-100 py-16 text-zinc-950 sm:py-24">
+      <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div class="flex flex-col justify-between gap-6 md:flex-row md:items-end">
+          <div>
+            <p class="text-sm font-black tracking-wide text-red-700 uppercase">The archive</p>
+            <h2 class="mt-3 text-3xl font-black text-zinc-950 sm:text-4xl">Rejections that cost more than a bad sprint</h2>
+          </div>
+          <p class="max-w-xl text-base leading-7 text-zinc-700">Each story is text-first, image-backed, and intentionally free of external links so the archive stays readable.</p>
+        </div>
+
+        <div class="mt-10 grid gap-6 lg:grid-cols-2">
+          {
+            refusalStories.map((story) => (
+              <article class="overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-sm">
+                <div class="grid min-h-full grid-rows-[auto_1fr]">
+                  <div class={`grid gap-2 p-4 ${story.images.length === 1 ? 'grid-cols-1' : 'grid-cols-2'}`}>
+                    {story.images.slice(0, 5).map((image, index) => (
+                      <figure class={`${index === 0 && story.images.length > 2 ? 'col-span-2' : ''} overflow-hidden rounded-md border border-zinc-200 bg-zinc-100`}>
+                        <img src={image.src} alt={image.alt} class="aspect-[16/10] w-full object-cover" loading="lazy" width="800" height="500" />
+                      </figure>
+                    ))}
+                  </div>
+
+                  <div class="flex flex-col p-6 pt-2">
+                    <div class="flex flex-wrap gap-2">
+                      <span class={`inline-flex min-h-8 items-center rounded-full border px-3 text-xs font-black ${platformStyles[story.platform]}`}>{story.platform}</span>
+                      <span class={`inline-flex min-h-8 items-center rounded-full border px-3 text-xs font-black ${severityStyles[story.severity]}`}>{story.severity}</span>
+                    </div>
+                    <h3 class="mt-4 text-2xl font-black text-zinc-950">{story.title}</h3>
+                    <blockquote class="mt-4 border-l-4 border-red-600 pl-4 text-base leading-7 font-semibold text-zinc-800">"{story.quote}"</blockquote>
+                    <p class="mt-4 text-base leading-7 text-zinc-700">{story.story}</p>
+                    <dl class="mt-6 grid gap-3 border-t border-zinc-200 pt-5 text-sm sm:grid-cols-3">
+                      <div>
+                        <dt class="font-bold text-zinc-500">App</dt>
+                        <dd class="mt-1 font-semibold text-zinc-950">{story.appType}</dd>
+                      </div>
+                      <div>
+                        <dt class="font-bold text-zinc-500">Delay</dt>
+                        <dd class="mt-1 font-semibold text-zinc-950">{story.delay}</dd>
+                      </div>
+                      <div>
+                        <dt class="font-bold text-zinc-500">Outcome</dt>
+                        <dd class="mt-1 font-semibold text-zinc-950">{story.outcome}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                </div>
+              </article>
+            ))
+          }
+        </div>
+      </div>
+    </section>
+
+    <section class="bg-zinc-950 py-16 sm:py-24">
+      <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div class="grid gap-10 rounded-lg border border-red-300/20 bg-red-950/25 p-6 shadow-2xl shadow-red-950/30 sm:p-8 lg:grid-cols-12 lg:items-center">
+          <div class="lg:col-span-7">
+            <p class="text-sm font-black tracking-wide text-red-200 uppercase">Avoid the next horror story</p>
+            <h2 class="mt-3 text-3xl font-black text-white sm:text-4xl">Ship urgent fixes with Capgo while the stores take their time.</h2>
+            <p class="mt-4 max-w-3xl text-base leading-7 text-zinc-300">
+              Capgo lets Capacitor teams send live updates, roll back broken releases, and target channels without waiting for a full App Store or Google Play review cycle.
+            </p>
+          </div>
+          <div class="lg:col-span-5">
+            <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
+              <a
+                href="/register/"
+                class="inline-flex min-h-12 items-center justify-center rounded-md bg-white px-5 text-sm font-black text-zinc-950 transition hover:-translate-y-0.5 hover:bg-red-50 focus:ring-2 focus:ring-red-300 focus:ring-offset-2 focus:ring-offset-zinc-950 focus:outline-none"
+              >
+                Start with Capgo
+              </a>
+              <a
+                href="/live-update/"
+                class="inline-flex min-h-12 items-center justify-center rounded-md border border-white/20 px-5 text-sm font-black text-white transition hover:-translate-y-0.5 hover:border-white/40 hover:bg-white/10 focus:ring-2 focus:ring-red-300 focus:ring-offset-2 focus:ring-offset-zinc-950 focus:outline-none"
+              >
+                See live updates
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <div id="add-story" class="mt-8 scroll-mt-8 rounded-lg border border-white/10 bg-white/5 p-6">
+          <div class="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+            <div>
+              <h2 class="text-xl font-black text-white">Add a refusal story</h2>
+              <p class="mt-2 max-w-3xl text-sm leading-6 text-zinc-300">
+                Edit the story data, include one to five local image paths, and open a PR. Keep names anonymized unless you own the story.
+              </p>
+            </div>
+            <a
+              href={githubEditUrl}
+              target="_blank"
+              rel="noreferrer"
+              class="inline-flex min-h-11 items-center justify-center rounded-md bg-red-500 px-5 text-sm font-black text-white transition hover:-translate-y-0.5 hover:bg-red-400 focus:ring-2 focus:ring-red-300 focus:ring-offset-2 focus:ring-offset-zinc-950 focus:outline-none"
+            >
+              Edit on GitHub
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</Layout>


### PR DESCRIPTION
## Summary
- add a standalone App Store Refusal Horror Story page with local image-backed story cards
- add story data in a GitHub-editable TypeScript file with 1-5 images per story
- add bottom Capgo ad CTA for avoiding store-review delays with live updates
- add an optional Layout `hideChrome` prop so this page has only one external GitHub edit link

## Verification
- bunx prettier --write apps/web/src/layouts/Layout.astro apps/web/src/data/appStoreRefusalStories.ts apps/web/src/pages/app-store-refusal-horror-story.astro
- NODE_OPTIONS=--max-old-space-size=16384 bunx astro check (apps/web)
- bun run ci:verify:web
- Playwright browser check at /app-store-refusal-horror-story/: one external anchor, the GitHub edit link