### PR TITLE
[codex] Clarify UDID route locale query

### DIFF
--- a/apps/web/src/lib/tools/api.ts
+++ b/apps/web/src/lib/tools/api.ts
@@ -180,8 +180,12 @@ function normalizeLocale(locale: string | null): string | null {
   return locales.includes(normalized as (typeof locales)[number]) ? normalized : null
 }
 
-function getUdidResultPath(locale: string | null): string {
-  return locale && locale !== defaultLocale ? `/${locale}${UDID_RESULT_PATH}` : UDID_RESULT_PATH
+function getRouteLocale(searchParams: URLSearchParams): string | null {
+  return normalizeLocale(searchParams.get('routeLocale') ?? searchParams.get('locale'))
+}
+
+function getUdidResultPath(routeLocale: string | null): string {
+  return routeLocale && routeLocale !== defaultLocale ? `/${routeLocale}${UDID_RESULT_PATH}` : UDID_RESULT_PATH
 }
 
 async function parseJsonBody(request: Request): Promise<Record<string, unknown>> {
@@ -223,11 +227,11 @@ async function handleUdidProfile(request: Request, env: ToolApiEnv): Promise<Res
   try {
     const baseUrl = new URL(request.url)
     const challenge = crypto.randomUUID()
-    const locale = normalizeLocale(baseUrl.searchParams.get('locale'))
+    const routeLocale = getRouteLocale(baseUrl.searchParams)
     const callbackUrl = new URL(UDID_CALLBACK_PATH, baseUrl)
     callbackUrl.searchParams.set('challenge', challenge)
-    if (locale) {
-      callbackUrl.searchParams.set('locale', locale)
+    if (routeLocale) {
+      callbackUrl.searchParams.set('routeLocale', routeLocale)
     }
 
     const profile = createUdidMobileconfig({
@@ -264,10 +268,10 @@ async function handleUdidProfile(request: Request, env: ToolApiEnv): Promise<Res
 
 async function handleUdidCallback(request: Request): Promise<Response> {
   const requestUrl = new URL(request.url)
-  const locale = normalizeLocale(requestUrl.searchParams.get('locale'))
+  const routeLocale = getRouteLocale(requestUrl.searchParams)
 
   if (request.method === 'GET') {
-    return redirect(locale && locale !== defaultLocale ? `/${locale}/tools/ios-udid-finder/` : '/tools/ios-udid-finder/')
+    return redirect(routeLocale && routeLocale !== defaultLocale ? `/${routeLocale}/tools/ios-udid-finder/` : '/tools/ios-udid-finder/')
   }
 
   const rawBody = await request.text()
@@ -287,7 +291,7 @@ async function handleUdidCallback(request: Request): Promise<Response> {
   const secure = requestUrl.protocol === 'https:'
   const headers = new Headers({
     ...NO_STORE_HEADERS,
-    Location: getUdidResultPath(locale),
+    Location: getUdidResultPath(routeLocale),
   })
   appendCookie(headers, UDID_RESULT_COOKIE, encodePayload(payload), UDID_RESULT_API_PATH, 300, secure, true)
   appendCookie(headers, UDID_CHALLENGE_COOKIE, '', UDID_CALLBACK_PATH, 0, secure, true)

--- a/apps/web/src/pages/tools/ios-udid-finder/index.astro
+++ b/apps/web/src/pages/tools/ios-udid-finder/index.astro
@@ -9,7 +9,7 @@ const title = 'iOS UDID Finder | Get an iPhone or iPad UDID Without a Mac'
 const description = 'Find an iPhone or iPad UDID directly on the device. Download a lightweight profile, install it in Settings, and view the UDID, model, serial, and iOS version.'
 
 const certificateLink = (import.meta.env.PUBLIC_IOS_UDID_CERTIFICATE_LINK || '').trim()
-const profileDownloadHref = `/api/tools/ios-udid-finder/profile?locale=${encodeURIComponent(Astro.locals.locale)}`
+const profileDownloadHref = `/api/tools/ios-udid-finder/profile?routeLocale=${encodeURIComponent(Astro.locals.locale)}`
 
 const faqItems = [
   {


### PR DESCRIPTION
## Summary

- Rename the iOS UDID profile download query from `locale` to `routeLocale`.
- Keep the old `locale` query as a fallback for already downloaded profiles or existing links.
- Pass `routeLocale` through the generated mobileconfig callback so localized result redirects still work.

## Root Cause

The parameter was only route state for the `/fr/...` style result redirect, but the name `locale` made it look like a language tag such as `fr-FR`.

## Validation

- `bunx prettier --write apps/web/src/pages/tools/ios-udid-finder/index.astro apps/web/src/lib/tools/api.ts`
- `bun run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale handling in the iOS UDID finder tool to ensure language preferences are properly maintained throughout the profile generation and download flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->