### PR TITLE
Add GitHub links to plugin docs headers

### DIFF
--- a/apps/docs/src/components/doc/PageTitle.astro
+++ b/apps/docs/src/components/doc/PageTitle.astro
@@ -2,11 +2,15 @@
 import Default from '@astrojs/starlight/components/PageTitle.astro'
 import CopyPage from './CopyPage.astro'
 import InstallPromptForAI from './InstallPromptForAI.astro'
+import PluginRepositoryLink from './PluginRepositoryLink.astro'
 ---
 
 <div class="page-title-wrapper">
   <Default><slot /></Default>
-  <CopyPage />
+  <div class="page-title-actions">
+    <PluginRepositoryLink />
+    <CopyPage />
+  </div>
 </div>
 <InstallPromptForAI />
 
@@ -22,6 +26,13 @@ import InstallPromptForAI from './InstallPromptForAI.astro'
   .page-title-wrapper :global(h1) {
     flex: 1;
     min-width: 0;
+  }
+
+  .page-title-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
   }
 
   @media (max-width: 768px) {

--- a/apps/docs/src/components/doc/PluginRepositoryLink.astro
+++ b/apps/docs/src/components/doc/PluginRepositoryLink.astro
@@ -1,0 +1,59 @@
+---
+import { actions } from '@/config/plugins'
+import { getPluginDocsSlugCandidates } from '@/services/pluginDocs'
+import { Icon } from '@astrojs/starlight/components'
+import type { StarlightRouteData } from '@astrojs/starlight/route-data'
+
+const getRoute = (): StarlightRouteData | undefined => {
+  try {
+    return Astro.locals.starlightRoute as StarlightRouteData | undefined
+  } catch {
+    return undefined
+  }
+}
+
+const routeId = getRoute()?.id ?? ''
+const pluginSlug = routeId.match(/(?:^|\/)plugins\/([^/]+)(?:\/.*)?$/)?.[1] ?? ''
+const plugin = pluginSlug ? actions.find((action) => getPluginDocsSlugCandidates(action).includes(pluginSlug)) : undefined
+const repositoryUrl = plugin?.href
+const repositoryLabel = plugin?.title ? plugin.title + ' GitHub repository' : 'GitHub repository'
+---
+
+{
+  repositoryUrl && (
+    <a class="plugin-repository-link" href={repositoryUrl} target="_blank" rel="noopener noreferrer" aria-label={repositoryLabel} title={repositoryLabel}>
+      <Icon name="github" class="plugin-repository-link__icon" size="1rem" />
+      <span>GitHub</span>
+    </a>
+  )
+}
+
+<style>
+  .plugin-repository-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--sl-color-bg-nav);
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.375rem;
+    color: var(--sl-color-text);
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.25;
+    text-decoration: none;
+    transition:
+      background 0.2s,
+      border-color 0.2s;
+  }
+
+  .plugin-repository-link:hover {
+    background: var(--sl-color-gray-6);
+    border-color: var(--sl-color-gray-4);
+    color: var(--sl-color-text);
+  }
+
+  .plugin-repository-link__icon {
+    flex-shrink: 0;
+  }
+</style>


### PR DESCRIPTION
## Summary
- add a shared plugin repository link to docs page headers
- resolve each plugin docs route against the existing plugin registry href
- keep the existing Copy Page action beside the new GitHub action

## Tests
- bunx prettier --write apps/docs/src/components/doc/PageTitle.astro apps/docs/src/components/doc/PluginRepositoryLink.astro
- NODE_OPTIONS=--max-old-space-size=16384 bunx astro check (apps/docs)
- bun run ci:verify:docs
- bun run check
- Playwright DOM smoke test on /docs/plugins/fast-sql/getting-started/ confirmed https://github.com/Cap-go/capacitor-fast-sql/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated GitHub repository links into documentation pages. Links now appear in the page title actions area with GitHub icon styling and are dynamically derived from plugin context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->