### PR TITLE
[codex] add ai-assisted plugin setup docs

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/accelerometer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/accelerometer/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-accelerometer` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-accelerometer` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/accelerometer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/accelerometer/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-accelerometer` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-accelerometer
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/admob/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/admob/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-admob` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-admob` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/admob/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/admob/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-admob` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-admob
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/age-range/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/age-range/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-age-range` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-age-range
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/age-range/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/age-range/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-age-range` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-age-range` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/age-signals/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/age-signals/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-android-age-signals` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-android-age-signals
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/age-signals/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/age-signals/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-android-age-signals` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-android-age-signals` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/alarm/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/alarm/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-alarm` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-alarm` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/alarm/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/alarm/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-alarm` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-alarm
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/android-inline-install/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/android-inline-install/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-android-inline-install` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-android-inline-install` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/android-inline-install/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/android-inline-install/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-android-inline-install` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-android-inline-install
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/android-kiosk/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/android-kiosk/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-android-kiosk` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-android-kiosk
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/android-kiosk/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/android-kiosk/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-android-kiosk` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-android-kiosk` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/android-sms-retriever/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/android-sms-retriever/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-android-sms-retriever` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-android-sms-retriever
 bunx cap sync android

--- a/apps/docs/src/content/docs/docs/plugins/android-sms-retriever/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/android-sms-retriever/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-android-sms-retriever` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-android-sms-retriever` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/android-usagestatsmanager/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/android-usagestatsmanager/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-android-usagestatsmanager` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-android-usagestatsmanager
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/android-usagestatsmanager/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/android-usagestatsmanager/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-android-usagestatsmanager` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-android-usagestatsmanager` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/app-attest/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/app-attest/getting-started.mdx
@@ -8,6 +8,22 @@ sidebar:
 import { PackageManagers } from 'starlight-package-managers'
 import { Steps } from '@astrojs/starlight/components';
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-app-attest` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the package**
    <PackageManagers pkg="@capgo/capacitor-app-attest" pkgManagers={['bun']} />

--- a/apps/docs/src/content/docs/docs/plugins/app-attest/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/app-attest/getting-started.mdx
@@ -13,13 +13,13 @@ import { Steps } from '@astrojs/starlight/components';
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-app-attest` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-app-attest` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/app-tracking-transparency/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/app-tracking-transparency/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-app-tracking-transparency` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-app-tracking-transparency` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/app-tracking-transparency/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/app-tracking-transparency/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-app-tracking-transparency` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-app-tracking-transparency
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/appinsights/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/appinsights/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-appinsights` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-appinsights` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/appinsights/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/appinsights/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-appinsights` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-appinsights
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/appsflyer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/appsflyer/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-appsflyer` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-appsflyer` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/appsflyer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/appsflyer/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-appsflyer` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-appsflyer
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/audio-recorder/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/audio-recorder/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-audio-recorder` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-audio-recorder` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/audio-recorder/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/audio-recorder/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-audio-recorder` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-audio-recorder
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/audiosession/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/audiosession/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-audio-session` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-audio-session
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/audiosession/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/audiosession/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-audio-session` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-audio-session` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/auto/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/auto/getting-started.mdx
@@ -8,6 +8,22 @@ sidebar:
 import { Steps, Aside } from '@astrojs/starlight/components';
 import { PackageManagers } from 'starlight-package-managers'
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-auto` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the package**
    <PackageManagers pkg="@capgo/capacitor-auto" pkgManagers={['npm']} />

