### PR TITLE
[codex] add verisoul plugin docs

### DIFF
--- a/apps/docs/src/config/llmsCustomSets.ts
+++ b/apps/docs/src/config/llmsCustomSets.ts
@@ -92,6 +92,7 @@ Plugin Photo Library|photo library access plugin|docs/plugins/photo-library/**
 Plugin Printer|printing plugin for documents and images|docs/plugins/printer/**
 Plugin RealtimeKit|real-time communication plugin|docs/plugins/realtimekit/**
 Plugin reCAPTCHA|Web reCAPTCHA, Web reCAPTCHA Enterprise, and native Enterprise mobile token plugin|docs/plugins/recaptcha/**
+Plugin Verisoul|native Verisoul fraud-prevention session plugin for Capacitor apps|docs/plugins/verisoul/**
 Plugin Ricoh 360 Camera|Ricoh 360 camera integration plugin|docs/plugins/ricoh360-camera/**
 Plugin Screen Orientation|screen orientation control plugin|docs/plugins/screen-orientation/**
 Plugin Screen Recorder|screen recording plugin|docs/plugins/screen-recorder/**

--- a/apps/docs/src/config/sidebar.mjs
+++ b/apps/docs/src/config/sidebar.mjs
@@ -186,6 +186,7 @@ const pluginEntries = [
   ['Capacitor Patch', 'capacitor-patch'],
   ['RealtimeKit', 'realtimekit'],
   ['reCAPTCHA', 'recaptcha', [linkItem('iOS setup', '/docs/plugins/recaptcha/ios'), linkItem('Android setup', '/docs/plugins/recaptcha/android')]],
+  ['Verisoul', 'verisoul', [linkItem('iOS setup', '/docs/plugins/verisoul/ios'), linkItem('Android setup', '/docs/plugins/verisoul/android')]],
   ['Ricoh 360 Camera', 'ricoh360-camera'],
   ['Screen Orientation', 'screen-orientation'],
   ['Screen Recorder', 'screen-recorder'],

--- a/apps/docs/src/content/docs/docs/plugins/verisoul/android.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/verisoul/android.mdx
@@ -1,0 +1,51 @@
+---
+title: Android setup
+description: Configure Android requirements for the Verisoul Capacitor plugin.
+sidebar:
+  order: 4
+---
+
+## Native SDK
+
+The plugin depends on Verisoul's Android SDK and adds the required Maven repository in its Gradle file:
+
+```groovy
+maven { url = uri("https://us-central1-maven.pkg.dev/verisoul/android") }
+```
+
+If your app cannot resolve `ai.verisoul:android`, add that repository to your root Gradle repositories.
+
+## Permissions
+
+The plugin manifest declares the required network permissions:
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+<uses-permission android:name="android.permission.INTERNET" />
+```
+
+## Sync
+
+After installing the plugin, sync Android:
+
+```bash
+npx cap sync android
+```
+
+## Touch signals
+
+Android exposes Verisoul touch-signal collection through `recordTouchEvent()`:
+
+```typescript
+import { Verisoul } from '@capgo/capacitor-verisoul';
+
+await Verisoul.recordTouchEvent({
+  x: 120,
+  y: 240,
+  action: 'down',
+});
+```
+
+## Keep going from Android setup
+
+If you are using **Android setup** to configure Verisoul, connect it with [Getting Started](/docs/plugins/verisoul/getting-started/) for app integration, [iOS setup](/docs/plugins/verisoul/ios/) for iOS parity, and [@capgo/capacitor-verisoul](/docs/plugins/verisoul/) for the API overview.

--- a/apps/docs/src/content/docs/docs/plugins/verisoul/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/verisoul/getting-started.mdx
@@ -1,0 +1,69 @@
+---
+title: Getting Started
+description: Learn how to install and use the Verisoul Capacitor plugin.
+sidebar:
+  order: 2
+---
+
+## Install
+
+```bash
+npm install @capgo/capacitor-verisoul
+npx cap sync
+```
+
+## Configure Verisoul
+
+Call `configure()` once, early in your app startup. Use `sandbox` for testing and `prod` for production traffic.
+
+```typescript
+import { Verisoul } from '@capgo/capacitor-verisoul';
+
+await Verisoul.configure({
+  environment: 'prod',
+  projectId: 'YOUR_PROJECT_ID',
+});
+```
+
+## Get a session ID
+
+After Verisoul has collected enough native signals, request the session ID and send it to your backend. Your backend should call Verisoul's server-side API for the risk assessment.
+
+```typescript
+const { sessionId } = await Verisoul.getSessionId();
+
+await fetch('/api/risk/verisoul', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ sessionId }),
+});
+```
+
+## Reset on account changes
+
+Call `reinitialize()` when user context changes, such as logout followed by login as another account.
+
+```typescript
+await Verisoul.reinitialize();
+```
+
+## Android touch signals
+
+On Android, forward touch events when your app needs Verisoul touch-pattern collection.
+
+```typescript
+await Verisoul.recordTouchEvent({
+  x: 120,
+  y: 240,
+  action: 'down',
+});
+```
+
+## Platform setup
+
+- [iOS setup](/docs/plugins/verisoul/ios/) covers App Attest entitlement notes.
+- [Android setup](/docs/plugins/verisoul/android/) covers the Verisoul Maven repository and permissions.
+
+## Keep going from Getting Started
+
+If you are using **Getting Started** to integrate Verisoul sessions, connect it with [@capgo/capacitor-verisoul](/docs/plugins/verisoul/) for the API overview, [iOS setup](/docs/plugins/verisoul/ios/) for App Attest notes, [Android setup](/docs/plugins/verisoul/android/) for Gradle setup, and [Using @capgo/capacitor-verisoul](/plugins/capacitor-verisoul/) for the plugin tutorial.

--- a/apps/docs/src/content/docs/docs/plugins/verisoul/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/verisoul/index.mdx
@@ -1,0 +1,49 @@
+---
+title: "@capgo/capacitor-verisoul"
+description: "Verisoul native fraud-prevention sessions for Capacitor apps."
+tableOfContents: false
+next: false
+prev: false
+sidebar:
+  order: 1
+  label: "Introduction"
+hero:
+  tagline: "Collect Verisoul fraud-prevention sessions from iOS and Android."
+  actions:
+    - text: Get started
+      link: /docs/plugins/verisoul/getting-started/
+      icon: right-arrow
+      variant: primary
+    - text: GitHub
+      link: https://github.com/Cap-go/capacitor-verisoul/
+      icon: external
+      variant: minimal
+---
+
+## Overview
+
+`@capgo/capacitor-verisoul` wraps the Verisoul native iOS and Android SDKs for Capacitor apps. Use it to initialize Verisoul early, collect native device and behavioral signals, retrieve a session ID, and send that session ID to your backend for Verisoul risk assessment.
+
+## Core Capabilities
+
+- `configure` - Initializes Verisoul with your project ID and target environment.
+- `getSessionId` - Returns the current Verisoul session ID once native collection is ready.
+- `reinitialize` - Resets collection and starts a fresh session after account context changes.
+- `recordTouchEvent` - Forwards Android touch events to Verisoul touch-signal collection.
+
+## Public API
+
+| Method | Description |
+| --- | --- |
+| `configure` | Initialize the Verisoul native SDK. |
+| `getSessionId` | Return the current Verisoul session identifier. |
+| `reinitialize` | Reset Verisoul collection and create a fresh session. |
+| `recordTouchEvent` | Forward touch events to the Android SDK. |
+
+## Source Of Truth
+
+This reference is synced from `src/definitions.ts` in [capacitor-verisoul](https://github.com/Cap-go/capacitor-verisoul/).
+
+## Keep going from @capgo/capacitor-verisoul
+
+If you are using **@capgo/capacitor-verisoul** to plan fraud prevention, connect it with [Using @capgo/capacitor-verisoul](/plugins/capacitor-verisoul/) for the native capability, [Getting Started](/docs/plugins/verisoul/getting-started/) for installation, [iOS setup](/docs/plugins/verisoul/ios/) for App Attest notes, [Android setup](/docs/plugins/verisoul/android/) for Maven setup, and [Capgo Security](/security/) for the broader security workflow.

--- a/apps/docs/src/content/docs/docs/plugins/verisoul/ios.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/verisoul/ios.mdx
@@ -1,0 +1,44 @@
+---
+title: iOS setup
+description: Configure iOS requirements for the Verisoul Capacitor plugin.
+sidebar:
+  order: 3
+---
+
+## Native SDK
+
+The plugin depends on `VerisoulSDK` and supports both CocoaPods and Swift Package Manager through the plugin package metadata.
+
+After installing the plugin, sync the native project:
+
+```bash
+npx cap sync ios
+```
+
+## App Attest
+
+Verisoul recommends enabling App Attest for stronger device checks. In Xcode, add the App Attest capability and include the entitlement value that matches your environment:
+
+```xml
+<key>com.apple.developer.devicecheck.appattest-environment</key>
+<string>production</string>
+```
+
+Use `development` for test builds.
+
+## Usage
+
+Initialize Verisoul early in your app lifecycle:
+
+```typescript
+import { Verisoul } from '@capgo/capacitor-verisoul';
+
+await Verisoul.configure({
+  environment: 'prod',
+  projectId: 'YOUR_PROJECT_ID',
+});
+```
+
+## Keep going from iOS setup
+
+If you are using **iOS setup** to configure Verisoul, connect it with [Getting Started](/docs/plugins/verisoul/getting-started/) for app integration, [Android setup](/docs/plugins/verisoul/android/) for Android parity, and [@capgo/capacitor-verisoul](/docs/plugins/verisoul/) for the API overview.

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -67,6 +67,7 @@ const actionDefinitionRows =
 @capgo/capacitor-appinsights|github.com/Cap-go|Track app usage, performance metrics, and user behavior with Apptopia AppInsights|https://github.com/Cap-go/capacitor-appinsights/|AppInsights
 @capgo/capacitor-app-attest|github.com/Cap-go|Capacitor plugin for cross-platform device attestation using Apple App Attest and Google Play Integrity Standard|https://github.com/Cap-go/capacitor-app-attest/|App Attest
 @capgo/capacitor-recaptcha|github.com/Cap-go|Generate Web reCAPTCHA or reCAPTCHA Enterprise tokens plus native Enterprise mobile tokens|https://github.com/Cap-go/capacitor-recaptcha/|reCAPTCHA
+@capgo/capacitor-verisoul|github.com/Cap-go|Collect Verisoul native fraud-prevention sessions from Capacitor apps on iOS and Android|https://github.com/Cap-go/capacitor-verisoul/|Verisoul
 @capgo/capacitor-audiosession|github.com/Cap-go|Configure iOS audio session for background playback, mixing, and routing control|https://github.com/Cap-go/capacitor-audiosession/|Audio Session
 @capgo/capacitor-background-geolocation|github.com/Cap-go|Accurate background location tracking with native iOS and Android geofencing plus transition webhooks|https://github.com/Cap-go/capacitor-background-geolocation/|Background Geolocation
 @capgo/capacitor-background-task|github.com/Cap-go|Schedule periodic background fetch tasks on iOS and Android with Expo-style task registration|https://github.com/Cap-go/capacitor-background-task/|Background Task
@@ -210,6 +211,7 @@ const pluginIconsByName: Record<string, string> = {
   '@capgo/capacitor-appinsights': 'ChartBar',
   '@capgo/capacitor-app-attest': 'ShieldCheck',
   '@capgo/capacitor-recaptcha': 'ShieldCheck',
+  '@capgo/capacitor-verisoul': 'ShieldCheck',
   '@capgo/capacitor-audiosession': 'SpeakerWave',
   '@capgo/capacitor-background-geolocation': 'MapPin',
   '@capgo/capacitor-background-task': 'Clock',

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-verisoul.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-verisoul.md
@@ -1,0 +1,56 @@
+---
+locale: en
+---
+# Using @capgo/capacitor-verisoul
+
+`@capgo/capacitor-verisoul` connects Capacitor apps to Verisoul native fraud-prevention sessions on iOS and Android.
+
+## Install
+
+```bash
+npm install @capgo/capacitor-verisoul
+npx cap sync
+```
+
+## What This Plugin Exposes
+
+- `configure` - Initializes the native Verisoul SDK with your environment and project ID.
+- `getSessionId` - Returns the current Verisoul session ID for backend risk assessment.
+- `reinitialize` - Starts a fresh Verisoul session after account context changes.
+- `recordTouchEvent` - Sends Android touch events to Verisoul touch-signal collection.
+
+## Example Usage
+
+```typescript
+import { Verisoul } from '@capgo/capacitor-verisoul';
+
+await Verisoul.configure({
+  environment: 'prod',
+  projectId: 'YOUR_PROJECT_ID',
+});
+
+const { sessionId } = await Verisoul.getSessionId();
+
+await fetch('/api/risk/verisoul', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ sessionId }),
+});
+```
+
+## Reset Sessions
+
+Call `reinitialize()` when a user logs out or switches accounts:
+
+```typescript
+await Verisoul.reinitialize();
+```
+
+## Full Reference
+
+- GitHub: https://github.com/Cap-go/capacitor-verisoul/
+- Docs: /docs/plugins/verisoul/
+
+## Keep going from Using @capgo/capacitor-verisoul
+
+If you are using **Using @capgo/capacitor-verisoul** to add fraud-prevention signals, connect it with [@capgo/capacitor-verisoul](/docs/plugins/verisoul/) for the implementation detail, [Getting Started](/docs/plugins/verisoul/getting-started/) for install steps, [iOS setup](/docs/plugins/verisoul/ios/) for App Attest notes, [Android setup](/docs/plugins/verisoul/android/) for Gradle setup, and [Capgo Security](/security/) for the broader security workflow.


### PR DESCRIPTION
## What changed
- Add `@capgo/capacitor-verisoul` to the plugin registry with ShieldCheck icon metadata.
- Add docs pages for overview, getting started, iOS setup, and Android setup.
- Add the plugin tutorial page and LLM custom set entry.

## Validation
- `bun run check:docs-mirror`
- `cd apps/docs && bun run check`
- `cd apps/web && bun run check`
- `bun run ci:verify:docs`
- `bun run ci:verify:web`
