### PR TITLE
docs: add persistent uuid plugin

### DIFF
--- a/apps/docs/src/config/llmsCustomSets.ts
+++ b/apps/docs/src/config/llmsCustomSets.ts
@@ -89,6 +89,7 @@ Plugin Pedometer|step counting pedometer plugin|docs/plugins/pedometer/**
 Plugin Persona|Persona identity verification inquiry plugin|docs/plugins/persona/**
 Plugin Intune|Microsoft Intune MAM and MSAL plugin|docs/plugins/intune/**
 Plugin Persistent Account|persistent account storage plugin|docs/plugins/persistent-account/**
+Plugin Persistent UUID|persistent app-scoped UUID plugin|docs/plugins/persistent-uuid/**
 Plugin Photo Library|photo library access plugin|docs/plugins/photo-library/**
 Plugin Printer|printing plugin for documents and images|docs/plugins/printer/**
 Plugin RealtimeKit|real-time communication plugin|docs/plugins/realtimekit/**

--- a/apps/docs/src/config/sidebar.mjs
+++ b/apps/docs/src/config/sidebar.mjs
@@ -181,6 +181,7 @@ const pluginEntries = [
   ['Persona', 'persona'],
   ['Intune', 'intune', [linkItem('iOS', '/docs/plugins/intune/ios'), linkItem('Android', '/docs/plugins/intune/android')]],
   ['Persistent Account', 'persistent-account'],
+  ['Persistent UUID', 'persistent-uuid', [linkItem('iOS behavior', '/docs/plugins/persistent-uuid/ios'), linkItem('Android behavior', '/docs/plugins/persistent-uuid/android')]],
   ['Photo Library', 'photo-library'],
   ['Pretty Toast', 'pretty-toast'],
   ['Printer', 'printer'],

--- a/apps/docs/src/content/docs/docs/plugins/persistent-uuid/android.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/persistent-uuid/android.mdx
@@ -1,0 +1,34 @@
+---
+title: Android Behavior
+description: "How @capgo/capacitor-persistent-uuid persists identifiers on Android."
+sidebar:
+  order: 3
+---
+
+## Storage Model
+
+On Android, the plugin stores the UUID in AccountManager under a plugin-owned authenticator account. The default account name uses the app package name as the scope.
+
+This lets the UUID survive common reinstall paths where app-private storage would be removed, including Android Studio uninstall/reinstall cycles and installs signed with different debug or Play signing keys when the package name stays the same.
+
+## Stable Scope Rules
+
+Use the default scope when the app package name is stable across builds.
+
+~~~typescript
+const result = await PersistentUuid.getId();
+~~~
+
+Use a custom scope when debug, staging, and production builds use different package identifiers but should share one persistent UUID.
+
+~~~typescript
+const result = await PersistentUuid.getId({ scope: 'com.example.app' });
+~~~
+
+## Limits
+
+The UUID can be lost if the user removes the account from Android settings, the device is factory reset, the package/scope changes, or the app calls resetId.
+
+## Keep going from Android Behavior
+
+If you are validating Android reinstall behavior, connect this page with [Getting Started](/docs/plugins/persistent-uuid/getting-started/) for API usage, [iOS behavior](/docs/plugins/persistent-uuid/ios/) for Apple platform differences, and [Using @capgo/capacitor-persistent-uuid](/plugins/capacitor-persistent-uuid/) for a complete walkthrough.

--- a/apps/docs/src/content/docs/docs/plugins/persistent-uuid/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/persistent-uuid/getting-started.mdx
@@ -1,0 +1,62 @@
+---
+title: Getting Started
+description: "Install @capgo/capacitor-persistent-uuid and create a stable app UUID."
+sidebar:
+  order: 2
+---
+
+## Install
+
+~~~bash
+npm install @capgo/capacitor-persistent-uuid
+npx cap sync
+~~~
+
+## Import
+
+~~~typescript
+import { PersistentUuid } from '@capgo/capacitor-persistent-uuid';
+~~~
+
+## Read Or Create The UUID
+
+~~~typescript
+import { PersistentUuid } from '@capgo/capacitor-persistent-uuid';
+
+const result = await PersistentUuid.getId();
+
+console.log(result.id);
+console.log(result.scope);
+console.log(result.created);
+~~~
+
+The first call creates and stores a UUID. Later calls return the same UUID for the same scope.
+
+## Use A Stable Custom Scope
+
+The native default scope is the package name on Android and the bundle identifier on iOS. If debug and production builds use different package identifiers but should share one UUID, pass a shared scope.
+
+~~~typescript
+const result = await PersistentUuid.getId({
+  scope: 'com.example.app',
+});
+~~~
+
+## Reset The UUID
+
+Call resetId when the user logs out, requests a privacy reset, or when automated tests need a new identifier.
+
+~~~typescript
+const replacement = await PersistentUuid.resetId();
+console.log(replacement.id);
+~~~
+
+## Persistence Expectations
+
+- Android can survive uninstall and reinstall, including Android Studio and Play installs with different signing keys, when the package name or custom scope is stable.
+- iOS survives app updates and iOS updates while Keychain access rules remain the same.
+- Web uses localStorage and is only a development fallback.
+
+## Keep going from Getting Started
+
+If you are using **Getting Started** to add persistent app identity, connect it with [@capgo/capacitor-persistent-uuid](/docs/plugins/persistent-uuid/) for the overview, [Android behavior](/docs/plugins/persistent-uuid/android/) for reinstall behavior, [iOS behavior](/docs/plugins/persistent-uuid/ios/) for Keychain behavior, [Using @capgo/capacitor-persistent-uuid](/plugins/capacitor-persistent-uuid/) for the tutorial, and [Capgo Plugin Directory](/plugins/) for other native plugins.

--- a/apps/docs/src/content/docs/docs/plugins/persistent-uuid/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/persistent-uuid/index.mdx
@@ -1,0 +1,57 @@
+---
+title: "@capgo/capacitor-persistent-uuid"
+description: "Generate and store a persistent app-scoped UUID for Capacitor apps."
+tableOfContents: false
+next: false
+prev: false
+sidebar:
+  order: 1
+  label: "Introduction"
+hero:
+  tagline: "Persistent app UUID for Capacitor."
+  actions:
+    - text: Get started
+      link: /docs/plugins/persistent-uuid/getting-started/
+      icon: right-arrow
+      variant: primary
+    - text: GitHub
+      link: https://github.com/Cap-go/capacitor-persistent-uuid/
+      icon: external
+      variant: minimal
+---
+
+## Overview
+
+The Persistent UUID plugin creates a random RFC 4122 UUID once and stores it with native persistence. Use it when your app needs a stable, app-scoped identifier that can survive app reinstall flows, Android Studio reinstall cycles, app updates, and device OS updates.
+
+## Core Capabilities
+
+- getId - Read the stored UUID, creating one if none exists for the selected scope.
+- resetId - Rotate the UUID for logout, account reset, privacy reset, or test cleanup flows.
+- scope - Use a stable namespace when debug and production builds use different package identifiers but should share one identifier.
+
+## Platform Storage
+
+| Platform | Storage | Default scope |
+| --- | --- | --- |
+| Android | AccountManager account owned by the plugin authenticator | App package name |
+| iOS | Keychain generic password, device-only accessibility | Bundle identifier |
+| Web | localStorage fallback | web |
+
+This is not a hardware identifier. It does not survive factory reset, manual account removal, Keychain clearing, browser storage clearing, or an explicit resetId call.
+
+## Public API
+
+| Method | Description |
+| --- | --- |
+| getId | Read or create the persistent UUID for a scope. |
+| resetId | Replace the stored UUID for a scope. |
+| getPluginVersion | Return the native plugin version marker. |
+
+## Source Of Truth
+
+This reference is synced from src/definitions.ts in [capacitor-persistent-uuid](https://github.com/Cap-go/capacitor-persistent-uuid/).
+
+## Keep going from @capgo/capacitor-persistent-uuid
+
+If you are using **@capgo/capacitor-persistent-uuid** to identify an app install across reinstall flows, connect it with [Getting Started](/docs/plugins/persistent-uuid/getting-started/) for install and usage, [Android behavior](/docs/plugins/persistent-uuid/android/) for AccountManager details, [iOS behavior](/docs/plugins/persistent-uuid/ios/) for Keychain details, [Using @capgo/capacitor-persistent-uuid](/plugins/capacitor-persistent-uuid/) for the tutorial, and [@capgo/capacitor-persistent-account](/docs/plugins/persistent-account/) when you need to persist account data instead of an identifier.

--- a/apps/docs/src/content/docs/docs/plugins/persistent-uuid/ios.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/persistent-uuid/ios.mdx
@@ -1,0 +1,34 @@
+---
+title: iOS Behavior
+description: "How @capgo/capacitor-persistent-uuid persists identifiers on iOS."
+sidebar:
+  order: 4
+---
+
+## Storage Model
+
+On iOS, the plugin stores the UUID in Keychain as a generic password item. The item is device-only and uses the bundle identifier as the default scope.
+
+This survives app updates and iOS updates. It also survives reinstall flows as long as iOS keeps the Keychain item and the app keeps compatible Keychain access through the same bundle and Apple team rules.
+
+## Stable Scope Rules
+
+Use the default scope when the bundle identifier is stable.
+
+~~~typescript
+const result = await PersistentUuid.getId();
+~~~
+
+Use a custom scope when multiple build variants should resolve to one app identifier.
+
+~~~typescript
+const result = await PersistentUuid.getId({ scope: 'com.example.app' });
+~~~
+
+## Limits
+
+The UUID can be lost if the user erases the device, Keychain data is cleared, Keychain access changes, the bundle/team access changes, or the app calls resetId.
+
+## Keep going from iOS Behavior
+
+If you are validating iOS persistence, connect this page with [Getting Started](/docs/plugins/persistent-uuid/getting-started/) for API usage, [Android behavior](/docs/plugins/persistent-uuid/android/) for Android reinstall behavior, and [Using @capgo/capacitor-persistent-uuid](/plugins/capacitor-persistent-uuid/) for a complete walkthrough.

--- a/apps/web/public/icons/plugins/capacitor-persistent-uuid.svg
+++ b/apps/web/public/icons/plugins/capacitor-persistent-uuid.svg
@@ -1,0 +1,9 @@
+<svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="56" height="56" rx="12" fill="#119eff" />
+  <path d="M16 18h24a4 4 0 0 1 4 4v12a4 4 0 0 1-4 4H16a4 4 0 0 1-4-4V22a4 4 0 0 1 4-4Z" fill="white" fill-opacity="0.18" />
+  <path d="M18 28h20" stroke="white" stroke-width="3" stroke-linecap="round" />
+  <path d="M18 34h10" stroke="white" stroke-width="3" stroke-linecap="round" />
+  <path d="M24 22v-3a4 4 0 0 1 8 0v3" stroke="white" stroke-width="3" stroke-linecap="round" />
+  <circle cx="38" cy="34" r="4" fill="white" />
+  <path d="M42 34h4m-2 0v4" stroke="white" stroke-width="2.5" stroke-linecap="round" />
+</svg>

--- a/apps/web/public/icons/plugins/persistent-uuid.svg
+++ b/apps/web/public/icons/plugins/persistent-uuid.svg
@@ -1,0 +1,9 @@
+<svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="56" height="56" rx="12" fill="#119eff" />
+  <path d="M16 18h24a4 4 0 0 1 4 4v12a4 4 0 0 1-4 4H16a4 4 0 0 1-4-4V22a4 4 0 0 1 4-4Z" fill="white" fill-opacity="0.18" />
+  <path d="M18 28h20" stroke="white" stroke-width="3" stroke-linecap="round" />
+  <path d="M18 34h10" stroke="white" stroke-width="3" stroke-linecap="round" />
+  <path d="M24 22v-3a4 4 0 0 1 8 0v3" stroke="white" stroke-width="3" stroke-linecap="round" />
+  <circle cx="38" cy="34" r="4" fill="white" />
+  <path d="M42 34h4m-2 0v4" stroke="white" stroke-width="2.5" stroke-linecap="round" />
+</svg>

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -92,6 +92,7 @@ const actionDefinitionRows =
 @capgo/capacitor-proximity|github.com/Cap-go|Enable native proximity monitoring so your app can react when the device is near a face, hand, or surface|https://github.com/Cap-go/capacitor-proximity/|Proximity
 @capgo/capacitor-pdf-generator|github.com/Cap-go|Create PDF documents from HTML templates for invoices, reports, and receipts|https://github.com/Cap-go/capacitor-pdf-generator/|PDF Generator
 @capgo/capacitor-persistent-account|github.com/Cap-go|Preserve user authentication and account data across app reinstalls and updates|https://github.com/Cap-go/capacitor-persistent-account/|Persistent Account
+@capgo/capacitor-persistent-uuid|github.com/Cap-go|Generate and persist one app-scoped UUID across reinstalls, app updates, and OS updates|https://github.com/Cap-go/capacitor-persistent-uuid/|Persistent UUID
 @capgo/capacitor-photo-library|github.com/Cap-go|Browse, save, and manage photos and videos in device photo library with permissions|https://github.com/Cap-go/capacitor-photo-library/|Photo Library
 @capgo/capacitor-sim|github.com/Cap-go|Retrieve SIM card information including carrier name, country code, and phone number|https://github.com/Cap-go/capacitor-sim/|SIM
 @capgo/capacitor-speech-recognition|github.com/Cap-go|Natural, low-latency speech recognition with streaming partial results and cross-platform parity|https://github.com/Cap-go/capacitor-speech-recognition/|Speech Recognition
@@ -236,6 +237,7 @@ const pluginIconsByName: Record<string, string> = {
   '@capgo/capacitor-privacy-screen': 'EyeSlash',
   '@capgo/capacitor-pdf-generator': 'DocumentText',
   '@capgo/capacitor-persistent-account': 'UserCircle',
+  '@capgo/capacitor-persistent-uuid': 'FingerPrint',
   '@capgo/capacitor-photo-library': 'Photo',
   '@capgo/capacitor-sim': 'Signal',
   '@capgo/capacitor-speech-recognition': 'Microphone',

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-persistent-uuid.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-persistent-uuid.md
@@ -1,0 +1,63 @@
+---
+locale: en
+---
+# Using @capgo/capacitor-persistent-uuid
+
+Generate one persistent app-scoped UUID for Capacitor and keep it stable across reinstall and update flows where normal app storage is removed.
+
+## Install
+
+~~~bash
+npm install @capgo/capacitor-persistent-uuid
+npx cap sync
+~~~
+
+## What This Plugin Exposes
+
+- getId - Read the stored UUID, creating one if none exists for the selected scope.
+- resetId - Rotate the stored UUID for logout, privacy reset, or test cleanup flows.
+- scope - Optional namespace for apps whose debug and production package identifiers differ.
+
+## Example Usage
+
+~~~typescript
+import { PersistentUuid } from '@capgo/capacitor-persistent-uuid';
+
+const { id, created, scope } = await PersistentUuid.getId();
+
+console.log(id);
+console.log(created);
+console.log(scope);
+~~~
+
+## Share One UUID Across Build Variants
+
+~~~typescript
+const result = await PersistentUuid.getId({
+  scope: 'com.example.app',
+});
+
+console.log(result.id);
+~~~
+
+## Reset The Identifier
+
+~~~typescript
+const replacement = await PersistentUuid.resetId();
+console.log(replacement.id);
+~~~
+
+## Platform Notes
+
+Android stores the UUID in AccountManager so it can survive Android Studio reinstall cycles and debug vs Play signing differences when the package name or custom scope is stable. iOS stores the UUID in Keychain and keeps it through app and iOS updates while Keychain access remains compatible. Web uses localStorage as a development fallback.
+
+This plugin does not expose a hardware ID and does not survive factory reset, manual account removal, Keychain clearing, browser storage clearing, or resetId.
+
+## Full Reference
+
+- GitHub: https://github.com/Cap-go/capacitor-persistent-uuid/
+- Docs: /docs/plugins/persistent-uuid/
+
+## Keep Going
+
+If you are using **@capgo/capacitor-persistent-uuid** to keep app identity stable, connect it with [@capgo/capacitor-persistent-uuid](/docs/plugins/persistent-uuid/) for the overview, [Getting Started](/docs/plugins/persistent-uuid/getting-started/) for install and API examples, [Android behavior](/docs/plugins/persistent-uuid/android/) for reinstall details, [iOS behavior](/docs/plugins/persistent-uuid/ios/) for Keychain details, and [@capgo/capacitor-persistent-account](/plugins/capacitor-persistent-account/) when you need account data persistence instead of a UUID.


### PR DESCRIPTION
## Summary
- Add @capgo/capacitor-persistent-uuid to the plugin directory.
- Add docs pages for getting started, Android behavior, iOS behavior, and LLM docs generation.
- Add plugin tutorial content and icons.

## Verification
- bun run ci:verify:docs
- bun run ci:verify:web