### PR TITLE
[codex] Add AI-friendly plugin index endpoints

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -60,6 +60,21 @@
   Access-Control-Expose-Headers: Link, ETag
   Cache-Control: public, max-age=3600
 
+/plugins.md
+  Content-Type: text/markdown; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, HEAD
+  Cache-Control: public, max-age=3600
+  Link: </plugins.json>; rel="alternate"; type="application/json"
+
+/plugins.json
+  Content-Type: application/json; charset=utf-8
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, HEAD
+  Access-Control-Expose-Headers: Link, ETag
+  Cache-Control: public, max-age=3600
+  Link: </plugins.md>; rel="alternate"; type="text/markdown"
+
 /sitemap.xml
   Content-Type: text/xml
 

--- a/apps/web/src/lib/pluginDirectory.ts
+++ b/apps/web/src/lib/pluginDirectory.ts
@@ -1,0 +1,143 @@
+import { actions, pluginCount, type Plugin } from '@/config/plugins'
+import { getPluginsWithStars, getSlug } from '@/services/github'
+import { defaultLocale } from '@/services/locale'
+import { getPluginDocsSlugs, resolvePluginDocsSlug } from '@/services/pluginDocs'
+
+export interface PluginDirectoryEntry {
+  rank: number
+  packageName?: string
+  title: string
+  slug: string
+  description: string
+  author: string
+  repositoryName: string
+  docsSlug?: string
+  urls: {
+    github: string
+    npm?: string
+    capgo?: string
+    docs?: string
+  }
+  metrics: {
+    githubStars?: number
+    npmWeeklyDownloads?: number
+  }
+  searchText: string
+}
+
+export interface PluginDirectory {
+  schemaVersion: 1
+  name: string
+  description: string
+  count: number
+  urls: {
+    markdown: string
+    json: string
+    directory: string
+  }
+  plugins: PluginDirectoryEntry[]
+}
+
+const normalizeBaseUrl = (baseUrl: string) => baseUrl.replace(/\/+$/, '')
+
+const absoluteUrl = (baseUrl: string, path: string) => new URL(path, `${normalizeBaseUrl(baseUrl)}/`).toString()
+
+const getRepositoryName = (href: string) => {
+  const normalizedHref = href.replace(/\/$/, '')
+  const repoHref = normalizedHref.includes('/tree/') ? normalizedHref.slice(0, normalizedHref.indexOf('/tree/')) : normalizedHref
+
+  return repoHref.slice(repoHref.lastIndexOf('/') + 1)
+}
+
+const getNpmUrl = (packageName?: string) => (packageName ? `https://www.npmjs.com/package/${packageName}` : undefined)
+
+const compact = <T>(items: (T | undefined)[]): T[] => items.filter((item): item is T => item !== undefined)
+
+export const buildPluginDirectory = async (baseUrl: string, pluginPageSlugs: ReadonlySet<string> = new Set()): Promise<PluginDirectory> => {
+  const { docsSlugs } = await getPluginDocsSlugs(defaultLocale)
+  const plugins = getPluginsWithStars(actions).map((plugin: Plugin, index): PluginDirectoryEntry => {
+    const slug = getSlug(plugin.href)
+    const docsSlug = resolvePluginDocsSlug(plugin, docsSlugs)
+    const repositoryName = getRepositoryName(plugin.href)
+    const capgoUrl = pluginPageSlugs.has(slug) ? absoluteUrl(baseUrl, `/plugins/${slug}/`) : undefined
+    const docsUrl = docsSlug ? absoluteUrl(baseUrl, `/docs/plugins/${docsSlug}/`) : undefined
+    const npmUrl = getNpmUrl(plugin.name)
+    const searchParts = compact([plugin.title, plugin.name, slug, repositoryName, docsSlug, plugin.description])
+
+    return {
+      rank: index + 1,
+      packageName: plugin.name,
+      title: plugin.title,
+      slug,
+      description: plugin.description,
+      author: plugin.author,
+      repositoryName,
+      docsSlug,
+      urls: {
+        github: plugin.href,
+        npm: npmUrl,
+        capgo: capgoUrl,
+        docs: docsUrl,
+      },
+      metrics: {
+        githubStars: plugin.githubStars,
+        npmWeeklyDownloads: plugin.npmDownloads,
+      },
+      searchText: searchParts.join(' | '),
+    }
+  })
+
+  return {
+    schemaVersion: 1,
+    name: 'Capgo Capacitor Plugin Index',
+    description: 'Searchable registry of Capgo and Capacitor plugins for AI agents, skills, and developer tools.',
+    count: pluginCount,
+    urls: {
+      markdown: absoluteUrl(baseUrl, '/plugins.md'),
+      json: absoluteUrl(baseUrl, '/plugins.json'),
+      directory: absoluteUrl(baseUrl, '/plugins/'),
+    },
+    plugins,
+  }
+}
+
+const formatMetric = (value?: number) => (value === undefined ? 'unknown' : value.toString())
+
+const renderPluginMarkdown = (plugin: PluginDirectoryEntry) => {
+  const lines = [
+    `## ${plugin.title}`,
+    '',
+    `- Package: ${plugin.packageName ? `\`${plugin.packageName}\`` : 'unknown'}`,
+    `- Slug: \`${plugin.slug}\``,
+    `- Summary: ${plugin.description}`,
+    `- GitHub: ${plugin.urls.github}`,
+  ]
+
+  if (plugin.urls.npm) lines.push(`- NPM: ${plugin.urls.npm}`)
+  if (plugin.urls.capgo) lines.push(`- Capgo page: ${plugin.urls.capgo}`)
+  if (plugin.urls.docs) lines.push(`- Docs: ${plugin.urls.docs}`)
+
+  lines.push(`- Weekly npm downloads: ${formatMetric(plugin.metrics.npmWeeklyDownloads)}`)
+  lines.push(`- GitHub stars: ${formatMetric(plugin.metrics.githubStars)}`)
+  lines.push(`- Search text: ${plugin.searchText}`)
+  lines.push('')
+
+  return lines.join('\n')
+}
+
+export const renderPluginDirectoryMarkdown = (directory: PluginDirectory) =>
+  [
+    '# Capgo Capacitor Plugin Index',
+    '',
+    directory.description,
+    '',
+    `Total plugins: ${directory.count}`,
+    '',
+    `JSON API: ${directory.urls.json}`,
+    `Human directory: ${directory.urls.directory}`,
+    '',
+    'Use this file to search Capgo plugins by package name, title, slug, repository, docs slug, and summary.',
+    '',
+    ...directory.plugins.map(renderPluginMarkdown),
+    '',
+  ].join('\n')