--- a/apps/docs/src/content/docs/docs/plugins/auto/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/auto/getting-started.mdx
@@ -13,13 +13,13 @@ import { PackageManagers } from 'starlight-package-managers'
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-auto` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-auto` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/autofill-save-password/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/autofill-save-password/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-autofill-save-password` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-autofill-save-password` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/autofill-save-password/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/autofill-save-password/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-autofill-save-password` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-autofill-save-password
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/background-geolocation/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/background-geolocation/getting-started.mdx
@@ -13,13 +13,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/background-geolocation` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/background-geolocation` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/background-geolocation/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/background-geolocation/getting-started.mdx
@@ -10,6 +10,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/background-geolocation` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/background-geolocation
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/background-task/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/background-task/getting-started.mdx
@@ -12,13 +12,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-background-task` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-background-task` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/background-task/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/background-task/getting-started.mdx
@@ -9,6 +9,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-background-task` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 npm install @capgo/capacitor-background-task
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/barometer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/barometer/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-barometer` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-barometer
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/barometer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/barometer/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-barometer` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-barometer` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/bluetooth-low-energy/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/bluetooth-low-energy/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-bluetooth-low-energy` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-bluetooth-low-energy` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/bluetooth-low-energy/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/bluetooth-low-energy/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-bluetooth-low-energy` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-bluetooth-low-energy
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/brightness/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/brightness/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-brightness` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-brightness` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/brightness/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/brightness/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-brightness` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-brightness
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/calendar/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/calendar/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-calendar` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 npm install @capgo/capacitor-calendar
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/calendar/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/calendar/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-calendar` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-calendar` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/camera-preview/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/camera-preview/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/camera-preview` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/camera-preview
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/camera-preview/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/camera-preview/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/camera-preview` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/camera-preview` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/capacitor-patch/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/capacitor-patch/getting-started.mdx
@@ -12,13 +12,13 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-patch` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-patch` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/capacitor-patch/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/capacitor-patch/getting-started.mdx
@@ -9,6 +9,20 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-patch` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 npm install @capgo/capacitor-patch
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/capacitor-plus/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/capacitor-plus/getting-started.mdx
@@ -14,13 +14,13 @@ import { PackageManagers } from 'starlight-package-managers'
 You can use our AI-Assisted Setup to install Capacitor+. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capacitor-plus/core`, `@capacitor-plus/cli`, `@capacitor-plus/android`, and `@capacitor-plus/ios` packages in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capacitor-plus/core`, `@capacitor-plus/cli`, `@capacitor-plus/android`, and `@capacitor-plus/ios` packages in my project.
 ```
 
 If you prefer Manual Setup, install the packages by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/capacitor-plus/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/capacitor-plus/getting-started.mdx
@@ -11,6 +11,20 @@ import { PackageManagers } from 'starlight-package-managers'
 
 ## New Project Installation
 
+You can use our AI-Assisted Setup to install Capacitor+. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capacitor-plus/core`, `@capacitor-plus/cli`, `@capacitor-plus/android`, and `@capacitor-plus/ios` packages in my project.
+```
+
+If you prefer Manual Setup, install the packages by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install core packages**
    ```bash

--- a/apps/docs/src/content/docs/docs/plugins/compass/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/compass/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-compass` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-compass
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/compass/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/compass/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-compass` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-compass` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/contacts/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/contacts/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-contacts` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-contacts
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/contacts/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/contacts/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-contacts` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-contacts` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/contentsquare/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/contentsquare/getting-started.mdx
@@ -12,13 +12,13 @@ import PluginSetupSteps from '@/components/doc/PluginSetupSteps.astro';
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-contentsquare` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-contentsquare` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/contentsquare/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/contentsquare/getting-started.mdx
@@ -7,6 +7,22 @@ sidebar:
 
 import PluginSetupSteps from '@/components/doc/PluginSetupSteps.astro';
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-contentsquare` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <PluginSetupSteps
   pkg="@capgo/capacitor-contentsquare"
   stepTitle="Review the upstream product configuration"

