### PR TITLE
[codex] Add log leak debug promise

### DIFF
--- a/apps/shared/copy/messages.ts
+++ b/apps/shared/copy/messages.ts
@@ -2503,6 +2503,8 @@ const messages = {
   security_what_we_promise_3: 'We will handle your report with strict confidentiality, and not pass on your personal details to third parties without your permission.',
   security_what_we_promise_4: 'We will keep you informed of the progress towards resolving the problem.',
   security_what_we_promise_5: 'In the public information concerning the problem reported, we will give your name as the discoverer of the problem (unless you desire otherwise).',
+  security_what_we_promise_6:
+    'If leaked data appears in logs shared with us, we treat it as debugging information used to fix the issue, never as a reason for retaliation or retribution.',
   security_what_we_promise_title: 'What we promise:',
   see_all_from_our_blog: 'See all from our blog',
   see_in_play_store: 'See in Play store',

--- a/apps/web/src/pages/security.astro
+++ b/apps/web/src/pages/security.astro
@@ -83,6 +83,7 @@ const content = { title, description }
       <li>{m.security_what_we_promise_3({}, { locale: Astro.locals.locale })}</li>
       <li>{m.security_what_we_promise_4({}, { locale: Astro.locals.locale })}</li>
       <li>{m.security_what_we_promise_5({}, { locale: Astro.locals.locale })}</li>
+      <li>{m.security_what_we_promise_6({}, { locale: Astro.locals.locale })}</li>
     </ul>
     <p>{m.security_closing({}, { locale: Astro.locals.locale })}</p>
   </div>


### PR DESCRIPTION
## Summary

- Add a security policy promise that leaked data appearing in logs is treated as debugging information.
- State that this debug context will not trigger retaliation or retribution.
- Render the new promise on the `/security/` page.

## Why

The security page already explains coordinated disclosure promises. This adds explicit reassurance for researchers who may need to share logs containing leaked data while helping Capgo debug a report.

## Validation

- `bun run check` from `apps/web`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced security policy page with an additional commitment regarding the handling of leaked data in shared logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->