### PR TITLE
[codex] Add Live Activities native iOS setup documentation

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/live-activities/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/live-activities/getting-started.mdx
@@ -12,6 +12,98 @@ bun add @capgo/capacitor-live-activities
 bunx cap sync
 ```
 
+## iOS Setup
+
+Installing and syncing the plugin does not create the native Live Activity UI. ActivityKit requires a Widget Extension that registers a Live Activity configuration before `startActivity` can display anything.
+
+### Requirements
+
+- Use iOS 16.1 or later for both the app target and Widget Extension target.
+- Test on an iOS device or a compatible simulator. The Dynamic Island only appears on supported device models; other devices use the Lock Screen presentation.
+- Keep the combined static and dynamic ActivityKit data below Apple's 4 KB limit.
+
+### 1. Create a Widget Extension
+
+Open the native iOS project:
+
+```bash
+bunx cap open ios
+```
+
+Then:
+
+1. Select **File > New > Target**.
+2. Add a **Widget Extension**.
+3. Enable **Include Live Activity**.
+4. Disable **Include Configuration Intent** unless the app also needs a configurable widget.
+5. Ensure the generated extension is embedded in the main app target.
+
+The Widget Extension must contain an `ActivityConfiguration` and register it in its `WidgetBundle`. It must provide every required Live Activity presentation:
+
+- Lock Screen
+- Dynamic Island expanded
+- Dynamic Island compact leading and trailing
+- Dynamic Island minimal
+
+Adding the target alone is not sufficient. The native app or plugin must call ActivityKit's request, update, and end APIs. The extension must contain SwiftUI code that can decode and render the same `ActivityAttributes` and content state used by those calls. Include shared ActivityKit models in both the main app and Widget Extension targets. The Xcode-generated Live Activity template does not automatically render the JSON layouts passed to this plugin; the extension also needs a compatible native layout renderer.
+
+### 2. Enable Live Activities
+
+Add the following key to the main app target's `Info.plist`:
+
+```xml
+<key>NSSupportsLiveActivities</key>
+<true/>
+```
+
+If the project generates its `Info.plist`, add **Supports Live Activities** with a Boolean value of `YES` under the main app target's custom iOS target properties instead.
+
+### 3. Configure the App Group for Shared Images
+
+An App Group is only required when using `saveImage`, `removeImage`, `listImages`, or `cleanupImages`. The plugin derives the App Group identifier from the main app bundle identifier using this exact format:
+
+```text
+group.<MAIN_APP_BUNDLE_ID>.liveactivities
+```
+
+For example, an app with bundle identifier `com.example.delivery` must use:
+
+```text
+group.com.example.delivery.liveactivities
+```
+
+In Xcode, add the **App Groups** capability to both the main app target and the Widget Extension target, then enable the same identifier on both targets.
+
+Live Activity extensions cannot access the network. Download remote images in the main app and save them to the shared App Group before referencing them from a Live Activity. For bundled images, also enable the Widget Extension in the asset's target membership.
+
+### 4. Configure Deep Links
+
+When using `behavior.widgetUrl` or a timer sequence `tapUrl`, register the matching URL scheme or Universal Link in the main app. For a custom scheme such as `myapp://order/12345`, add the scheme under the main app target's **Info > URL Types** settings.
+
+### 5. Optional: Enable Server-Driven Updates
+
+Push Notifications are not required for local updates initiated by the app. To start, update, or end Live Activities from a server:
+
+- Add the **Push Notifications** capability to the main app target.
+- Obtain ActivityKit push tokens and send them to the server.
+- Send ActivityKit notifications through APNs using the `liveactivity` push type.
+- Add `NSSupportsLiveActivitiesFrequentUpdates` to the main app `Info.plist` only when the use case requires frequent push updates.
+
+ActivityKit push tokens are separate from standard user-notification device tokens.
+Enabling the Push Notifications capability alone is not sufficient; server-driven updates require native token handling and an APNs backend.
+
+### Native Setup Checklist
+
+Before calling `startActivity`, verify that:
+
+- `NSSupportsLiveActivities` is enabled on the main app target.
+- The Widget Extension is embedded and registers an `ActivityConfiguration`.
+- The native ActivityKit implementation and Widget Extension use the same `ActivityAttributes` type.
+- The app and Widget Extension deployment targets are iOS 16.1 or later.
+- Live Activities are enabled for the app in iOS Settings.
+- The matching App Group is enabled on both targets when using shared images.
+- Any custom URL scheme used by `widgetUrl` or `tapUrl` is registered.
+
 ## Import
 
 ```typescript

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-live-activities.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-live-activities.md
@@ -12,6 +12,44 @@ bun add @capgo/capacitor-live-activities
 bunx cap sync
 ```
 