--- a/apps/docs/src/content/docs/docs/plugins/crisp/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/crisp/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-crisp` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-crisp` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/crisp/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/crisp/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-crisp` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-crisp
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/data-storage-sqlite/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/data-storage-sqlite/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-data-storage-sqlite` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-data-storage-sqlite
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/data-storage-sqlite/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/data-storage-sqlite/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-data-storage-sqlite` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-data-storage-sqlite` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/date-picker/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/date-picker/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-date-picker` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-date-picker` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/date-picker/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/date-picker/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-date-picker` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 npm install @capgo/capacitor-date-picker
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/device-info/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/device-info/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-device-info` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-device-info` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/device-info/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/device-info/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-device-info` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-device-info
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/document-scanner/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/document-scanner/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-document-scanner` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-document-scanner` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/document-scanner/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/document-scanner/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-document-scanner` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-document-scanner
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/downloader/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/downloader/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-downloader` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-downloader` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/downloader/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/downloader/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-downloader` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-downloader
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/electron-updater/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/electron-updater/getting-started.mdx
@@ -21,6 +21,20 @@ This guide walks you through setting up `@capgo/electron-updater` in your Electr
 
 ## Installation
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/electron-updater` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 
 1. Install the package:

--- a/apps/docs/src/content/docs/docs/plugins/electron-updater/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/electron-updater/getting-started.mdx
@@ -24,13 +24,13 @@ This guide walks you through setting up `@capgo/electron-updater` in your Electr
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/electron-updater` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/electron-updater` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/env/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/env/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-env` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-env
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/env/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/env/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-env` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-env` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/facebook-analytics/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/facebook-analytics/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-facebook-analytics` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-facebook-analytics
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/facebook-analytics/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/facebook-analytics/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-facebook-analytics` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-facebook-analytics` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/fast-sql/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/fast-sql/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-fast-sql` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-fast-sql
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/fast-sql/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/fast-sql/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-fast-sql` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-fast-sql` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/ffmpeg/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/ffmpeg/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-ffmpeg` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-ffmpeg
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/ffmpeg/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/ffmpeg/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-ffmpeg` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-ffmpeg` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/file-compressor/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/file-compressor/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-file-compressor` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-file-compressor
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/file-compressor/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/file-compressor/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-file-compressor` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-file-compressor` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/file-picker/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/file-picker/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-file-picker` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-file-picker` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/file-picker/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/file-picker/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-file-picker` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-file-picker
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/file-sharer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/file-sharer/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-file-sharer` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-file-sharer` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/file-sharer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/file-sharer/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-file-sharer` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-file-sharer
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/file/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/file/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-file` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-file
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/file/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/file/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-file` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-file` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/firebase-analytics/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-analytics/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-analytics` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-firebase-analytics
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/firebase-analytics/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-analytics/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-analytics` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-firebase-analytics` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/firebase-app-check/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-app-check/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-app-check` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-firebase-app-check` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/firebase-app-check/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-app-check/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-app-check` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-firebase-app-check
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/firebase-app/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-app/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-app` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-firebase-app
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/firebase-app/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-app/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-app` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-firebase-app` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/firebase-authentication/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-authentication/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-authentication` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-firebase-authentication
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/firebase-authentication/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-authentication/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-authentication` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-firebase-authentication` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/firebase-crashlytics/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-crashlytics/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-crashlytics` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-firebase-crashlytics` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/firebase-crashlytics/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-crashlytics/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-crashlytics` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-firebase-crashlytics
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/firebase-firestore/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-firestore/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-firestore` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-firebase-firestore` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/firebase-firestore/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-firestore/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-firestore` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-firebase-firestore
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/firebase-functions/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-functions/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-functions` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-firebase-functions` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/firebase-functions/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-functions/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-functions` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-firebase-functions
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/firebase-messaging/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-messaging/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-messaging` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-firebase-messaging
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/firebase-messaging/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-messaging/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-messaging` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-firebase-messaging` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/firebase-performance/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-performance/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-performance` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-firebase-performance
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/firebase-performance/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-performance/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-performance` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-firebase-performance` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/firebase-remote-config/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-remote-config/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-remote-config` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-firebase-remote-config
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/firebase-remote-config/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-remote-config/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-remote-config` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-firebase-remote-config` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/firebase-storage/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-storage/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-storage` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-firebase-storage` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/firebase-storage/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/firebase-storage/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-firebase-storage` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-firebase-storage
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/flash/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/flash/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-flash` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-flash` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/flash/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/flash/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-flash` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-flash
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/gtm/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/gtm/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-gtm` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-gtm` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/gtm/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/gtm/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-gtm` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-gtm
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/health/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/health/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-health` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-health
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/health/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/health/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-health` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-health` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/home-indicator/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/home-indicator/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-home-indicator` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-home-indicator` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/home-indicator/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/home-indicator/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-home-indicator` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-home-indicator
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/ibeacon/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/ibeacon/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-ibeacon` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-ibeacon` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/ibeacon/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/ibeacon/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-ibeacon` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-ibeacon
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/in-app-review/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/in-app-review/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-in-app-review` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-in-app-review
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/in-app-review/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/in-app-review/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-in-app-review` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-in-app-review` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/inappbrowser/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/inappbrowser/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-inappbrowser` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 npm install @capgo/capacitor-inappbrowser
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/inappbrowser/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/inappbrowser/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-inappbrowser` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-inappbrowser` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/incoming-call-kit/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/incoming-call-kit/getting-started.mdx
@@ -13,13 +13,13 @@ import { Steps } from '@astrojs/starlight/components';
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-incoming-call-kit` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-incoming-call-kit` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/incoming-call-kit/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/incoming-call-kit/getting-started.mdx
@@ -8,6 +8,22 @@ sidebar:
 import { PackageManagers } from 'starlight-package-managers'
 import { Steps } from '@astrojs/starlight/components';
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-incoming-call-kit` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the package**
    <PackageManagers pkg="@capgo/capacitor-incoming-call-kit" pkgManagers={['bun']} />

