### PR TITLE
docs(api): document API key org creation

### DIFF
--- a/apps/docs/src/content/docs/docs/cli/commands.mdx
+++ b/apps/docs/src/content/docs/docs/cli/commands.mdx
@@ -307,10 +307,10 @@ Optionally, you can give:
   
 ### **Compatibility** 
 
-`npx @capgo/cli bundle compatibility [appId] -c [channelId]`
+`npx @capgo/cli bundle compatibility [appId] -c [channelName]`
 
 `[appId]` is your app ID, the format is explained [here](https://capacitorjs.com/docs/cli/commands/init/).
-`[channelId]` the name of your new channel.
+`[channelName]` the name of the channel to check.
 
 Optionally, you can give:
 
@@ -324,15 +324,15 @@ Optionally, you can give:
 
 ### **Add**
 
-`npx @capgo/cli channel add [channelId] [appId]`
+`npx @capgo/cli channel add [channelName] [appId]`
 
-`[channelId]` the name of your new channel. `[appId]` your app ID the format `com.test.app` is explained [here](https://capacitorjs.com/docs/cli/commands/init/).
+`[channelName]` the name of your new channel, such as `production` or `beta`. `[appId]` your app ID the format `com.test.app` is explained [here](https://capacitorjs.com/docs/cli/commands/init/).
 
 ### **Delete**
 
-`npx @capgo/cli channel delete [channelId] [appId]`
+`npx @capgo/cli channel delete [channelName] [appId]`
 
-`[channelId]` the name of your channel you want to delete. `[appId]` your app ID the format `com.test.app` is explained [here](https://capacitorjs.com/docs/cli/commands/init/).
+`[channelName]` the name of the channel you want to delete. `[appId]` your app ID the format `com.test.app` is explained [here](https://capacitorjs.com/docs/cli/commands/init/).
 
 ### **List**
 
@@ -346,9 +346,10 @@ Optionally, you can give:
 
 ### **Set**
 
-`npx @capgo/cli channel set [channelId] [appId]`
+`npx @capgo/cli channel set [channelName] [appId]`
 
 `[appId]` is your app ID, the format is explained [here](https://capacitorjs.com/docs/cli/commands/init/).
+`[channelName]` the name of the channel you want to configure, such as `production` or `beta`.
 
 Optionally, you can give:
 

--- a/apps/docs/src/content/docs/docs/plugins/updater/api.md
+++ b/apps/docs/src/content/docs/docs/plugins/updater/api.md
@@ -1009,10 +1009,12 @@ If you don't use backend, you need to provide the URL and version of the bundle.
 
 | Prop                 | Type                 | Description                                     | Since |
 | -------------------- | -------------------- | ----------------------------------------------- | ----- |
-| **`id`**             | <code>string</code>  | The channel ID                                  | 7.5.0 |
+| **`id`**             | <code>number</code>  | The numeric channel ID                          | 7.5.0 |
 | **`name`**           | <code>string</code>  | The channel name                                | 7.5.0 |
 | **`public`**         | <code>boolean</code> | If true, this is a default/fallback channel. Devices cannot self-assign to public channels. Instead, when a device removes its channel override (using `unsetChannel()`), it will automatically receive updates from the matching public channel. | 7.5.0 |
 | **`allow_self_set`** | <code>boolean</code> | If true, devices can explicitly self-assign to this channel using `setChannel()`. This is typically used for beta testing, A/B testing, or opt-in update tracks. | 7.5.0 |
+
+Channel commands use the channel `name`, not this numeric `id`.
 
 
 ### SetCustomIdOptions

--- a/apps/docs/src/content/docs/docs/public-api/api-keys.mdx
+++ b/apps/docs/src/content/docs/docs/public-api/api-keys.mdx
@@ -33,6 +33,38 @@ If an API key has explicit role bindings, **only those bindings** are evaluated 
 Keys without role bindings fall back to a legacy mode-based system (`read`, `upload`, `write`, `all`). These modes are deprecated — use RBAC roles instead.
 :::
 
+## Organization creation permission
+
+Creating organizations with an API key now uses an explicit global permission: `org.create`.
+
+This permission is separate from normal org/app role bindings because a new organization does not exist yet when `POST /organization/` is called. To create organizations with an API key:
+
+- The API key must include `org.create` in `global_permissions`.
+- The same API key must also have a current organization-scoped `org_admin` or `org_super_admin` binding.
+- New API keys do not receive `org.create` by default. Enable **Allow creating organizations** when creating or editing an RBAC API key in the dashboard.
+- Existing write-capable org admin/super admin API keys were backfilled with `org.create` so existing integrations can continue creating organizations.
+
+When an API key creates an organization, Capgo automatically assigns that same API key as `org_super_admin` on the newly created organization. This lets the integration manage the organization it just created without needing a separate manual role binding.
+
+If you create an API key through the API, include `global_permissions` alongside the org admin binding:
+
+```json
+{
+  "name": "Provisioning key",
+  "hashed": true,
+  "bindings": [
+    {
+      "role_name": "org_admin",
+      "scope_type": "org",
+      "org_id": "00000000-0000-0000-0000-000000000000"
+    }
+  ],
+  "global_permissions": ["org.create"]
+}
+```
+
+`org.create` only applies to creating organizations. Deleting an organization still requires delete permission on the target organization, typically through `org_super_admin`.
+
 ## Secure (Hashed) Keys
 
 When creating a secure key, the server generates the key material and returns the plain-text value once. Only a hash is stored. This means:
@@ -67,6 +99,7 @@ Organization policies can enforce:
 3. **Monitoring Tools**: Create keys with the `app_reader` role for external monitoring integrations
 4. **Admin Access**: Use keys with the `org_admin` role sparingly for administrative tools
 5. **Third-Party Integrations**: Create keys restricted to specific apps with the minimum required role
+6. **Organization Provisioning**: Use an `org_admin` or `org_super_admin` RBAC key with `org.create` only for trusted automation that needs to create organizations
 
 ## Keep going from API Keys
 

--- a/apps/docs/src/content/docs/docs/public-api/index.mdx
+++ b/apps/docs/src/content/docs/docs/public-api/index.mdx
@@ -11,18 +11,21 @@ This is the documentation of the public API of Capgo cloud. The API allows you t
 
 ## Authentication
 
-All API endpoints require authentication. To authenticate your requests, add your API key in the `authorization` header.
+All API endpoints require authentication. To authenticate your requests, add your API key in the `x-api-key` header.
 
 Example:
+
 ```bash
-curl -H "authorization: your-api-key" https://api.capgo.app/organization/
+curl -H "x-api-key: YOUR_API_KEY" https://api.capgo.app/organization/
 ```
 
 <LinkCard
 	title="Get API key"
 	description="Generate your API key in the Capgo dashboard"
-	href="https://console.capgo.app/dashboard/apikeys/"
+	href="https://console.capgo.app/settings/organization/api-keys"
 />
+
+The `authorization` header is still accepted for legacy API keys, but `x-api-key` is the recommended header for all key types, including secure hashed keys.
 
 ## Rate Limiting
 

--- a/apps/docs/src/content/docs/docs/public-api/organizations.mdx
+++ b/apps/docs/src/content/docs/docs/public-api/organizations.mdx
@@ -45,10 +45,10 @@ interface Organization {
 
 ```bash
 # Get all organizations
-curl -H "authorization: your-api-key" https://api.capgo.app/organization/
+curl -H "x-api-key: YOUR_API_KEY" https://api.capgo.app/organization/
 
 # Get specific organization
-curl -H "authorization: your-api-key" https://api.capgo.app/organization/?orgId=org_123
+curl -H "x-api-key: YOUR_API_KEY" https://api.capgo.app/organization/?orgId=org_123
 ```
 
 #### Example Response
@@ -73,11 +73,22 @@ curl -H "authorization: your-api-key" https://api.capgo.app/organization/?orgId=
 
 Create a new organization.
 
+When using an API key, the key must have the global `org.create` permission and a current organization-scoped `org_admin` or `org_super_admin` binding. This is required because the target organization does not exist yet, so normal org-scoped RBAC cannot be checked against it.
+
+When the request succeeds, Capgo automatically assigns the same API key as `org_super_admin` on the new organization.
+
+:::note
+`org.create` is not granted to new API keys by default. Enable **Allow creating organizations** in the API key form, or include `"global_permissions": ["org.create"]` when creating the key through the API.
+:::
+
 #### Request Body
 
 ```typescript
 interface OrganizationCreate {
   name: string
+  email?: string
+  estimatedMau?: number
+  website?: string
 }
 ```
 
@@ -85,10 +96,12 @@ interface OrganizationCreate {
 
 ```bash
 curl -X POST \
-  -H "authorization: your-api-key" \
+  -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "New Organization"
+    "name": "New Organization",
+    "email": "admin@example.com",
+    "website": "https://example.com"
   }' \
   https://api.capgo.app/organization/
 ```
@@ -97,8 +110,17 @@ curl -X POST \
 
 ```json
 {
-  "status": "Organization created",
   "id": "org_456"
+}
+```
+
+#### Permission Error
+
+If the API key does not have `org.create`, the API returns:
+
+```json
+{
+  "error": "permission_denied"
 }
 ```
 
@@ -106,7 +128,7 @@ curl -X POST \
 
 `https://api.capgo.app/organization/`
 
-Update an existing organization. Requires admin role.
+Update an existing organization. Requires admin role on the target organization.
 
 #### Request Body
 
@@ -123,7 +145,7 @@ interface OrganizationUpdate {
 
 ```bash
 curl -X PUT \
-  -H "authorization: your-api-key" \
+  -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "orgId": "org_123",
@@ -150,7 +172,9 @@ curl -X PUT \
 
 `https://api.capgo.app/organization/`
 
-Delete an existing organization. Requires admin role. This action is irreversible and will remove all associated apps, bundles (versions), and resources.
+Delete an existing organization. Requires delete permission on the target organization, typically through the `org_super_admin` role. This action is irreversible and will remove all associated apps, bundles (versions), and resources.
+
+The `org.create` global permission does not allow deleting organizations.
 
 #### Query Parameters
 
@@ -160,7 +184,7 @@ Delete an existing organization. Requires admin role. This action is irreversibl
 
 ```bash
 curl -X DELETE \
-  -H "authorization: your-api-key" \
+  -H "x-api-key: YOUR_API_KEY" \
   https://api.capgo.app/organization/?orgId=org_123
 ```
 
@@ -168,8 +192,7 @@ curl -X DELETE \
 
 ```json
 {
-  "status": "Organization deleted",
-  "id": "org_123"
+  "status": "ok"
 }
 ```
 

--- a/apps/docs/src/content/docs/docs/webapp/api-keys.mdx
+++ b/apps/docs/src/content/docs/docs/webapp/api-keys.mdx
@@ -36,7 +36,11 @@ The page displays two sections:
    - **Member** — Basic read access to the organization.
    - **Admin** — Full administrative access to the organization (inherits access to all apps).
 
-4. If the selected org role is not Admin, you can add **per-app access**:
+4. If the key needs to create organizations through the public API, enable **Allow creating organizations**.
+
+   This adds the global `org.create` permission. It is available when the key has an Admin organization role. When this key creates a new organization, Capgo automatically assigns the key as Super Admin on that new organization.
+
+5. If the selected org role is not Admin, you can add **per-app access**:
    - Click **"+ Add App"** to open the app picker.
    - Select one or more apps, then assign a role to each:
      - **App Reader** — Read-only access to the app.
@@ -47,9 +51,9 @@ The page displays two sections:
 {/* [SCREENSHOT: apikeys-rbac-roles.webp] — The role selection section showing org role radio buttons and the per-app role assignment table */}
 <figure><img src="/apikeys-rbac-roles.webp" alt="RBAC role selection with org-level and per-app roles" /><figcaption></figcaption></figure>
 
-5. Click **"Create"**.
+6. Click **"Create"**.
 
-6. If you checked "Create secure key", a modal will display the plain-text key. **Copy it immediately** — it cannot be retrieved after closing the modal.
+7. If you checked "Create secure key", a modal will display the plain-text key. **Copy it immediately** — it cannot be retrieved after closing the modal.
 
 {/* [SCREENSHOT: apikeys-secret-modal.webp] — The one-time secret modal showing the plain-text key with a copy button */}
 <figure><img src="/apikeys-secret-modal.webp" alt="One-time API key secret modal with copy button" /><figcaption></figcaption></figure>
@@ -60,6 +64,7 @@ Click the **wrench icon** (Manage) on any RBAC key in the list. This opens the k
 
 - Change the key **name**.
 - Update the **organization role**.
+- Enable or disable **Allow creating organizations** when the key has an Admin organization role.
 - Add, remove, or change **per-app roles**.
 
 Click **"Save Changes"** when done.

--- a/apps/web/src/content/blog/en/how-to-use-semantic-versioning-with-capgo-ota-updates.md
+++ b/apps/web/src/content/blog/en/how-to-use-semantic-versioning-with-capgo-ota-updates.md
@@ -218,7 +218,7 @@ npx @capgo/cli@latest init [apikey]
 npx @capgo/cli bundle upload [appId]
 
 # Add a new distribution channel
-npx @capgo/cli channel add [channelId] [appId]
+npx @capgo/cli channel add [channelName] [appId]
 ```
 
 Capgo ensures secure deployment with end-to-end encryption and safe key management.


### PR DESCRIPTION
Summary
- Document the `org.create` global API key permission in the public API key docs.
- Update the organization API docs for API-key org creation, auto-assigned `org_super_admin`, and delete-org permission behavior.
- Point public API auth examples to the recommended `x-api-key` header and document the dashboard checkbox in the webapp API key guide.

Motivation
- API keys can create organizations only when explicitly granted `org.create`; users need the website docs to explain how to create and use those keys.

Test Plan
- [x] `bunx prettier --write apps/docs/src/content/docs/docs/public-api/index.mdx apps/docs/src/content/docs/docs/public-api/api-keys.mdx apps/docs/src/content/docs/docs/public-api/organizations.mdx apps/docs/src/content/docs/docs/webapp/api-keys.mdx`
- [x] `bun run check:docs-mirror`
- [x] `bun run check` from `apps/docs`
- [x] `bun run build:docs`
