### PR TITLE
Make plugin docs header actions responsive

### DIFF
--- a/apps/docs/src/components/doc/CopyPage.astro
+++ b/apps/docs/src/components/doc/CopyPage.astro
@@ -232,20 +232,81 @@ const translations = {
 </div>
 
 <script is:inline define:vars={{ translations, editUrl: editUrl?.toString() ?? '', markdownSourceUrl }}>
+  const getMenuItems = (menu) => Array.from(menu.querySelectorAll('.menu-item')).filter((item) => item instanceof HTMLElement && !item.hasAttribute('disabled'))
+
+  const closeMenu = (menu, restoreFocus = false) => {
+    menu.hidden = true
+
+    if (restoreFocus && menu.previousElementSibling instanceof HTMLElement) {
+      menu.previousElementSibling.focus()
+    }
+  }
+
+  const closeOtherMenus = (currentMenu) => {
+    document.querySelectorAll('.copy-page-menu').forEach((menu) => {
+      if (menu !== currentMenu && menu instanceof HTMLElement) closeMenu(menu)
+    })
+  }
+
+  const openMenu = (menu) => {
+    closeOtherMenus(menu)
+    menu.hidden = false
+    getMenuItems(menu)[0]?.focus()
+  }
+
   // Toggle menu visibility
   const buttons = document.querySelectorAll('.copy-page-button')
   buttons.forEach((button) => {
     button.addEventListener('click', (e) => {
       e.stopPropagation()
       const menu = button.nextElementSibling
-      const isHidden = menu.hidden
+      if (!(menu instanceof HTMLElement)) return
 
-      // Close all other menus
-      document.querySelectorAll('.copy-page-menu').forEach((m) => {
-        if (m !== menu) m.hidden = true
-      })
+      if (menu.hidden) {
+        openMenu(menu)
+      } else {
+        closeMenu(menu)
+      }
+    })
 
-      menu.hidden = !isHidden
+    button.addEventListener('keydown', (e) => {
+      const menu = button.nextElementSibling
+      if (!(menu instanceof HTMLElement)) return
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        openMenu(menu)
+      }
+
+      if (e.key === 'Escape' && !menu.hidden) {
+        e.preventDefault()
+        closeMenu(menu, true)
+      }
+    })
+  })
+
+  document.querySelectorAll('.copy-page-menu').forEach((menu) => {
+    menu.addEventListener('keydown', (e) => {
+      if (!(menu instanceof HTMLElement)) return
+
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        closeMenu(menu, true)
+        return
+      }
+
+      if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(e.key)) return
+
+      const items = getMenuItems(menu)
+      if (items.length === 0) return
+
+      e.preventDefault()
+
+      const currentIndex = items.indexOf(document.activeElement)
+      const nextIndex =
+        e.key === 'Home' ? 0 : e.key === 'End' ? items.length - 1 : e.key === 'ArrowUp' ? (currentIndex - 1 + items.length) % items.length : (currentIndex + 1) % items.length
+
+      items[nextIndex]?.focus()
     })
   })
 
@@ -453,6 +514,11 @@ const translations = {
     border-color: var(--sl-color-gray-4);
   }
 
+  .copy-page-button:focus-visible {
+    outline: 2px solid var(--sl-color-text-accent);
+    outline-offset: 2px;
+  }
+
   .copy-page-button .chevron {
     transition: transform 0.2s;
   }
@@ -492,8 +558,14 @@ const translations = {
     transition: background 0.2s;
   }
 
-  .menu-item:hover {
+  .menu-item:hover,
+  .menu-item:focus-visible {
     background: var(--sl-color-gray-6);
+  }
+
+  .menu-item:focus-visible {
+    outline: 2px solid var(--sl-color-text-accent);
+    outline-offset: -2px;
   }
 
   .menu-item > svg:first-child {
@@ -526,6 +598,8 @@ const translations = {
     .copy-page-menu {
       right: auto;
       left: 0;
+      width: min(20rem, calc(100vw - 2rem));
+      min-width: 0;
     }
   }
 </style>

--- a/apps/docs/src/components/doc/PageTitle.astro
+++ b/apps/docs/src/components/doc/PageTitle.astro
@@ -41,4 +41,24 @@ import PluginRepositoryLink from './PluginRepositoryLink.astro'
       align-items: flex-start;
     }
   }
+
+  @media (max-width: 480px) {
+    .page-title-actions {
+      width: 100%;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.5rem;
+    }
+
+    .page-title-actions :global(.plugin-repository-link),
+    .page-title-actions :global(.copy-page-container),
+    .page-title-actions :global(.copy-page-button) {
+      width: 100%;
+    }
+
+    .page-title-actions :global(.plugin-repository-link),
+    .page-title-actions :global(.copy-page-button) {
+      justify-content: center;
+    }
+  }
 </style>


### PR DESCRIPTION
## Summary
- stack the plugin docs header actions on narrow screens
- clamp the Copy Page dropdown width to the viewport
- prevent horizontal overflow when the Copy Page menu is open on mobile

## Tests
- bunx prettier --write apps/docs/src/components/doc/PageTitle.astro apps/docs/src/components/doc/CopyPage.astro
- Playwright DOM smoke test on http://localhost:3000/docs/plugins/alarm/getting-started/ at 320px with the Copy Page menu open
- bun run ci:verify:docs
- bun run check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked dropdown menu logic for more reliable open/close behavior and keyboard navigation (Arrow keys, Home/End, Escape).
* **Bug Fixes**
  * Ensure only one menu opens at a time and Escape restores focus to the triggering control.
* **Style**
  * Added visible focus outlines and consistent hover/focus styles; improved mobile sizing and stacked page-title actions on small screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->