--- a/apps/docs/src/content/docs/docs/plugins/install-referrer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/install-referrer/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-install-referrer` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-install-referrer
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/install-referrer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/install-referrer/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-install-referrer` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-install-referrer` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/intent-launcher/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/intent-launcher/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-intent-launcher` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-intent-launcher
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/intent-launcher/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/intent-launcher/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-intent-launcher` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-intent-launcher` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/intercom/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/intercom/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-intercom` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-intercom
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/intercom/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/intercom/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-intercom` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-intercom` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/intune/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/intune/getting-started.mdx
@@ -13,13 +13,13 @@ import { PackageManagers } from 'starlight-package-managers'
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-intune` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-intune` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/intune/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/intune/getting-started.mdx
@@ -8,6 +8,22 @@ sidebar:
 import { Steps } from '@astrojs/starlight/components';
 import { PackageManagers } from 'starlight-package-managers'
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-intune` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the package**
    <PackageManagers pkg="@capgo/capacitor-intune" pkgManagers={['bun']} />

--- a/apps/docs/src/content/docs/docs/plugins/is-root/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/is-root/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-is-root` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-is-root` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/is-root/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/is-root/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-is-root` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-is-root
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/ivs-player/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/ivs-player/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-ivs-player` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-ivs-player
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/ivs-player/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/ivs-player/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-ivs-player` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-ivs-player` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/jw-player/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/jw-player/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-jw-player` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-jw-player
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/jw-player/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/jw-player/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-jw-player` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-jw-player` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/keep-awake/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/keep-awake/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-keep-awake` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-keep-awake
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/keep-awake/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/keep-awake/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-keep-awake` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-keep-awake` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/launch-navigator/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/launch-navigator/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-launch-navigator` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-launch-navigator
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/launch-navigator/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/launch-navigator/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-launch-navigator` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-launch-navigator` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/light-sensor/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/light-sensor/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-light-sensor` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-light-sensor
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/light-sensor/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/light-sensor/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-light-sensor` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-light-sensor` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/live-activities/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/live-activities/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-live-activities` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-live-activities
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/live-activities/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/live-activities/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-live-activities` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-live-activities` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/live-reload/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/live-reload/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-live-reload` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-live-reload` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/live-reload/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/live-reload/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-live-reload` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-live-reload
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/llm/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/llm/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-llm` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-llm
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/llm/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/llm/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-llm` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-llm` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/media-session/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/media-session/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-media-session` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-media-session
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/media-session/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/media-session/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-media-session` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-media-session` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/mqtt/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/mqtt/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-mqtt` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-mqtt
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/mqtt/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/mqtt/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-mqtt` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-mqtt` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/mute/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/mute/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-mute` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-mute` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/mute/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/mute/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-mute` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-mute
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/mux-player/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/mux-player/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-mux-player` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-mux-player
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/mux-player/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/mux-player/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-mux-player` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-mux-player` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/native-audio/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-audio/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-native-audio` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 npm install @capgo/capacitor-native-audio
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/native-audio/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-audio/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-native-audio` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-native-audio` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/native-biometric/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-biometric/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-native-biometric` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-native-biometric` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/native-biometric/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-biometric/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-native-biometric` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-native-biometric
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/native-loader/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-loader/getting-started.mdx
@@ -12,13 +12,13 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-native-loader` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-native-loader` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/native-loader/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-loader/getting-started.mdx
@@ -7,6 +7,22 @@ sidebar:
 
 import { Steps, Aside } from '@astrojs/starlight/components';
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-native-loader` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the package**
 