--- a/apps/web/src/lib/pluginDirectoryEndpoint.ts
+++ b/apps/web/src/lib/pluginDirectoryEndpoint.ts
@@ -1,0 +1,28 @@
+import { useRuntimeConfig } from '@/config/app'
+import { pluginDemosBySlug } from '@/config/pluginDemos'
+import { buildPluginDirectory } from '@/lib/pluginDirectory'
+import { getSlug } from '@/services/github'
+import { defaultLocale } from '@/services/locale'
+import { getCollection } from 'astro:content'
+
+const getPluginPageSlugs = async () => {
+  const pluginPageSlugs = new Set<string>()
+  const tutorialEntries = await getCollection('plugin', ({ data, filePath }) => data.published !== false && Boolean(filePath) && (data.locale ?? defaultLocale) === defaultLocale)
+
+  for (const entry of tutorialEntries) {
+    if (entry.filePath) pluginPageSlugs.add(getSlug(entry.filePath).replace(/\.md$/, ''))
+  }
+
+  for (const slug of Object.keys(pluginDemosBySlug)) {
+    pluginPageSlugs.add(slug)
+  }
+
+  return pluginPageSlugs
+}
+
+export const getPluginDirectoryForEndpoint = async () => {
+  const config = useRuntimeConfig()
+  const pluginPageSlugs = await getPluginPageSlugs()
+
+  return buildPluginDirectory(config.public.baseUrl, pluginPageSlugs)
+}