+## iOS Setup
+
+Installing and syncing the plugin does not create the native Live Activity UI. Before calling `startActivity`, configure ActivityKit in Xcode:
+
+1. Run `bunx cap open ios`.
+2. Add a **Widget Extension** target and enable **Include Live Activity**.
+3. Set the app and Widget Extension deployment targets to iOS 16.1 or later.
+4. Ensure the extension is embedded in the main app.
+5. Keep an `ActivityConfiguration` registered in the extension's `WidgetBundle`, with Lock Screen and all Dynamic Island presentations.
+6. Add `NSSupportsLiveActivities` to the main app target's `Info.plist`.
+
+```xml
+<key>NSSupportsLiveActivities</key>
+<true/>
+```
+
+Adding the target alone is not sufficient. The native app or plugin must call ActivityKit's request, update, and end APIs. The Widget Extension must contain SwiftUI code that can decode and render the same `ActivityAttributes` and content state used by those calls. Include shared ActivityKit models in both the main app and Widget Extension targets. The Xcode-generated Live Activity template does not automatically render the JSON layouts passed to this plugin; the extension also needs a compatible native layout renderer.
+
+### Shared Images
+
+When using the image-management methods, add the **App Groups** capability to the main app and Widget Extension targets. Enable the same group on both targets using the exact identifier expected by the plugin:
+
+```text
+group.<MAIN_APP_BUNDLE_ID>.liveactivities
+```
+
+Live Activity extensions cannot access the network. Download remote images in the main app, save them to the shared App Group with `saveImage`, and then reference the saved image from the layout. Bundled assets must also belong to the Widget Extension target.
+
+### Deep Links and Push Updates
+
+- Register any custom URL scheme used by `behavior.widgetUrl` or `tapUrl` under the main app target's **Info > URL Types** settings.
+- For server-driven updates, add the **Push Notifications** capability and implement ActivityKit push-token handling with APNs.
+- Add `NSSupportsLiveActivitiesFrequentUpdates` only when the app requires frequent ActivityKit push updates.
+
+Enabling the Push Notifications capability alone is not sufficient; server-driven updates require native token handling and an APNs backend.
+
+ActivityKit limits the combined static and dynamic Live Activity data to 4 KB. The Dynamic Island is only visible on supported device models; other devices use the Lock Screen presentation.
+
 ## What This Plugin Exposes
 
 - `areActivitiesSupported` - Check if Live Activities are supported on this device. Requires iOS 16.1+ and device support.