--- a/apps/docs/src/content/docs/docs/plugins/native-market/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-market/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-native-market` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 npm install @capgo/capacitor-native-market
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/native-market/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-market/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-native-market` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-native-market` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/native-navigation/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-navigation/getting-started.mdx
@@ -8,6 +8,22 @@ sidebar:
 import { Steps, Aside } from '@astrojs/starlight/components';
 import { PackageManagers } from 'starlight-package-managers'
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-native-navigation` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the package**
    <PackageManagers pkg="@capgo/capacitor-native-navigation" pkgManagers={['npm']} />

--- a/apps/docs/src/content/docs/docs/plugins/native-navigation/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-navigation/getting-started.mdx
@@ -13,13 +13,13 @@ import { PackageManagers } from 'starlight-package-managers'
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-native-navigation` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-native-navigation` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/native-purchases/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-purchases/getting-started.mdx
@@ -9,6 +9,22 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 import { Steps } from '@astrojs/starlight/components';
 import { PackageManagers } from 'starlight-package-managers'
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/native-purchases` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the package**
    <PackageManagers pkg="@capgo/native-purchases" pkgManagers={['bun']} />

--- a/apps/docs/src/content/docs/docs/plugins/native-purchases/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/native-purchases/getting-started.mdx
@@ -14,13 +14,13 @@ import { PackageManagers } from 'starlight-package-managers'
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/native-purchases` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/native-purchases` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/nativegeocoder/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/nativegeocoder/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-nativegeocoder` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-nativegeocoder` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/nativegeocoder/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/nativegeocoder/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-nativegeocoder` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 npm install @capgo/capacitor-nativegeocoder
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/navigation-bar/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/navigation-bar/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-navigation-bar` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-navigation-bar
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/navigation-bar/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/navigation-bar/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-navigation-bar` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-navigation-bar` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/network-diagnostics/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/network-diagnostics/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-network-diagnostics` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-network-diagnostics` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/network-diagnostics/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/network-diagnostics/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-network-diagnostics` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 npm install @capgo/capacitor-network-diagnostics
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/nfc/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/nfc/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-nfc` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-nfc` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/nfc/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/nfc/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-nfc` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-nfc
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/passkey/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/passkey/getting-started.mdx
@@ -13,13 +13,13 @@ import { PackageManagers } from 'starlight-package-managers'
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-passkey` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-passkey` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/passkey/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/passkey/getting-started.mdx
@@ -8,6 +8,22 @@ sidebar:
 import { Steps, Card, CardGrid } from '@astrojs/starlight/components';
 import { PackageManagers } from 'starlight-package-managers'
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-passkey` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the package**
    <PackageManagers pkg="@capgo/capacitor-passkey" pkgManagers={['bun']} />

--- a/apps/docs/src/content/docs/docs/plugins/pay/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/pay/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-pay` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-pay
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/pay/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/pay/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-pay` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-pay` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/pdf-generator/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/pdf-generator/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-pdf-generator` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-pdf-generator
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/pdf-generator/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/pdf-generator/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-pdf-generator` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-pdf-generator` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/pedometer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/pedometer/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-pedometer` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-pedometer` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/pedometer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/pedometer/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-pedometer` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-pedometer
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/persistent-account/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/persistent-account/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-persistent-account` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-persistent-account
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/persistent-account/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/persistent-account/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-persistent-account` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-persistent-account` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/persistent-uuid/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/persistent-uuid/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-persistent-uuid` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ~~~bash
 npm install @capgo/capacitor-persistent-uuid
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/persistent-uuid/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/persistent-uuid/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-persistent-uuid` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-persistent-uuid` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/persona/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/persona/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-intune` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-intune` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/persona/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/persona/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-intune` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-intune
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/photo-library/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/photo-library/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-photo-library` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-photo-library
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/photo-library/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/photo-library/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-photo-library` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-photo-library` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/pretty-toast/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/pretty-toast/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-pretty-toast` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-pretty-toast` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/pretty-toast/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/pretty-toast/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-pretty-toast` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 npm install @capgo/capacitor-pretty-toast
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/printer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/printer/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-printer` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-printer
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/printer/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/printer/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-printer` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-printer` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/privacy-screen/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/privacy-screen/getting-started.mdx
@@ -13,13 +13,13 @@ import { PackageManagers } from 'starlight-package-managers'
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-privacy-screen` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-privacy-screen` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/privacy-screen/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/privacy-screen/getting-started.mdx
@@ -8,6 +8,22 @@ sidebar:
 import { Steps } from '@astrojs/starlight/components';
 import { PackageManagers } from 'starlight-package-managers'
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-privacy-screen` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the plugin**
    <PackageManagers pkg="@capgo/capacitor-privacy-screen" pkgManagers={['bun']} />

