### PR TITLE
Replace "M-series Mac" with "M4 Mac" in native build copy

### DIFF
--- a/apps/shared/copy/messages.ts
+++ b/apps/shared/copy/messages.ts
@@ -4190,7 +4190,7 @@ const messages = {
   native_build_v2_meta_nosdk: 'No Mac, no Android SDK',
   native_build_v2_meta_speed: 'Avg build 2–3 min',
   native_build_v2_strip_ios_k: 'iOS runners',
-  native_build_v2_strip_ios_v: 'M-series Mac',
+  native_build_v2_strip_ios_v: 'M4 Mac',
   native_build_v2_strip_android_k: 'Android runners',
   native_build_v2_strip_android_v: 'Docker',
   native_build_v2_strip_build_k: 'Avg build',

--- a/apps/web/src/pages/native-build.astro
+++ b/apps/web/src/pages/native-build.astro
@@ -306,7 +306,7 @@ $ capgo build request --platform android  ✔ 1m 22s</pre>
             <h3 class="ttl"><span class="ttl-accent">{copy('native_build_v2_tile_hw_title')}</span></h3>
             <p class="sub">{copy('native_build_v2_tile_hw_sub')}</p>
             <div class="more">
-              iOS jobs run on M-series Mac runners — fast Xcode + Fastlane. Android jobs run on Linux Docker — fast Gradle, roughly half the cost of iOS, no Mac required. You don't
+              iOS jobs run on M4 Mac runners — fast Xcode + Fastlane. Android jobs run on Linux Docker — fast Gradle, roughly half the cost of iOS, no Mac required. You don't
               pick the runner; we do, by platform flag.
             </div>
           </div>


### PR DESCRIPTION
## What

Updates the iOS runner copy on the native build page to say **"M4 Mac"** instead of **"M-series Mac"**.

## Changes

- `apps/shared/copy/messages.ts` — `native_build_v2_strip_ios_v`: `M-series Mac` → `M4 Mac`
- `apps/web/src/pages/native-build.astro` — tile copy: "iOS jobs run on M-series Mac runners…" → "iOS jobs run on M4 Mac runners…"

These were the only two occurrences of "M-series" in the repo (case-insensitive search). "Mac" is kept capitalized to stay consistent with the surrounding copy on the same page (e.g. "No Mac mini", "no Mac required").

https://claude.ai/code/session_019FPoZHSB7hjePNsV7ga5cJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019FPoZHSB7hjePNsV7ga5cJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined hardware specification messaging throughout the platform. Updated all references from "M-series Mac" to the more specific "M4 Mac" designation in iOS build documentation and Capgo Builder messaging to provide users with precise information about available build infrastructure and hardware capabilities for native application builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/website/pull/739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->