--- a/src/content/docs/docs/plugins/live-activities/getting-started.mdx
+++ b/src/content/docs/docs/plugins/live-activities/getting-started.mdx
@@ -12,6 +12,98 @@ bun add @capgo/capacitor-live-activities
 bunx cap sync
 ```
 
+## iOS Setup
+
+Installing and syncing the plugin does not create the native Live Activity UI. ActivityKit requires a Widget Extension that registers a Live Activity configuration before `startActivity` can display anything.
+
+### Requirements
+
+- Use iOS 16.1 or later for both the app target and Widget Extension target.
+- Test on an iOS device or a compatible simulator. The Dynamic Island only appears on supported device models; other devices use the Lock Screen presentation.
+- Keep the combined static and dynamic ActivityKit data below Apple's 4 KB limit.
+
+### 1. Create a Widget Extension
+
+Open the native iOS project:
+
+```bash
+bunx cap open ios
+```
+
+Then:
+
+1. Select **File > New > Target**.
+2. Add a **Widget Extension**.
+3. Enable **Include Live Activity**.
+4. Disable **Include Configuration Intent** unless the app also needs a configurable widget.
+5. Ensure the generated extension is embedded in the main app target.
+
+The Widget Extension must contain an `ActivityConfiguration` and register it in its `WidgetBundle`. It must provide every required Live Activity presentation:
+
+- Lock Screen
+- Dynamic Island expanded
+- Dynamic Island compact leading and trailing
+- Dynamic Island minimal
+
+Adding the target alone is not sufficient. The native app or plugin must call ActivityKit's request, update, and end APIs. The extension must contain SwiftUI code that can decode and render the same `ActivityAttributes` and content state used by those calls. Include shared ActivityKit models in both the main app and Widget Extension targets. The Xcode-generated Live Activity template does not automatically render the JSON layouts passed to this plugin; the extension also needs a compatible native layout renderer.
+
+### 2. Enable Live Activities
+
+Add the following key to the main app target's `Info.plist`:
+
+```xml
+<key>NSSupportsLiveActivities</key>
+<true/>
+```
+
+If the project generates its `Info.plist`, add **Supports Live Activities** with a Boolean value of `YES` under the main app target's custom iOS target properties instead.
+
+### 3. Configure the App Group for Shared Images
+
+An App Group is only required when using `saveImage`, `removeImage`, `listImages`, or `cleanupImages`. The plugin derives the App Group identifier from the main app bundle identifier using this exact format:
+
+```text
+group.<MAIN_APP_BUNDLE_ID>.liveactivities
+```
+
+For example, an app with bundle identifier `com.example.delivery` must use:
+
+```text
+group.com.example.delivery.liveactivities
+```
+
+In Xcode, add the **App Groups** capability to both the main app target and the Widget Extension target, then enable the same identifier on both targets.
+
+Live Activity extensions cannot access the network. Download remote images in the main app and save them to the shared App Group before referencing them from a Live Activity. For bundled images, also enable the Widget Extension in the asset's target membership.
+
+### 4. Configure Deep Links
+
+When using `behavior.widgetUrl` or a timer sequence `tapUrl`, register the matching URL scheme or Universal Link in the main app. For a custom scheme such as `myapp://order/12345`, add the scheme under the main app target's **Info > URL Types** settings.
+
+### 5. Optional: Enable Server-Driven Updates
+
+Push Notifications are not required for local updates initiated by the app. To start, update, or end Live Activities from a server:
+
+- Add the **Push Notifications** capability to the main app target.
+- Obtain ActivityKit push tokens and send them to the server.
+- Send ActivityKit notifications through APNs using the `liveactivity` push type.
+- Add `NSSupportsLiveActivitiesFrequentUpdates` to the main app `Info.plist` only when the use case requires frequent push updates.
+
+ActivityKit push tokens are separate from standard user-notification device tokens.
+Enabling the Push Notifications capability alone is not sufficient; server-driven updates require native token handling and an APNs backend.
+
+### Native Setup Checklist
+
+Before calling `startActivity`, verify that:
+
+- `NSSupportsLiveActivities` is enabled on the main app target.
+- The Widget Extension is embedded and registers an `ActivityConfiguration`.
+- The native ActivityKit implementation and Widget Extension use the same `ActivityAttributes` type.
+- The app and Widget Extension deployment targets are iOS 16.1 or later.
+- Live Activities are enabled for the app in iOS Settings.
+- The matching App Group is enabled on both targets when using shared images.
+- Any custom URL scheme used by `widgetUrl` or `tapUrl` is registered.
+
 ## Import
 
 ```typescript


### PR DESCRIPTION
## Summary

- add a from-scratch native iOS setup guide for Live Activities
- document Widget Extension, ActivityKit model, `Info.plist`, App Group, deep-link, and optional APNs requirements
- clarify that Xcode's generated template does not automatically render the plugin's JSON layouts
- keep the mirrored plugin docs and web tutorial aligned

## Why

The existing documentation moved directly from installation to JavaScript API calls and omitted the native ActivityKit configuration required before a Live Activity can display. This left developers without the Widget Extension, capabilities, shared model, and platform constraints needed to diagnose setup failures.

## Validation

- `bunx prettier --write` on touched files
- `bun run check:docs-mirror`
- `NODE_OPTIONS=--max-old-space-size=16384 bun run check` in `apps/docs`
- `NODE_OPTIONS=--max-old-space-size=16384 bun run check` in `apps/web`
- `git diff --check`

Both Astro checks completed with 0 errors. They each reported one pre-existing hint outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive iOS setup guidance for Live Activities, including prerequisites (iOS 16.1+), widget extension configuration, Info.plist and App Groups setup, deep linking, optional push update configuration, and a verification checklist before implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->