--- a/apps/docs/src/content/docs/docs/plugins/proximity/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/proximity/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-proximity` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-proximity
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/proximity/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/proximity/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-proximity` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-proximity` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/realtimekit/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/realtimekit/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-realtimekit` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-realtimekit
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/realtimekit/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/realtimekit/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-realtimekit` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-realtimekit` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/recaptcha/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/recaptcha/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-recaptcha` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 npm install @capgo/capacitor-recaptcha
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/recaptcha/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/recaptcha/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-recaptcha` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-recaptcha` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/ricoh360-camera/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/ricoh360-camera/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-ricoh360` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 npm install @capgo/capacitor-ricoh360
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/ricoh360-camera/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/ricoh360-camera/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-ricoh360` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-ricoh360` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/rudderstack/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/rudderstack/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-rudderstack` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-rudderstack
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/rudderstack/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/rudderstack/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-rudderstack` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-rudderstack` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/screen-orientation/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/screen-orientation/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-screen-orientation` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-screen-orientation` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/screen-orientation/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/screen-orientation/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-screen-orientation` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-screen-orientation
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/screen-recorder/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/screen-recorder/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-screen-recorder` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-screen-recorder` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/screen-recorder/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/screen-recorder/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-screen-recorder` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-screen-recorder
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/shake/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/shake/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-shake` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-shake` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/shake/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/shake/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-shake` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-shake
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/share-target/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/share-target/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-share-target` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-share-target` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/share-target/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/share-target/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-share-target` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-share-target
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/sheets/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/sheets/getting-started.mdx
@@ -12,13 +12,13 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-sheets` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-sheets` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/sheets/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/sheets/getting-started.mdx
@@ -7,6 +7,22 @@ sidebar:
 
 import { Steps, Aside } from '@astrojs/starlight/components';
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-sheets` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the package**
 

--- a/apps/docs/src/content/docs/docs/plugins/sim/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/sim/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-sim` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-sim
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/sim/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/sim/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-sim` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-sim` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/social-login/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/social-login/getting-started.mdx
@@ -15,13 +15,13 @@ import MicroCard from '@/components/MicroCard.astro'
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-social-login` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-social-login` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/social-login/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/social-login/getting-started.mdx
@@ -10,6 +10,22 @@ import { Code, Card, CardGrid } from '@astrojs/starlight/components';
 import { PackageManagers } from 'starlight-package-managers'
 import MicroCard from '@/components/MicroCard.astro'
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-social-login` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the package**
    <PackageManagers pkg="@capgo/capacitor-social-login" pkgManagers={['bun']} />

