### PR TITLE
docs: clarify setChannel device override visibility

### DIFF
--- a/apps/docs/src/content/docs/docs/live-updates/channels.mdx
+++ b/apps/docs/src/content/docs/docs/live-updates/channels.mdx
@@ -19,6 +19,7 @@ When a device checks for an update, Capgo decides which channel to use in this s
 
 1. **Forced device mapping (Dashboard)** – Manually pin a specific device ID to a channel. Use for urgent debugging or controlled testing with a single real user. This always wins.
 2. **Cloud override (per‑device) via Dashboard or API** – Created when you change the device's channel in the dashboard or via API. Use for QA users switching between feature / PR channels or to reproduce a user issue. Reinstalling the binary does not clear it; deleting the device entry does.
+3. **Plugin `setChannel()` local channel** – Created when the app calls `setChannel()` and the backend validates that the target channel allows self-assignment. The selected channel is stored locally on that device, takes effect instantly, and is not shown in the Device Override UI.
 
 <Aside type="tip" title="Instant Channel Switching with setChannel()">
 **Starting from plugin version 5.34.0, 6.34.0, 7.34.0, or 8.0.0** (depending on your major version), `setChannel()` works differently: it contacts the backend to **validate** that the channel is allowed (checking if self-assignment is enabled for that channel), then stores the channel **locally on the device** as `defaultChannel`. This means the new channel takes effect **instantly** for the next update check—no waiting for replication.
@@ -31,17 +32,17 @@ Because `setChannel()` is local-only, it does **not** create a Device Override e
 
 **Important:** When channel changes are made via the Dashboard or API, there is still a replication lag of up to 2 minutes before all edge servers reflect the change. For instant channel switching, use `setChannel()` from your app code—it validates with the backend, then sets the channel locally for immediate effect.
 </Aside>
-3. **Capacitor config `defaultChannel` (test build default)** – If present in `capacitor.config.*` and no force/override exists, the app starts on this channel (e.g. `beta`, `qa`, `pr-123`). Intended for TestFlight / internal builds so testers land on a pre‑release channel automatically. Production builds typically leave this unset.
-4. **Cloud Default Channel (primary path ~99% of users)** – If you mark a default channel in the dashboard, all normal end‑users (no force, no override, no config defaultChannel) attach here. Change it to roll out or roll back instantly—no new binary. If you have platform-specific defaults (for example, one iOS-only, one Android-only, one Electron-only), each device lands on the default matching its platform. Leaving the cloud default unset is allowed; in that case the device must match on steps 1–3 to receive updates.
+4. **Capacitor config `defaultChannel` (test build default)** – If present in `capacitor.config.*` and no force/override/local channel exists, the app starts on this channel (e.g. `beta`, `qa`, `pr-123`). Intended for TestFlight / internal builds so testers land on a pre‑release channel automatically. Production builds typically leave this unset.
+5. **Cloud Default Channel (primary path ~99% of users)** – If you mark a default channel in the dashboard, all normal end‑users (no force, no Dashboard/API override, no plugin local channel, no config defaultChannel) attach here. Change it to roll out or roll back instantly—no new binary. If you have platform-specific defaults (for example, one iOS-only, one Android-only, one Electron-only), each device lands on the default matching its platform. Leaving the cloud default unset is allowed; in that case the device must match on steps 1–4 to receive updates.
 
 Best practice:
-- Treat 1–3 as exception / testing layers; when you set a cloud default, real users should flow into it. If you choose not to set one, be deliberate about how users attach (typically via `defaultChannel` in config or per-device overrides).
+- Treat 1–4 as exception / testing layers; when you set a cloud default, real users should flow into it. If you choose not to set one, be deliberate about how users attach (typically via `defaultChannel` in config or per-device overrides).
 - Only configure `defaultChannel` in binaries you explicitly ship to testers. Leaving it unset keeps production logic centralized in the dashboard.
 - Use `setChannel()` sparingly in production—mainly for QA or targeted diagnostics.
 
 If a channel is disabled for the platform (iOS/Android/Electron toggles) when it would otherwise be chosen, the selection process skips it and continues down the list.
 
