### PR TITLE
[codex] clarify channel identifiers in docs

### DIFF
--- a/apps/docs/src/content/docs/docs/cli/commands.mdx
+++ b/apps/docs/src/content/docs/docs/cli/commands.mdx
@@ -307,10 +307,10 @@ Optionally, you can give:
   
 ### **Compatibility** 
 
-`npx @capgo/cli bundle compatibility [appId] -c [channelId]`
+`npx @capgo/cli bundle compatibility [appId] -c [channelName]`
 
 `[appId]` is your app ID, the format is explained [here](https://capacitorjs.com/docs/cli/commands/init/).
-`[channelId]` the name of your new channel.
+`[channelName]` the name of the channel to check.
 
 Optionally, you can give:
 
@@ -324,15 +324,15 @@ Optionally, you can give:
 
 ### **Add**
 
-`npx @capgo/cli channel add [channelId] [appId]`
+`npx @capgo/cli channel add [channelName] [appId]`
 
-`[channelId]` the name of your new channel. `[appId]` your app ID the format `com.test.app` is explained [here](https://capacitorjs.com/docs/cli/commands/init/).
+`[channelName]` the name of your new channel, such as `production` or `beta`. `[appId]` your app ID the format `com.test.app` is explained [here](https://capacitorjs.com/docs/cli/commands/init/).
 
 ### **Delete**
 
-`npx @capgo/cli channel delete [channelId] [appId]`
+`npx @capgo/cli channel delete [channelName] [appId]`
 
-`[channelId]` the name of your channel you want to delete. `[appId]` your app ID the format `com.test.app` is explained [here](https://capacitorjs.com/docs/cli/commands/init/).
+`[channelName]` the name of the channel you want to delete. `[appId]` your app ID the format `com.test.app` is explained [here](https://capacitorjs.com/docs/cli/commands/init/).
 
 ### **List**
 
@@ -346,9 +346,10 @@ Optionally, you can give:
 
 ### **Set**
 
-`npx @capgo/cli channel set [channelId] [appId]`
+`npx @capgo/cli channel set [channelName] [appId]`
 
 `[appId]` is your app ID, the format is explained [here](https://capacitorjs.com/docs/cli/commands/init/).
+`[channelName]` the name of the channel you want to configure, such as `production` or `beta`.
 
 Optionally, you can give:
 

--- a/apps/docs/src/content/docs/docs/plugins/updater/api.md
+++ b/apps/docs/src/content/docs/docs/plugins/updater/api.md
@@ -1009,10 +1009,12 @@ If you don't use backend, you need to provide the URL and version of the bundle.
 
 | Prop                 | Type                 | Description                                     | Since |
 | -------------------- | -------------------- | ----------------------------------------------- | ----- |
-| **`id`**             | <code>string</code>  | The channel ID                                  | 7.5.0 |
+| **`id`**             | <code>number</code>  | The numeric channel ID                          | 7.5.0 |
 | **`name`**           | <code>string</code>  | The channel name                                | 7.5.0 |
 | **`public`**         | <code>boolean</code> | If true, this is a default/fallback channel. Devices cannot self-assign to public channels. Instead, when a device removes its channel override (using `unsetChannel()`), it will automatically receive updates from the matching public channel. | 7.5.0 |
 | **`allow_self_set`** | <code>boolean</code> | If true, devices can explicitly self-assign to this channel using `setChannel()`. This is typically used for beta testing, A/B testing, or opt-in update tracks. | 7.5.0 |
+
+Channel commands use the channel `name`, not this numeric `id`.
 
 
 ### SetCustomIdOptions

--- a/apps/web/src/content/blog/en/how-to-use-semantic-versioning-with-capgo-ota-updates.md
+++ b/apps/web/src/content/blog/en/how-to-use-semantic-versioning-with-capgo-ota-updates.md
@@ -218,7 +218,7 @@ npx @capgo/cli@latest init [apikey]
 npx @capgo/cli bundle upload [appId]
 
 # Add a new distribution channel
-npx @capgo/cli channel add [channelId] [appId]
+npx @capgo/cli channel add [channelName] [appId]
 ```
 
 Capgo ensures secure deployment with end-to-end encryption and safe key management.


### PR DESCRIPTION
## Summary
- Clarify website CLI docs to use channel names instead of channel IDs for channel commands.
- Correct `ChannelInfo.id` in the updater API docs to `number`.
- Update the semver blog command placeholder to `[channelName]`.

## Motivation
The channel self/list response returns a numeric channel `id`, but CLI commands operate on channel names such as `production` or `beta`. The docs mixed those concepts.

## Business Impact
Reduces developer confusion when following website docs and avoids users passing numeric database IDs to CLI commands that expect channel names.

## Test Plan
- `bunx prettier --write apps/docs/src/content/docs/docs/cli/commands.mdx apps/docs/src/content/docs/docs/plugins/updater/api.md apps/web/src/content/blog/en/how-to-use-semantic-versioning-with-capgo-ota-updates.md`
- `NODE_OPTIONS=--max-old-space-size=16384 bun run check`