--- a/apps/docs/src/content/docs/docs/plugins/speech-recognition/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/speech-recognition/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-speech-recognition` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-speech-recognition
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/speech-recognition/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/speech-recognition/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-speech-recognition` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-speech-recognition` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/speech-synthesis/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/speech-synthesis/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-speech-synthesis` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-speech-synthesis
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/speech-synthesis/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/speech-synthesis/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-speech-synthesis` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-speech-synthesis` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/ssl-pinning/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/ssl-pinning/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-ssl-pinning` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-ssl-pinning
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/ssl-pinning/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/ssl-pinning/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-ssl-pinning` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-ssl-pinning` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/streamcall/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/streamcall/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-stream-call` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-stream-call` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/streamcall/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/streamcall/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-stream-call` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-stream-call
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/supabase/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/supabase/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-supabase` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-supabase` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/supabase/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/supabase/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-supabase` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 npm install @capgo/capacitor-supabase
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/textinteraction/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/textinteraction/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-textinteraction` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-textinteraction` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/textinteraction/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/textinteraction/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-textinteraction` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-textinteraction
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/transitions/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/transitions/getting-started.mdx
@@ -12,13 +12,13 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-transitions` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-transitions` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/transitions/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/transitions/getting-started.mdx
@@ -7,6 +7,22 @@ sidebar:
 
 import { Steps, Aside } from '@astrojs/starlight/components';
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-transitions` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the package**
 

--- a/apps/docs/src/content/docs/docs/plugins/twilio-video/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/twilio-video/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-twilio-video` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-twilio-video` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/twilio-video/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/twilio-video/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-twilio-video` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-twilio-video
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/twilio-voice/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/twilio-voice/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-twilio-voice` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-twilio-voice` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/twilio-voice/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/twilio-voice/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-twilio-voice` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-twilio-voice
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/updater/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/updater/getting-started.mdx
@@ -12,13 +12,13 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-updater` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-updater` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/updater/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/updater/getting-started.mdx
@@ -9,6 +9,20 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## Installation
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-updater` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Tabs>
   <TabItem label="npm">
     ```bash

--- a/apps/docs/src/content/docs/docs/plugins/uploader/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/uploader/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-uploader` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-uploader
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/uploader/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/uploader/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-uploader` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-uploader` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/verisoul/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/verisoul/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-verisoul` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-verisoul` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/verisoul/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/verisoul/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-verisoul` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 npm install @capgo/capacitor-verisoul
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/video-player/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/video-player/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-video-player` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-video-player
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/video-player/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/video-player/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-video-player` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-video-player` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/video-thumbnails/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/video-thumbnails/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-video-thumbnails` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-video-thumbnails` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/video-thumbnails/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/video-thumbnails/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-video-thumbnails` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-video-thumbnails
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/volume-buttons/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/volume-buttons/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-volume-buttons` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-volume-buttons
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/volume-buttons/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/volume-buttons/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-volume-buttons` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-volume-buttons` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/watch/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/watch/getting-started.mdx
@@ -8,6 +8,22 @@ sidebar:
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 import { PackageManagers } from 'starlight-package-managers'
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-watch` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the package**
    <PackageManagers pkg="@capgo/capacitor-watch" pkgManagers={['bun']} />

--- a/apps/docs/src/content/docs/docs/plugins/watch/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/watch/getting-started.mdx
@@ -13,13 +13,13 @@ import { PackageManagers } from 'starlight-package-managers'
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-watch` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-watch` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-webview-crash` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 npm install @capgo/capacitor-webview-crash
 npx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-crash/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-webview-crash` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-webview-crash` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/webview-guardian/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-guardian/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-webview-guardian` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-webview-guardian` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/webview-guardian/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-guardian/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-webview-guardian` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-webview-guardian
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/webview-version-checker/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-version-checker/getting-started.mdx
@@ -13,13 +13,13 @@ import { Steps } from '@astrojs/starlight/components';
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-webview-version-checker` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-webview-version-checker` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/webview-version-checker/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/webview-version-checker/getting-started.mdx
@@ -8,6 +8,22 @@ sidebar:
 import { PackageManagers } from 'starlight-package-managers'
 import { Steps } from '@astrojs/starlight/components';
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-webview-version-checker` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the package**
    <PackageManagers pkg="@capgo/capacitor-webview-version-checker" pkgManagers={['bun']} />

--- a/apps/docs/src/content/docs/docs/plugins/wechat/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/wechat/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-wechat` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-wechat
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/wechat/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/wechat/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-wechat` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-wechat` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/widget-kit/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/widget-kit/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-widget-kit` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-widget-kit
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/widget-kit/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/widget-kit/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-widget-kit` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-widget-kit` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/wifi/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/wifi/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-wifi` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-wifi
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/wifi/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/wifi/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-wifi` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-wifi` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/youtube-player/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/youtube-player/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-youtube-player` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-youtube-player` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/youtube-player/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/youtube-player/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-youtube-player` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-youtube-player
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/zebra-datawedge/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/zebra-datawedge/getting-started.mdx
@@ -13,13 +13,13 @@ import { PackageManagers } from 'starlight-package-managers'
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-zebra-datawedge` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-zebra-datawedge` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/apps/docs/src/content/docs/docs/plugins/zebra-datawedge/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/zebra-datawedge/getting-started.mdx
@@ -8,6 +8,22 @@ sidebar:
 import { Steps } from '@astrojs/starlight/components';
 import { PackageManagers } from 'starlight-package-managers'
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-zebra-datawedge` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the plugin**
    <PackageManagers pkg="@capgo/capacitor-zebra-datawedge" pkgManagers={['bun']} />

--- a/apps/docs/src/content/docs/docs/plugins/zip/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/zip/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-zip` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-zip
 bunx cap sync