-> Summary: Force > Override > Config `defaultChannel` > Cloud Default.
+> Summary: Force > Dashboard/API Override > Plugin `setChannel()` local channel > Config `defaultChannel` > Cloud Default.
 
 ## Default Channel Behavior
 

--- a/apps/docs/src/content/docs/docs/live-updates/channels.mdx
+++ b/apps/docs/src/content/docs/docs/live-updates/channels.mdx
@@ -25,6 +25,8 @@ When a device checks for an update, Capgo decides which channel to use in this s
 
 Previously, `setChannel()` saved the channel override to the backend database (like Dashboard or API changes), and devices had to wait for data replication (up to 2 minutes) before the new channel was recognized. The new behavior only reads from the backend (for validation) and stores locally, making channel switches instant.
 
+Because `setChannel()` is local-only, it does **not** create a Device Override entry in the Capgo dashboard. The Device Override UI only shows overrides created from the dashboard or the Public API.
+
 **Note:** Even if a channel becomes disallowed after being set locally, the backend will still validate the channel during update checks, so security is maintained.
 
 **Important:** When channel changes are made via the Dashboard or API, there is still a replication lag of up to 2 minutes before all edge servers reflect the change. For instant channel switching, use `setChannel()` from your app code—it validates with the backend, then sets the channel locally for immediate effect.
