### PR TITLE
docs: add YouTube referer patch config

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/youtube-player/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/youtube-player/getting-started.mdx
@@ -18,6 +18,28 @@ bunx cap sync
 import { YoutubePlayer } from '@capgo/capacitor-youtube-player';
 ```
 
+## Fix YouTube Referer Blocking in the Main WebView
+
+If YouTube works inside the plugin but fails when the same app loads YouTube pages, embeds, or APIs through Capacitor's main WebView, enable `patchRefererHeader` in your Capacitor config.
+
+When enabled, the plugin patches Capacitor during sync/update so intercepted YouTube requests include a valid `Referer` header.
+
+```json
+{
+  "plugins": {
+    "YoutubePlayer": {
+      "patchRefererHeader": true,
+      "refererHeader": "https://www.youtube.com"
+    }
+  }
+}
+```
+
+- Only `youtube.com`, `youtube-nocookie.com`, and `youtu.be` requests are affected.
+- Requests that already define a `Referer` header keep their original value.
+- `refererHeader` is optional and defaults to `https://www.youtube.com`.
+- Supported on Capacitor `8.x` for installed iOS and Android platforms.
+
 ## API Overview
 
 ### `initialize`

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-youtube-player.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-youtube-player.md
@@ -19,6 +19,23 @@ bunx cap sync
 - `stopVideo` - Stop video playback and cancel loading. Use this sparingly - pauseVideo() is usually preferred.
 - `playVideo` - Play the currently cued or loaded video. Final player state will be PLAYING (1).
 
+## Main WebView Referer Patch
+
+Enable `patchRefererHeader` when YouTube content works in the plugin but fails from Capacitor's main WebView because YouTube expects a browser-like `Referer` header.
+
+```json
+{
+  "plugins": {
+    "YoutubePlayer": {
+      "patchRefererHeader": true,
+      "refererHeader": "https://www.youtube.com"
+    }
+  }
+}
+```
+
+The patch only applies to `youtube.com`, `youtube-nocookie.com`, and `youtu.be` requests. Existing request-level `Referer` headers are preserved, and `refererHeader` defaults to `https://www.youtube.com` when omitted.
+
 ## Example Usage
 
 ### `initialize`


### PR DESCRIPTION
## Summary
- document the YouTube Player `patchRefererHeader` Capacitor config in plugin docs
- add the same config guidance to the plugin tutorial page

## Tests
- `bunx prettier --write apps/docs/src/content/docs/docs/plugins/youtube-player/getting-started.mdx apps/web/src/content/plugins-tutorials/en/capacitor-youtube-player.md`
- `NODE_OPTIONS=--max-old-space-size=16384 bunx astro check` in `apps/docs`
- `NODE_OPTIONS=--max-old-space-size=16384 bunx astro check` in `apps/web`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Enhanced Getting Started guide with instructions for resolving YouTube playback issues in the main WebView using the `patchRefererHeader` configuration option
* Added configuration documentation for the YouTube player plugin, including setup examples and affected domain information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->