--- a/apps/docs/src/content/docs/docs/plugins/zip/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/zip/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-zip` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-zip` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/src/content/docs/docs/plugins/contentsquare/getting-started.mdx
+++ b/src/content/docs/docs/plugins/contentsquare/getting-started.mdx
@@ -12,13 +12,13 @@ import PluginSetupSteps from '@/components/doc/PluginSetupSteps.astro';
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-contentsquare` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-contentsquare` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/src/content/docs/docs/plugins/contentsquare/getting-started.mdx
+++ b/src/content/docs/docs/plugins/contentsquare/getting-started.mdx
@@ -7,6 +7,22 @@ sidebar:
 
 import PluginSetupSteps from '@/components/doc/PluginSetupSteps.astro';
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-contentsquare` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <PluginSetupSteps
   pkg="@capgo/capacitor-contentsquare"
   stepTitle="Review the upstream product configuration"

--- a/src/content/docs/docs/plugins/live-activities/getting-started.mdx
+++ b/src/content/docs/docs/plugins/live-activities/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-live-activities` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-live-activities
 bunx cap sync

--- a/src/content/docs/docs/plugins/live-activities/getting-started.mdx
+++ b/src/content/docs/docs/plugins/live-activities/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-live-activities` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-live-activities` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/src/content/docs/docs/plugins/sheets/getting-started.mdx
+++ b/src/content/docs/docs/plugins/sheets/getting-started.mdx
@@ -12,13 +12,13 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-sheets` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-sheets` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/src/content/docs/docs/plugins/sheets/getting-started.mdx
+++ b/src/content/docs/docs/plugins/sheets/getting-started.mdx
@@ -7,6 +7,22 @@ sidebar:
 
 import { Steps, Aside } from '@astrojs/starlight/components';
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-sheets` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the package**
 

--- a/src/content/docs/docs/plugins/transitions/getting-started.mdx
+++ b/src/content/docs/docs/plugins/transitions/getting-started.mdx
@@ -12,13 +12,13 @@ import { Steps, Aside } from '@astrojs/starlight/components';
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-transitions` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-transitions` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/src/content/docs/docs/plugins/transitions/getting-started.mdx
+++ b/src/content/docs/docs/plugins/transitions/getting-started.mdx
@@ -7,6 +7,22 @@ sidebar:
 
 import { Steps, Aside } from '@astrojs/starlight/components';
 
+## Installation
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-transitions` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 <Steps>
 1. **Install the package**
 

--- a/src/content/docs/docs/plugins/twilio-video/getting-started.mdx
+++ b/src/content/docs/docs/plugins/twilio-video/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-twilio-video` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-twilio-video` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:

--- a/src/content/docs/docs/plugins/twilio-video/getting-started.mdx
+++ b/src/content/docs/docs/plugins/twilio-video/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-twilio-video` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-twilio-video
 bunx cap sync

--- a/src/content/docs/docs/plugins/widget-kit/getting-started.mdx
+++ b/src/content/docs/docs/plugins/widget-kit/getting-started.mdx
@@ -7,6 +7,20 @@ sidebar:
 
 ## Install
 
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-widget-kit` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
 ```bash
 bun add @capgo/capacitor-widget-kit
 bunx cap sync

--- a/src/content/docs/docs/plugins/widget-kit/getting-started.mdx
+++ b/src/content/docs/docs/plugins/widget-kit/getting-started.mdx
@@ -10,13 +10,13 @@ sidebar:
 You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
 
 ```bash
-npx skills add https://github.com/cap-go/capacitor-skills --skill capacitor-plugins
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
 ```
 
 Then use the following prompt:
 
 ```text
-Use the `capacitor-plugins` skill from `cap-go/capacitor-skills` to install the `@capgo/capacitor-widget-kit` plugin in my project.
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-widget-kit` plugin in my project.
 ```
 
 If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:


### PR DESCRIPTION
## Summary
- Add AI-Assisted Setup instructions to every direct plugin getting-started doc.
- Replace each prompt package with the page-specific package name, including custom Capacitor+ package wording.
- Sync the six mirrored plugin docs required by the docs parity check.

## Validation
- bunx prettier --write apps/docs/src/content/docs/docs/plugins/*/getting-started.mdx src/content/docs/docs/plugins/{contentsquare,live-activities,sheets,transitions,twilio-video,widget-kit}/getting-started.mdx
- bun run check:docs-mirror
- bun run ci:verify:docs