### PR TITLE
feat(web): track Facebook signup event

### DIFF
--- a/apps/web/src/pages/register.astro
+++ b/apps/web/src/pages/register.astro
@@ -268,6 +268,12 @@ const content = {
     if ((window as any).datafast) {
       ;(window as any).datafast('signup', { email: email.value })
     }
+    if ((window as any).fbq) {
+      ;(window as any).fbq('track', 'CompleteRegistration', {
+        content_name: 'Capgo signup',
+        status: true,
+      })
+    }
     if ((window as any).posthog) {
       ;(window as any).posthog.capture('user_signed_up', {
         email: email.value,


### PR DESCRIPTION
## Summary
- track Meta Pixel `CompleteRegistration` after successful signup
- keep existing DataFast and PostHog signup tracking unchanged

## Tests
- bunx prettier --write apps/web/src/pages/register.astro
- NODE_OPTIONS=--max-old-space-size=16384 bunx astro check