--- a/apps/web/src/pages/plugins.json.ts
+++ b/apps/web/src/pages/plugins.json.ts
@@ -1,0 +1,19 @@
+import { getPluginDirectoryForEndpoint } from '@/lib/pluginDirectoryEndpoint'
+import type { APIRoute } from 'astro'
+
+export const prerender = true
+
+export const GET: APIRoute = async () => {
+  const directory = await getPluginDirectoryForEndpoint()
+
+  return new Response(JSON.stringify(directory, null, 2), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, HEAD',
+      'Access-Control-Expose-Headers': 'Link, ETag',
+      Link: `<${directory.urls.markdown}>; rel="alternate"; type="text/markdown"`,
+    },
+  })
+}

--- a/apps/web/src/pages/plugins.md.ts
+++ b/apps/web/src/pages/plugins.md.ts
@@ -1,0 +1,19 @@
+import { getPluginDirectoryForEndpoint } from '@/lib/pluginDirectoryEndpoint'
+import { renderPluginDirectoryMarkdown } from '@/lib/pluginDirectory'
+import type { APIRoute } from 'astro'
+
+export const prerender = true
+
+export const GET: APIRoute = async () => {
+  const directory = await getPluginDirectoryForEndpoint()
+
+  return new Response(renderPluginDirectoryMarkdown(directory), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, HEAD',
+      Link: `<${directory.urls.json}>; rel="alternate"; type="application/json"`,
+    },
+  })
+}

--- a/apps/web/src/services/pluginDocs.ts
+++ b/apps/web/src/services/pluginDocs.ts
@@ -1,6 +1,8 @@
 import type { Action } from '@/config/plugins'
 import { defaultLocale, locales, type Locales } from '@/services/locale'
 import { globSync } from 'glob'
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 type PluginReference = Pick<Action, 'href' | 'name'>
@@ -10,7 +12,12 @@ type PluginDocsSlugs = {
   docsSlugs: Set<string>
 }
 
-const DOCS_CONTENT_ROOT = fileURLToPath(new URL('../../../docs/src/content/docs/', import.meta.url))
+const docsContentRootCandidates = [
+  fileURLToPath(new URL('../../../docs/src/content/docs/', import.meta.url)),
+  resolve(process.cwd(), '../docs/src/content/docs'),
+  resolve(process.cwd(), 'apps/docs/src/content/docs'),
+]
+const DOCS_CONTENT_ROOT = docsContentRootCandidates.find((path) => existsSync(path)) ?? docsContentRootCandidates[0]
 
 const getPluginDocEntry = (filePath?: string): { locale: Locales; slug: string } | null => {
   if (!filePath) return null


### PR DESCRIPTION
## Summary
- add `/plugins.md` as a generated Markdown index for AI agents and skills
- add `/plugins.json` as a generated JSON API with package, docs, Capgo, npm, GitHub, metrics, and search fields
- make plugin docs slug discovery resilient when the web build runs from bundled static endpoint code
- add static headers for content type, CORS, cache, and alternate links

## Validation
- `bunx prettier --write apps/web/src/lib/pluginDirectory.ts apps/web/src/lib/pluginDirectoryEndpoint.ts apps/web/src/services/pluginDocs.ts apps/web/src/pages/plugins.md.ts apps/web/src/pages/plugins.json.ts apps/web/public/_headers`
- `NODE_OPTIONS=--max-old-space-size=16384 bunx astro check`
- `bun run build`

## Generated endpoint check
- `/plugins.json` emits 142 plugins
- `/plugins.md` and `/plugins.json` are emitted by `astro build`