@@ -90,7 +92,7 @@ const config: CapacitorConfig = {
 Next, build your web app and run `npx cap sync` to copy the updated config file to your iOS, Android, and Electron projects. If you skip this sync step, your native projects will continue to use whichever channel they were previously configured for.
 
 <Aside type="caution">
-Channel selection order: Force > Override (`setChannel` / dashboard) > Config `defaultChannel` > Cloud Default.
+Channel selection order: Force > Dashboard/API device override > Plugin `setChannel()` local channel > Config `defaultChannel` > Cloud Default.
 
 Use `defaultChannel` only in test/internal builds; leave it out for production so users follow the Cloud Default (when set) instead of duplicating the routing in native config.
 
@@ -165,15 +167,17 @@ When `setChannel()` is called:
 
 **Why this matters:** In older versions, `setChannel()` saved the channel override to the backend database (same as Dashboard or API changes). Devices had to wait for backend replication (up to 2 minutes) before the channel change took effect. Now, `setChannel()` only reads from the backend (for validation) and stores locally, making channel switches instant.
 
+**Dashboard visibility:** A channel set with the plugin does not make the device appear as a Device Override in the Capgo UI. Only channel assignments created from the dashboard or the Public API are listed there. Use the dashboard or API when you need an admin-visible override.
+
 **Security note:** Even if a channel's permissions change after being set locally (e.g., self-assignment is disabled), the backend will still validate the channel during update checks, ensuring security is maintained.
 
 **Comparison of channel change methods:**
 
-| Method | Effect Time | Persisted Where | Use Case |
-|--------|-------------|-----------------|----------|
-| `setChannel()` from plugin | **Instant** | Device only (local) | User-initiated channel switching in-app |
-| Dashboard device override | Up to 2 min | Backend database | Admin-initiated changes for specific devices |
-| API channel assignment | Up to 2 min | Backend database | Automated backend integrations |
+| Method | Effect Time | Persisted Where | Shown in Device Override UI | Use Case |
+|--------|-------------|-----------------|------------------------------|----------|
+| `setChannel()` from plugin | **Instant** | Device only (local) | No | User-initiated channel switching in-app |
+| Dashboard device override | Up to 2 min | Backend database | Yes | Admin-initiated changes for specific devices |
+| API channel assignment | Up to 2 min | Backend database | Yes | Automated backend integrations |
 
 For the best user experience when building channel-switching UIs, always use the plugin's `setChannel()` method.
 

--- a/apps/docs/src/content/docs/docs/live-updates/version-targeting.mdx
+++ b/apps/docs/src/content/docs/docs/live-updates/version-targeting.mdx
@@ -394,13 +394,15 @@ git branch -d v1-maintenance
 
 When multiple channel configurations exist, Capgo uses this precedence order:
 
-1. **Device Override** (Dashboard or API) - Highest priority
-2. **Cloud Override** via `setChannel()` call
+1. **Device Override** (Dashboard or API) - Highest priority and visible in the Device Override UI
+2. **Local plugin channel** via `setChannel()` - Stored on the device only and not shown in the Device Override UI
 3. **defaultChannel** in capacitor.config.ts
 4. **Default Channel** (Cloud setting) - Lowest priority
 
 <Aside type="note" title="Precedence Example">
   If a user's app has `defaultChannel: 'v2'` but you override their device to `'beta'` in the dashboard, they'll receive updates from the `'beta'` channel.
+
+  The Device Override UI only lists overrides set from the dashboard or Public API. Calling `setChannel()` from the app validates the channel with the backend, then stores it locally on the device.
 </Aside>
 
 ## Best Practices

--- a/apps/docs/src/content/docs/docs/live-updates/version-targeting.mdx
+++ b/apps/docs/src/content/docs/docs/live-updates/version-targeting.mdx
@@ -54,14 +54,17 @@ Capgo uses a multi-layered approach to match users with compatible updates:
 graph TD
     A[User Opens App] --> B{Check Device Override}
     B -->|Override Set| C[Use Override Channel]
-    B -->|No Override| D{Check defaultChannel in App}
-    D -->|Has defaultChannel| E[Use App's defaultChannel]
-    D -->|No defaultChannel| F[Use Cloud Default Channel]
-    C --> G{Check Version Constraints}
-    E --> G
-    F --> G
-    G -->|Compatible| H[Deliver Update]
-    G -->|Incompatible| I[Skip Update]
+    B -->|No Override| D{Check local plugin channel}
+    D -->|setChannel value| E[Use local setChannel channel]
+    D -->|No local channel| F{Check defaultChannel in App}
+    F -->|Has defaultChannel| G[Use App's defaultChannel]
+    F -->|No defaultChannel| H[Use Cloud Default Channel]
+    C --> I{Check Version Constraints}
+    E --> I
+    G --> I
+    H --> I
+    I -->|Compatible| J[Deliver Update]
+    I -->|Incompatible| K[Skip Update]
 ```
 
 ## Strategy 1: Channel-Based Version Routing

--- a/apps/docs/src/content/docs/docs/plugin/api.md
+++ b/apps/docs/src/content/docs/docs/plugin/api.md
@@ -816,11 +816,12 @@ This validates the channel with the Capgo backend and, when accepted, stores the
 unsetChannel(options: UnsetChannelOptions) => Promise<void>
 ```
 
-Remove the device's channel assignment and return to the default channel.
+Remove the plugin-managed local channel assignment and continue with normal channel precedence.
 
-This unlinks the device from any specifically assigned channel, causing it to fall back to:
+This clears only the channel stored locally by {@link setChannel}; it does not delete Dashboard or Public API Device Override records. After the local assignment is cleared, normal channel precedence applies:
+- An existing Dashboard or Public API Device Override, if one exists
 - The {@link PluginsConfig.CapacitorUpdater.defaultChannel} if configured, or
-- Your backend's default channel for this app
+- Your backend default channel for this app
 
 Use this when:
 - Users opt out of beta/testing programs

--- a/apps/docs/src/content/docs/docs/plugin/api.md
+++ b/apps/docs/src/content/docs/docs/plugin/api.md
@@ -762,6 +762,8 @@ Assign this device to a specific update channel at runtime.
 Channels allow you to distribute different bundle versions to different groups of users
 (e.g., "production", "beta", "staging"). This method switches the device to a new channel.
 
+**Device Override UI:** `setChannel()` validates the channel with the backend, then stores the selected channel locally on the device. It does not create or update a backend Device Override, so the device will not appear as overridden in the Capgo dashboard. Only assignments created from the dashboard or the Public API are shown in the Device Override UI.
+
 **Requirements:**
 - The target channel must allow self-assignment (configured in your Capgo dashboard or backend)
 - The backend may accept or reject the request based on channel settings

--- a/apps/docs/src/content/docs/docs/plugin/api.md
+++ b/apps/docs/src/content/docs/docs/plugin/api.md
@@ -790,7 +790,7 @@ CapacitorUpdater.addListener('channelPrivate', (data) => {
 });
 ```
 
-This sends a request to the Capgo backend linking your device ID to the specified channel.
+This validates the channel with the Capgo backend and, when accepted, stores the selected channel locally on the device.
 
 **Parameters**
 

--- a/apps/docs/src/content/docs/docs/plugins/updater/api.md
+++ b/apps/docs/src/content/docs/docs/plugins/updater/api.md
@@ -425,7 +425,9 @@ Get Latest bundle available from update Url
 setChannel(options: SetChannelOptions) => Promise<ChannelRes>
 ```
 
-Sets the channel for this device. The channel must have `allow_device_self_set` enabled for this to work.
+Sets the plugin-managed local channel for this device. The channel must have `allow_device_self_set` enabled for this to work.
+
+`setChannel()` validates the channel with the backend, then stores the selected channel locally on the device. It does not create or update a backend Device Override, so the device will not appear as overridden in the Capgo dashboard. Only assignments created from the dashboard or the Public API are shown in the Device Override UI.
 
 **Important notes:**
 - Do not use this method to set the channel at boot. Use the `defaultChannel` in your Capacitor config instead.
@@ -450,7 +452,9 @@ Sets the channel for this device. The channel must have `allow_device_self_set` 
 unsetChannel(options: UnsetChannelOptions) => Promise<void>
 ```
 
-Unset the channel override for this device. After calling this method, the device will automatically receive updates from the **public channel** that matches its conditions (platform, device type, build type).
+Unset the plugin-managed local channel for this device. This clears only the channel stored locally by `setChannel()`; it does not delete Dashboard or Public API Device Override records.
+
+After calling this method, the device will automatically receive updates from the **public channel** that matches its conditions (platform, device type, build type).
 
 This is useful when:
 - You want to move a device back to the default update track

--- a/apps/docs/src/content/docs/docs/plugins/updater/api.md
+++ b/apps/docs/src/content/docs/docs/plugins/updater/api.md
@@ -454,7 +454,7 @@ unsetChannel(options: UnsetChannelOptions) => Promise<void>
 
 Unset the plugin-managed local channel for this device. This clears only the channel stored locally by `setChannel()`; it does not delete Dashboard or Public API Device Override records.
 
-After calling this method, the device will automatically receive updates from the **public channel** that matches its conditions (platform, device type, build type).
+After calling this method, normal channel precedence applies: an existing Dashboard or Public API Device Override still wins; otherwise the device can fall back to the matching public/default channel for its conditions (platform, device type, build type).
 
 This is useful when:
 - You want to move a device back to the default update track

--- a/apps/docs/src/content/docs/docs/plugins/updater/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/updater/index.mdx
@@ -51,7 +51,7 @@ Live update for capacitor apps.
 | `setMultiDelay` | Configure conditions that must be met before a pending update is applied. |
 | `cancelDelay` | Cancel all delay conditions and apply the pending update immediately. |
 | `getLatest` | Check the update server for the latest available bundle version. |
-| `setChannel` | Assign this device to a specific update channel at runtime. |
+| `setChannel` | Set a local runtime update channel for this device. It does not create a dashboard/API device override. |
 | `unsetChannel` | Remove the device's channel assignment and return to the default channel. |
 | `getChannel` | Get the current channel assigned to this device. |
 | `listChannels` | Get a list of all channels available for this device to self-assign to. |

--- a/src/content/docs/docs/plugin/api.md
+++ b/src/content/docs/docs/plugin/api.md
@@ -1091,6 +1091,8 @@ Assign this device to a specific update channel at runtime.
 Channels allow you to distribute different bundle versions to different groups of users
 (e.g., "production", "beta", "staging"). This method switches the device to a new channel.
 
+**Device Override UI:** `setChannel()` validates the channel with the backend, then stores the selected channel locally on the device. It does not create or update a backend Device Override, so the device will not appear as overridden in the Capgo dashboard. Only assignments created from the dashboard or the Public API are shown in the Device Override UI.
+
 **Requirements:**
 - The target channel must allow self-assignment (configured in your Capgo dashboard or backend)
 - The backend may accept or reject the request based on channel settings

--- a/src/content/docs/docs/plugin/api.md
+++ b/src/content/docs/docs/plugin/api.md
@@ -1145,11 +1145,12 @@ This validates the channel with the Capgo backend and, when accepted, stores the
 unsetChannel(options: UnsetChannelOptions) => Promise<void>
 ```
 
-Remove the device's channel assignment and return to the default channel.
+Remove the plugin-managed local channel assignment and continue with normal channel precedence.
 
-This unlinks the device from any specifically assigned channel, causing it to fall back to:
+This clears only the channel stored locally by {@link setChannel}; it does not delete Dashboard or Public API Device Override records. After the local assignment is cleared, normal channel precedence applies:
+- An existing Dashboard or Public API Device Override, if one exists
 - The {@link PluginsConfig.CapacitorUpdater.defaultChannel} if configured, or
-- Your backend's default channel for this app
+- Your backend default channel for this app
 
 Use this when:
 - Users opt out of beta/testing programs

--- a/src/content/docs/docs/plugin/api.md
+++ b/src/content/docs/docs/plugin/api.md
@@ -1119,7 +1119,7 @@ CapacitorUpdater.addListener('channelPrivate', (data) => {
 });
 ```
 
-This sends a request to the Capgo backend linking your device ID to the specified channel.
+This validates the channel with the Capgo backend and, when accepted, stores the selected channel locally on the device.
 
 **Parameters**
 


### PR DESCRIPTION
## What
- Clarify that plugin `setChannel()` stores the channel locally and does not create a dashboard/API Device Override.
- Update channel precedence docs and comparison table so Dashboard/API overrides are distinct from plugin-local channel selection.
- Add the same clarification to updater plugin docs surfaces.

## Why
- Users can expect `setChannel()` devices to appear in the Device Override UI, but only dashboard/API overrides are shown there.
- Source definition PR: https://github.com/Cap-go/capacitor-updater/pull/818

## How
- Updated live update channel docs and version targeting docs.
- Updated generated updater plugin docs to match the upstream definition clarification.

## Testing
- `bunx prettier --write apps/docs/src/content/docs/docs/live-updates/channels.mdx apps/docs/src/content/docs/docs/live-updates/version-targeting.mdx apps/docs/src/content/docs/docs/plugin/api.md apps/docs/src/content/docs/docs/plugins/updater/index.mdx src/content/docs/docs/plugin/api.md`
- `NODE_OPTIONS=--max-old-space-size=16384 bun run check` in `apps/docs`

## Not Tested
- Full root `bun run check` was not run; this change is docs-only and scoped to `apps/docs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `setChannel()` behavior: it sets a local runtime update channel on the device and does not create a dashboard Device Override entry.
  * Updated channel precedence documentation to reflect the ordering between local plugin settings and dashboard overrides.
  * Enhanced API documentation with Device Override UI visibility notes for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->