### PR TITLE
docs: expand documented updater stats events

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/updater/debugging.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/updater/debugging.mdx
@@ -50,7 +50,7 @@ Capgo logs can include metadata for the event. In the dashboard, use the action 
 | ---- | ---------------- | ------------- |
 | `invalidIp` | Capgo detected traffic that looks like bot traffic (Google/cloud infrastructure IP). | Ignore on real users; retry from real devices and normal networks, or check after some time. |
 | `needPlanUpgrade` | Organization reached plan/device limit. | Upgrade plan in dashboard or wait for next billing cycle. |
-| `semver_error` | Native app version in config is missing or not valid semver (`x.y.z`). | Set `plugins.CapacitorUpdater.version` to valid semver and rebuild the app. |
+| `semver_error` | Native app version in config is missing or not valid semver (`x.y.z`). | Set `plugins.CapacitorUpdater.version` to valid semver, then verify it in the [SemVer tester](https://capgo.app/semver_tester/) and rebuild the app. |
 | `disablePlatformIos` | iOS is disabled in channel policy. | Enable iOS in that channel and republish routing. |
 | `disablePlatformAndroid` | Android is disabled in channel policy. | Enable Android in that channel and republish routing. |
 | `disableAutoUpdate` | Channel auto-update mode blocks this update style. | Change channel auto-update policy (major/minor/patch/metadata/none) to allow your intended rollout. |

--- a/apps/docs/src/content/docs/docs/plugins/updater/debugging.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/updater/debugging.mdx
@@ -38,11 +38,21 @@ Capgo logs can include metadata for the event. In the dashboard, use the action 
 | **no_channel** (**NoChannelOrOverride**)                              | No default channel is configured for this app and the device has no specific channel override assigned. At least one must be present for updates to work.                                                                                                   |
 | **rate_limited** (**rateLimited**)                                    | The device has been rate limited due to excessive requests.                                                                                                                                                                                                |
 | **key_id_mismatch** (**keyMismatch**)                                 | The device's encryption public key does not match the public key used to encrypt the bundle. Metadata includes `device_key_id`, `bundle_key_id`, and `version` to help identify the mismatch.                                                              |
-| **disable_prod_build** (**disableProdBuild**)                          | Updates are blocked for this build profile (production build handling is restricted by channel or key policy).                                                                                                            |
-| **disable_device** (**disableDevice**)                                 | Real devices are explicitly blocked from receiving updates by device-level policy (opposite of `disableEmulator`). |
-| **disable_platform_electron** (**disablePlatformElectron**)             | Electron is currently disabled for this channel or account policy.                                                                                                                                                                                     |
-| **customIdBlocked**                                                  | `allow_device_custom_id = false` and a non-empty `custom_id` were sent in `/stats`; stats are still accepted but `custom_id` is dropped (stored as empty) and this event is emitted.                                                                                                                                                                            |
-| **backend_refusal**                                                  | The backend refused the request before update evaluation could continue. Check the request context and response metadata in logs to identify the gatekeeping rule.                                                                                        |
+| **disable_prod_build** (**disableProdBuild**)                          | A production build called `/updates` was blocked by channel policy.                                                                                                            |
+| **disable_device** (**disableDevice**)                                 | A normal phone/tablet was blocked because this channel blocks real devices.                                                                                                                  |
+| **disable_platform_electron** (**disablePlatformElectron**)             | Electron is blocked in this channel.                                                                                                                                                                                     |
+| **customIdBlocked**                                                  | A custom device ID was sent, but this app does not accept custom IDs, so it is ignored.                                                                     |
+| **backend_refusal**                                                  | `v4` of the updater is not supported anymore. Upgrade to updater `v5` at least (with Capacitor `v5`), and prefer `v8` because old Capacitor versions can no longer be updated through app store pipelines.                                                                                            |
+
+### Quick fixes for new policy blocks
+
+| Code | Why this happens | What to do next |
+| ---- | ---------------- | ------------- |
+| `disableProdBuild` | A production build called `/updates`, but your channel blocked it. | Allow production updates in that channel, or build your app as non-production. |
+| `disableDevice` | A real phone/tablet was blocked because this channel is set to block real devices. | Turn on real-device updates for this channel. |
+| `disablePlatformElectron` | Electron was blocked because this channel does not allow it. | Turn on Electron in this channel or move Electron apps to another channel. |
+| `customIdBlocked` | A custom device ID was sent, but this app does not accept custom IDs. | Turn on custom IDs only if you need them. |
+| `backend_refusal` | The updater is `v4`, which the backend no longer accepts. Update updater `v5` or newer (prefer `v8`) with a Capacitor `v5`+ app, then rebuild and republish. | Update updater plugin/CLI, rebuild, and republish bundle metadata. |
 
 
 ### Sent from the device

--- a/apps/docs/src/content/docs/docs/plugins/updater/debugging.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/updater/debugging.mdx
@@ -44,16 +44,36 @@ Capgo logs can include metadata for the event. In the dashboard, use the action 
 | **customIdBlocked**                                                  | A custom device ID was sent, but this app does not accept custom IDs, so it is ignored.                                                                     |
 | **backend_refusal**                                                  | `v4` of the updater is not supported anymore. Upgrade to updater `v5` at least (with Capacitor `v5`), and prefer `v8` because old Capacitor versions can no longer be updated through app store pipelines.                                                                                            |
 
-### Quick fixes for new policy blocks
+### Quick fixes for policy / configuration issues
 
 | Code | Why this happens | What to do next |
 | ---- | ---------------- | ------------- |
-| `disableProdBuild` | A production build called `/updates`, but your channel blocked it. | Allow production updates in that channel, or build your app as non-production. |
-| `disableDevice` | A real phone/tablet was blocked because this channel is set to block real devices. | Turn on real-device updates for this channel. |
-| `disablePlatformElectron` | Electron was blocked because this channel does not allow it. | Turn on Electron in this channel or move Electron apps to another channel. |
-| `customIdBlocked` | A custom device ID was sent, but this app does not accept custom IDs. | Turn on custom IDs only if you need them. |
-| `backend_refusal` | The updater is `v4`, which the backend no longer accepts. Update updater `v5` or newer (prefer `v8`) with a Capacitor `v5`+ app, then rebuild and republish. | Update updater plugin/CLI, rebuild, and republish bundle metadata. |
-
+| `invalidIp` | Capgo detected traffic that looks like bot traffic (Google/cloud infrastructure IP). | Ignore on real users; retry from real devices and normal networks, or check after some time. |
+| `needPlanUpgrade` | Organization reached plan/device limit. | Upgrade plan in dashboard or wait for next billing cycle. |
+| `semver_error` | Native app version in config is missing or not valid semver (`x.y.z`). | Set `plugins.CapacitorUpdater.version` to valid semver and rebuild the app. |
+| `disablePlatformIos` | iOS is disabled in channel policy. | Enable iOS in that channel and republish routing. |
+| `disablePlatformAndroid` | Android is disabled in channel policy. | Enable Android in that channel and republish routing. |
+| `disableAutoUpdate` | Channel auto-update mode blocks this update style. | Change channel auto-update policy (major/minor/patch/metadata/none) to allow your intended rollout. |
+| `disableAutoUpdateUnderNative` | Channel is set to block updates older than the device baseline. | Push a version at or above the native baseline, or disable that under-native protection. |
+| `disableAutoUpdateMetadata` | Channel requires `min_update_version` metadata and the app is older. | Set `min_update_version` for the target bundle or release from a newer native version. |
+| `disableAutoUpdateToMajor` | The channel blocks major version jumps. | Keep major versions in the same channel strategy, or allow major jumps for this track. |
+| `disableAutoUpdateToMinor` | The channel blocks minor version jumps. | Keep minor versions in the same channel strategy, or allow minor jumps for this track. |
+| `disableAutoUpdateToPatch` | The channel blocks patch-level jumps for this flow. | Align your release cadence, or open patch jumps in channel policy for this track. |
+| `disableEmulator` | Emulator updates are not allowed for this channel. | Turn on emulator updates only if you test emulators in this channel. |
+| `disableDevBuild` | Dev builds are blocked for this channel. | If this is a dev build, allow dev updates or test on a build without this restriction. |
+| `disableProdBuild` | A device build in production mode called `/updates`, while your channel blocked it. | Allow production updates in that channel, or build your app as non-production. |
+| `cannotGetBundle` | Capgo could not build a valid download URL for the selected bundle. | Re-upload the bundle or regenerate manifests and check R2/public bundle settings. |
+| `cannotUpdateViaPrivateChannel` | App tried to self-switch to a private channel that does not allow self-assignment. | Enable `allow_device_self_set` on the channel or switch to a public/allowed channel. |
+| `channelMisconfigured` | Channel auto-update rule is missing required data (`version_number` without `min_update_version`). | Fill the missing config for that rule or switch to a simpler auto-update mode. |
+| `missingBundle` | Bundle has no downloadable payload (missing `external_url`/`r2_path` and no manifest). | Rebuild/re-upload the version and verify the bundle has real file content. |
+| `NoChannelOrOverride` | No channel matched this device (no cloud default + no config fallback + no override). | Set a channel default in dashboard or keep a test `defaultChannel` in that build. |
+| `rateLimited` | Too many update/channel calls in a short time (often render-loop `setChannel`/`getChannel`). | Stop calling in render. Only call on user action. Use `defaultChannel` in `capacitor.config`. |
+| `keyMismatch` | The app and bundle encryption key IDs differ (`device_key_id` vs `bundle_key_id`). | In the console, compare device and bundle key IDs. If they differ, publish with the same key and matching CLI/plugin version; key encoding can differ between versions. |
+| `disableDevice` | A real phone/tablet was blocked because this channel is set to block real devices. | Turn on real-device updates for that channel. |
+| `disablePlatformElectron` | Electron is blocked in this channel. | Enable Electron in this channel or move Electron users to a different channel. |
+| `customIdBlocked` | A custom device ID was sent, but this app does not accept custom IDs. | Turn off custom ID sending or enable custom IDs only if your workflow requires it. |
+| `blocked_by_server_url` | The app has `server.url` configured, so Capacitor serves remote URL instead of local files. | Remove/clear `server.url` for production builds and keep update payloads local. |
+| `backend_refusal` | The updater is `v4`, which the backend no longer accepts. | Upgrade plugin/CLI to `v5`+ (prefer `v8`), with Capacitor `v5`+, then rebuild and republish bundle metadata. |
 
 ### Sent from the device
 
@@ -92,13 +112,13 @@ Capgo logs can include metadata for the event. In the dashboard, use the action 
 | **app_killed_excessive_resource_usage** | The OS killed the app for excessive resource use. Metadata can include the resource type or platform reason when available. |
 | **app_initialization_failure** | The updater or app startup flow failed before normal runtime was ready. Metadata can include the failing step and error message. |
 | **app_memory_warning** | iOS reported a memory warning. Metadata can include the active bundle and memory context when available. |
-| **webview_javascript_error** | The WebView reported an uncaught JavaScript error. Metadata can include the message, source URL, line, column, and stack. |
-| **webview_unhandled_rejection** | The WebView reported an unhandled promise rejection. Metadata can include the rejection reason, source URL, and stack. |
-| **webview_resource_error** | A WebView resource failed to load. Metadata can include the URL, status code, resource type, and error message. |
-| **webview_security_policy_violation** | The WebView reported a content security policy violation. Metadata can include the blocked URI, directive, and document URL. |
-| **webview_unclean_restart** | The app detected a previous WebView session that did not shut down cleanly. This can help identify crash loops after an update. |
-| **webview_render_process_gone** | Android reported that the WebView renderer process exited. Metadata can include whether the renderer crashed and the renderer priority. |
-| **webview_content_process_terminated** | iOS reported that the WebView content process terminated. Metadata can include the active bundle and page URL when available. |
+| **webview_javascript_error** | The WebView reported an uncaught JavaScript error. Metadata can include the message, source URL, line, column, and stack. Install Sentry in both places: JS SDK in your web app and native SDK in iOS/Android, then compare sessions to fix the exact line causing the error. |
+| **webview_unhandled_rejection** | The WebView reported an unhandled promise rejection. Metadata can include the rejection reason, source URL, and stack. Install Sentry in both places (JS + native) so async failures are visible with user/device/session context. |
+| **webview_resource_error** | A WebView resource failed to load. Metadata can include the URL, status code, resource type, and error message. Install Sentry (JS + native) to capture the failing URL and environment context, then patch broken asset loading faster. |
+| **webview_security_policy_violation** | The WebView reported a content security policy violation. Metadata can include the blocked URI, directive, and document URL. Install Sentry (JS + native) to see when and where CSP blocks happen in real sessions and update rules safely. |
+| **webview_unclean_restart** | The app detected a previous WebView session that did not shut down cleanly. This can help identify crash loops after an update. Add Sentry in both JS and native sides to connect restart events with surrounding errors. |
+| **webview_render_process_gone** | Android reported that the WebView renderer process exited. Metadata can include whether the renderer crashed and the renderer priority. Install Sentry (JS + native) to tie renderer exits to recent crashes and device logs. |
+| **webview_content_process_terminated** | iOS reported that the WebView content process terminated. Metadata can include the active bundle and page URL when available. Install Sentry on JS and native layers so you get timing, URL, and session context around each content-process end. |
 | **decrypt_fail**        | Failed to decrypt the downloaded bundle.                                          |
 | **os_version_changed** | The device OS version changed between checks. This is used to correlate update behavior with OS-level changes. |
 | **native_app_version_changed** | The native app version changed (for example from a native rollout), helping separate native and web-view behavior changes. |

--- a/apps/docs/src/content/docs/docs/plugins/updater/debugging.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/updater/debugging.mdx
@@ -38,6 +38,11 @@ Capgo logs can include metadata for the event. In the dashboard, use the action 
 | **no_channel** (**NoChannelOrOverride**)                              | No default channel is configured for this app and the device has no specific channel override assigned. At least one must be present for updates to work.                                                                                                   |
 | **rate_limited** (**rateLimited**)                                    | The device has been rate limited due to excessive requests.                                                                                                                                                                                                |
 | **key_id_mismatch** (**keyMismatch**)                                 | The device's encryption public key does not match the public key used to encrypt the bundle. Metadata includes `device_key_id`, `bundle_key_id`, and `version` to help identify the mismatch.                                                              |
+| **disable_prod_build** (**disableProdBuild**)                          | Updates are blocked for this build profile (production build handling is restricted by channel or key policy).                                                                                                            |
+| **disable_device** (**disableDevice**)                                 | Real devices are explicitly blocked from receiving updates by device-level policy (opposite of `disableEmulator`). |
+| **disable_platform_electron** (**disablePlatformElectron**)             | Electron is currently disabled for this channel or account policy.                                                                                                                                                                                     |
+| **customIdBlocked**                                                  | `allow_device_custom_id = false` and a non-empty `custom_id` were sent in `/stats`; stats are still accepted but `custom_id` is dropped (stored as empty) and this event is emitted.                                                                                                                                                                            |
+| **backend_refusal**                                                  | The backend refused the request before update evaluation could continue. Check the request context and response metadata in logs to identify the gatekeeping rule.                                                                                        |
 
 
 ### Sent from the device
@@ -50,6 +55,7 @@ Capgo logs can include metadata for the event. In the dashboard, use the action 
 | **set**               | A bundle has been set on the device.                                              |
 | **set_fail**          | The bundle failed to set.                                                         |
 | **reset**             | The device reset to the `builtin` bundle.                                         |
+| **download_0**        | The download sequence started at 0% progress.                                    |
 | **download_XX**       | A new bundle has been downloaded - progress indicated by XX% (increments of 10%). |
 | **download_complete** | The new bundle has finished downloading.                                          |
 | **download_manifest_start** | The device started downloading the update manifest.                             |
@@ -84,6 +90,8 @@ Capgo logs can include metadata for the event. In the dashboard, use the action 
 | **webview_render_process_gone** | Android reported that the WebView renderer process exited. Metadata can include whether the renderer crashed and the renderer priority. |
 | **webview_content_process_terminated** | iOS reported that the WebView content process terminated. Metadata can include the active bundle and page URL when available. |
 | **decrypt_fail**        | Failed to decrypt the downloaded bundle.                                          |
+| **os_version_changed** | The device OS version changed between checks. This is used to correlate update behavior with OS-level changes. |
+| **native_app_version_changed** | The native app version changed (for example from a native rollout), helping separate native and web-view behavior changes. |
 | **get_channel** (**getChannel**) | The current channel for the device was queried.                                   |
 | **set_channel** (**setChannel**) | A channel was successfully set for the device.                                    |
 | **uninstall**           | The application was uninstalled or Capgo data cleared.                            |

--- a/apps/docs/src/content/docs/docs/plugins/updater/debugging.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/updater/debugging.mdx
@@ -51,17 +51,17 @@ Capgo logs can include metadata for the event. In the dashboard, use the action 
 | `invalidIp` | Capgo detected traffic that looks like bot traffic (Google/cloud infrastructure IP). | Ignore on real users; retry from real devices and normal networks, or check after some time. |
 | `needPlanUpgrade` | Organization reached plan/device limit. | Upgrade plan in dashboard or wait for next billing cycle. |
 | `semver_error` | Native app version in config is missing or not valid semver (`x.y.z`). | Set `plugins.CapacitorUpdater.version` to valid semver, then verify it in the [SemVer tester](https://capgo.app/semver_tester/) and rebuild the app. |
-| `disablePlatformIos` | iOS is disabled in channel policy. | Enable iOS in that channel and republish routing. |
-| `disablePlatformAndroid` | Android is disabled in channel policy. | Enable Android in that channel and republish routing. |
+| `disablePlatformIos` | iOS is disabled in channel policy. | If this was accidental, enable iOS in that channel and republish routing. If you intentionally block iOS in this track, keep it off and move iOS builds to a separate channel. |
+| `disablePlatformAndroid` | Android is disabled in channel policy. | If this was accidental, enable Android in that channel and republish routing. If you intentionally block Android in this track, keep it off and move Android builds to a separate channel. |
 | `disableAutoUpdate` | Channel auto-update mode blocks this update style. | Change channel auto-update policy (major/minor/patch/metadata/none) to allow your intended rollout. |
 | `disableAutoUpdateUnderNative` | Channel is set to block updates older than the device baseline. | Push a version at or above the native baseline, or disable that under-native protection. |
 | `disableAutoUpdateMetadata` | Channel requires `min_update_version` metadata and the app is older. | Set `min_update_version` for the target bundle or release from a newer native version. |
 | `disableAutoUpdateToMajor` | The channel blocks major version jumps. | Keep major versions in the same channel strategy, or allow major jumps for this track. |
 | `disableAutoUpdateToMinor` | The channel blocks minor version jumps. | Keep minor versions in the same channel strategy, or allow minor jumps for this track. |
 | `disableAutoUpdateToPatch` | The channel blocks patch-level jumps for this flow. | Align your release cadence, or open patch jumps in channel policy for this track. |
-| `disableEmulator` | Emulator updates are not allowed for this channel. | Turn on emulator updates only if you test emulators in this channel. |
-| `disableDevBuild` | Dev builds are blocked for this channel. | If this is a dev build, allow dev updates or test on a build without this restriction. |
-| `disableProdBuild` | A device build in production mode called `/updates`, while your channel blocked it. | Allow production updates in that channel, or build your app as non-production. |
+| `disableEmulator` | Emulator updates are not allowed for this channel. | If this was accidental, turn on emulator updates in a test channel where you validate emulators. If intentional, keep this channel emulator-blocked and use another channel for emulator builds. |
+| `disableDevBuild` | Dev builds are blocked for this channel. | If this was accidental, allow dev updates or move this device to a dev-enabled channel. If this is intentional, keep this channel locked to release builds only. |
+| `disableProdBuild` | A device build in production mode called `/updates`, while your channel blocked it. | If this was accidental, allow production updates in that channel and republish. If this is intentional, keep the restriction and send production builds to the proper channel/build. |
 | `cannotGetBundle` | Capgo could not build a valid download URL for the selected bundle. | Re-upload the bundle or regenerate manifests and check R2/public bundle settings. |
 | `cannotUpdateViaPrivateChannel` | App tried to self-switch to a private channel that does not allow self-assignment. | Enable `allow_device_self_set` on the channel or switch to a public/allowed channel. |
 | `channelMisconfigured` | Channel auto-update rule is missing required data (`version_number` without `min_update_version`). | Fill the missing config for that rule or switch to a simpler auto-update mode. |
@@ -69,8 +69,8 @@ Capgo logs can include metadata for the event. In the dashboard, use the action 
 | `NoChannelOrOverride` | No channel matched this device (no cloud default + no config fallback + no override). | Set a channel default in dashboard or keep a test `defaultChannel` in that build. |
 | `rateLimited` | Too many update/channel calls in a short time (often render-loop `setChannel`/`getChannel`). | Stop calling in render. Only call on user action. Use `defaultChannel` in `capacitor.config`. |
 | `keyMismatch` | The app and bundle encryption key IDs differ (`device_key_id` vs `bundle_key_id`). | In the console, compare device and bundle key IDs. If they differ, publish with the same key and matching CLI/plugin version; key encoding can differ between versions. |
-| `disableDevice` | A real phone/tablet was blocked because this channel is set to block real devices. | Turn on real-device updates for that channel. |
-| `disablePlatformElectron` | Electron is blocked in this channel. | Enable Electron in this channel or move Electron users to a different channel. |
+| `disableDevice` | A real phone/tablet was blocked because this channel is set to block real devices. | If accidental, turn on real-device updates in that channel. If intentional, keep it blocked and route real devices to another channel. |
+| `disablePlatformElectron` | Electron is blocked in this channel. | If this was accidental, enable Electron in this channel and republish routing. If intentional, keep it blocked and send Electron users to a dedicated channel. |
 | `customIdBlocked` | A custom device ID was sent, but this app does not accept custom IDs. | Turn off custom ID sending or enable custom IDs only if your workflow requires it. |
 | `blocked_by_server_url` | The app has `server.url` configured, so Capacitor serves remote URL instead of local files. | Remove/clear `server.url` for production builds and keep update payloads local. |
 | `backend_refusal` | The updater is `v4`, which the backend no longer accepts. | Upgrade plugin/CLI to `v5`+ (prefer `v8`), with Capacitor `v5`+, then rebuild and republish bundle metadata. |

--- a/apps/docs/src/content/docs/docs/plugins/updater/self-hosted/handling-stats.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/updater/self-hosted/handling-stats.mdx
@@ -73,8 +73,7 @@ Here is an example of code in JavaScript to save the stats of the plugin:
 ```typescript
 interface AppInfos {
   version_name: string
-  action: 'ping' |
-          'delete' |
+  action: 'delete' |
           'reset' |
           'set' |
           'get' |
@@ -96,13 +95,6 @@ interface AppInfos {
           'download_80' |
           'download_90' |
           'download_complete' |
-          'download_manifest_start' |
-          'download_manifest_complete' |
-          'download_zip_start' |
-          'download_zip_complete' |
-          'download_manifest_file_fail' |
-          'download_manifest_checksum_fail' |
-          'download_manifest_brotli_fail' |
           'decrypt_fail' |
           'app_moved_to_foreground' |
           'app_moved_to_background' |
@@ -121,16 +113,47 @@ interface AppInfos {
           'disableAutoUpdateUnderNative' |
           'disableDevBuild' |
           'disableEmulator' |
+          'disablePlatformElectron' |
+          'disableProdBuild' |
+          'disableDevice' |
+          'customIdBlocked' |
           'cannotGetBundle' |
           'checksum_fail' |
+          'checksum_required' |
           'NoChannelOrOverride' |
           'setChannel' |
           'getChannel' |
           'rateLimited' |
           'disableAutoUpdate' |
-          'InvalidIp' |
           'keyMismatch' |
-          'blocked_by_server_url'
+          'ping' |
+          'InvalidIp' |
+          'blocked_by_server_url' |
+          'download_manifest_start' |
+          'download_manifest_complete' |
+          'download_zip_start' |
+          'download_zip_complete' |
+          'download_manifest_file_fail' |
+          'download_manifest_checksum_fail' |
+          'download_manifest_brotli_fail' |
+          'backend_refusal' |
+          'app_crash' |
+          'app_crash_native' |
+          'app_anr' |
+          'app_killed_low_memory' |
+          'app_killed_excessive_resource_usage' |
+          'app_initialization_failure' |
+          'app_memory_warning' |
+          'webview_javascript_error' |
+          'webview_unhandled_rejection' |
+          'webview_resource_error' |
+          'webview_security_policy_violation' |
+          'webview_unclean_restart' |
+          'webview_render_process_gone' |
+          'webview_content_process_terminated' |
+          'os_version_changed' |
+          'native_app_version_changed' |
+          'download_0'
   version_build: string
   version_code: string
   version_os: string

--- a/apps/docs/src/content/docs/docs/webapp/logs.mdx
+++ b/apps/docs/src/content/docs/docs/webapp/logs.mdx
@@ -161,15 +161,35 @@ These codes come from the `stats_action` enum used by the dashboard API (`capgo/
 | `ping` | Health/heartbeat check from device |
 | `setChannel`, `getChannel` | Channel overridden or fetched via SDK call |
 
-### New policy-block events (quick fix)
+### New policy-block / throttle quick fix
 | Code | Why this happens | What to do next |
 |------|------------------|-------------|
-| `disableProdBuild` | A production build called `/updates`, but this channel does not allow production updates. | Allow production updates in that channel, or build your app as non-production. |
-| `disableDevice` | A real phone or tablet used a blocked channel. | Turn on real-device updates for that channel. |
-| `disablePlatformElectron` | The channel does not allow Electron apps. | Turn on Electron in that channel, or move Electron apps to another channel. |
-| `customIdBlocked` | A custom device ID was sent, but this app does not accept custom IDs. | Turn on custom IDs only if you need them. |
-| `backend_refusal` | The updater is `v4`, which the backend no longer accepts. Update to updater `v5` or newer (prefer `v8`) with a Capacitor `v5`+ app, then rebuild and republish bundle metadata. | Update updater plugin/CLI, rebuild, and republish bundle metadata. |
-
+| `invalidIp` | Capgo detected traffic that looks like bot traffic (Google/cloud infrastructure IP). | Ignore on real users; retry from real devices and normal networks, or check after some time. |
+| `needPlanUpgrade` | Organization reached plan/device limit. | Upgrade plan in dashboard or wait for next billing cycle. |
+| `semver_error` | Native app version in config is missing or not valid semver (`x.y.z`). | Set `plugins.CapacitorUpdater.version` to valid semver and rebuild the app. |
+| `disablePlatformIos` | iOS is disabled in channel policy. | Enable iOS in that channel and republish routing. |
+| `disablePlatformAndroid` | Android is disabled in channel policy. | Enable Android in that channel and republish routing. |
+| `disableAutoUpdate` | Channel auto-update mode blocks this update style. | Change channel auto-update policy (major/minor/patch/metadata/none) to allow your intended rollout. |
+| `disableAutoUpdateUnderNative` | Channel is set to block updates older than the device baseline. | Push a version at or above the native baseline, or disable that under-native protection. |
+| `disableAutoUpdateMetadata` | Channel requires `min_update_version` metadata and the app is older. | Set `min_update_version` for the target bundle or release from a newer native version. |
+| `disableAutoUpdateToMajor` | The channel blocks major version jumps. | Keep major versions in the same channel strategy, or allow major jumps for this track. |
+| `disableAutoUpdateToMinor` | The channel blocks minor version jumps. | Keep minor versions in the same channel strategy, or allow minor jumps for this track. |
+| `disableAutoUpdateToPatch` | The channel blocks patch-level jumps for this flow. | Align your release cadence, or open patch jumps in channel policy for this track. |
+| `disableEmulator` | Emulator updates are not allowed for this channel. | Turn on emulator updates only if you test emulators in this channel. |
+| `disableDevBuild` | Dev builds are blocked for this channel. | If this is a dev build, allow dev updates or test on a build without this restriction. |
+| `disableProdBuild` | A device build in production mode called `/updates`, while your channel blocked it. | Allow production updates in that channel, or build your app as non-production. |
+| `cannotGetBundle` | Capgo could not build a valid download URL for the selected bundle. | Re-upload the bundle or regenerate manifests and check R2/public bundle settings. |
+| `cannotUpdateViaPrivateChannel` | App tried to self-switch to a private channel that does not allow self-assignment. | Enable `allow_device_self_set` on the channel or switch to a public/allowed channel. |
+| `channelMisconfigured` | Channel auto-update rule is missing required data (`version_number` without `min_update_version`). | Fill the missing config for that rule or switch to a simpler auto-update mode. |
+| `missingBundle` | Bundle has no downloadable payload (missing `external_url`/`r2_path` and no manifest). | Rebuild/re-upload the version and verify the bundle has real file content. |
+| `NoChannelOrOverride` | No channel matched this device (no cloud default + no config fallback + no override). | Set a channel default in dashboard or keep a test `defaultChannel` in that build. |
+| `rateLimited` | Too many update/channel calls in a short time (often render-loop `setChannel`/`getChannel`). | Stop calling in render. Only call on user action. Use `defaultChannel` in `capacitor.config`. |
+| `keyMismatch` | The app and bundle encryption key IDs differ (`device_key_id` vs `bundle_key_id`). | In the console, compare device and bundle key IDs. If they differ, publish with the same key and matching CLI/plugin version; key encoding can differ between versions. |
+| `disableDevice` | A real phone/tablet was blocked because this channel is set to block real devices. | Turn on real-device updates for that channel. |
+| `disablePlatformElectron` | Electron is blocked in this channel. | Enable Electron in this channel or move Electron users to a different channel. |
+| `customIdBlocked` | A custom device ID was sent, but this app does not accept custom IDs. | Turn off custom ID sending or enable custom IDs only if your workflow requires it. |
+| `blocked_by_server_url` | The app has `server.url` configured, so Capacitor serves remote URL instead of local files. | Remove/clear `server.url` for production builds and keep update payloads local. |
+| `backend_refusal` | The updater is `v4`, which the backend no longer accepts. | Upgrade plugin/CLI to `v5`+ (prefer `v8`), with Capacitor `v5`+, then rebuild and republish bundle metadata. |
 **Configuration or policy blocks**
 
 | Code(s) | Why the update was blocked |
@@ -183,7 +203,7 @@ These codes come from the `stats_action` enum used by the dashboard API (`capgo/
 | `missingBundle`, `cannotGetBundle` | Manifest refers to a bundle Capgo cannot serve |
 | `needPlanUpgrade` | Org hit its plan/device limit |
 | `rateLimited` | Too many requests; SDK throttles until restart |
-| `blocked_by_server_url`, `backend_refusal`, `InvalidIp` | Server-side rule blocked the request |
+| `blocked_by_server_url`, `backend_refusal`, `invalidIp` | Server-side rule blocked the request |
 
 **Download / integrity / install failures**
 
@@ -204,7 +224,7 @@ These codes come from the `stats_action` enum used by the dashboard API (`capgo/
 | `app_anr` | Android reported an Application Not Responding. |
 | `app_killed_low_memory`, `app_killed_excessive_resource_usage` | App process termination due to memory or resource limits. |
 | `app_initialization_failure`, `app_memory_warning` | Startup was interrupted or memory pressure was observed before normal runtime. |
-| `webview_javascript_error`, `webview_unhandled_rejection`, `webview_resource_error`, `webview_security_policy_violation`, `webview_unclean_restart`, `webview_render_process_gone`, `webview_content_process_terminated` | WebView lifecycle and rendering/JS errors. |
+| `webview_javascript_error`, `webview_unhandled_rejection`, `webview_resource_error`, `webview_security_policy_violation`, `webview_unclean_restart`, `webview_render_process_gone`, `webview_content_process_terminated` | WebView lifecycle and JS/rendering errors. Install Sentry in both JS and native layers to capture stack traces, session/device context, and URL/state for faster fixes. |
 | `os_version_changed`, `native_app_version_changed` | OS or native app version changed; this helps separate platform-level rollout effects from web bundle behavior. |
 
 ➡️ Need deeper per-code guidance? See **[Full Log Code Reference and Debugging Guide](/docs/plugins/updater/debugging/#understanding-cloud-logs)**.

--- a/apps/docs/src/content/docs/docs/webapp/logs.mdx
+++ b/apps/docs/src/content/docs/docs/webapp/logs.mdx
@@ -161,6 +161,15 @@ These codes come from the `stats_action` enum used by the dashboard API (`capgo/
 | `ping` | Health/heartbeat check from device |
 | `setChannel`, `getChannel` | Channel overridden or fetched via SDK call |
 
+### New policy-block events (quick fix)
+| Code | Why this happens | What to do next |
+|------|------------------|-------------|
+| `disableProdBuild` | A production build called `/updates`, but this channel does not allow production updates. | Allow production updates in that channel, or build your app as non-production. |
+| `disableDevice` | A real phone or tablet used a blocked channel. | Turn on real-device updates for that channel. |
+| `disablePlatformElectron` | The channel does not allow Electron apps. | Turn on Electron in that channel, or move Electron apps to another channel. |
+| `customIdBlocked` | A custom device ID was sent, but this app does not accept custom IDs. | Turn on custom IDs only if you need them. |
+| `backend_refusal` | The updater is `v4`, which the backend no longer accepts. Update to updater `v5` or newer (prefer `v8`) with a Capacitor `v5`+ app, then rebuild and republish bundle metadata. | Update updater plugin/CLI, rebuild, and republish bundle metadata. |
+
 **Configuration or policy blocks**
 
 | Code(s) | Why the update was blocked |
@@ -168,8 +177,8 @@ These codes come from the `stats_action` enum used by the dashboard API (`capgo/
 | `disableAutoUpdate`, `disableAutoUpdateToMajor`, `disableAutoUpdateToMinor`, `disableAutoUpdateToPatch`, `disableAutoUpdateMetadata`, `disableAutoUpdateUnderNative` | Channel strategy forbids this [semver jump](/semver_tester/) |
 | `disablePlatformIos`, `disablePlatformAndroid` | Platform is disabled on the channel |
 | `disableDevBuild`, `disableEmulator` | Dev builds or emulators not allowed |
-| `disableProdBuild`, `disableDevice`, `disablePlatformElectron` | Additional backend/platform policy blocks (production build policy, real-device block, or Electron disabled). Opposite of this is `disableEmulator`. |
-| `customIdBlocked` | `allow_device_custom_id = false` while `custom_id` is provided in `/stats`; stats still arrive, but `custom_id` is ignored and stored empty. |
+| `disableProdBuild`, `disableDevice`, `disablePlatformElectron` | Production builds, real devices, or Electron are blocked for this channel. |
+| `customIdBlocked` | Custom device IDs are not accepted for this app. |
 | `cannotUpdateViaPrivateChannel`, `NoChannelOrOverride`, `channelMisconfigured` | Channel selection or override failed |
 | `missingBundle`, `cannotGetBundle` | Manifest refers to a bundle Capgo cannot serve |
 | `needPlanUpgrade` | Org hit its plan/device limit |

--- a/apps/docs/src/content/docs/docs/webapp/logs.mdx
+++ b/apps/docs/src/content/docs/docs/webapp/logs.mdx
@@ -151,6 +151,7 @@ These codes come from the `stats_action` enum used by the dashboard API (`capgo/
 | `download_manifest_start`, `download_manifest_complete` | Manifest download began / finished (for delta or multi-file bundles) |
 | `download_zip_start`, `download_zip_complete` | Zip archive download began / finished |
 | `download_10` … `download_90` | Download progress milestones |
+| `download_0` | 0% progress marker for the first progress event |
 | `download_complete` | Entire bundle downloaded |
 | `set` | Bundle staged for next launch |
 | `reset` | Device reverted to the builtin bundle |
@@ -167,6 +168,8 @@ These codes come from the `stats_action` enum used by the dashboard API (`capgo/
 | `disableAutoUpdate`, `disableAutoUpdateToMajor`, `disableAutoUpdateToMinor`, `disableAutoUpdateToPatch`, `disableAutoUpdateMetadata`, `disableAutoUpdateUnderNative` | Channel strategy forbids this [semver jump](/semver_tester/) |
 | `disablePlatformIos`, `disablePlatformAndroid` | Platform is disabled on the channel |
 | `disableDevBuild`, `disableEmulator` | Dev builds or emulators not allowed |
+| `disableProdBuild`, `disableDevice`, `disablePlatformElectron` | Additional backend/platform policy blocks (production build policy, real-device block, or Electron disabled). Opposite of this is `disableEmulator`. |
+| `customIdBlocked` | `allow_device_custom_id = false` while `custom_id` is provided in `/stats`; stats still arrive, but `custom_id` is ignored and stored empty. |
 | `cannotUpdateViaPrivateChannel`, `NoChannelOrOverride`, `channelMisconfigured` | Channel selection or override failed |
 | `missingBundle`, `cannotGetBundle` | Manifest refers to a bundle Capgo cannot serve |
 | `needPlanUpgrade` | Org hit its plan/device limit |
@@ -184,6 +187,16 @@ These codes come from the `stats_action` enum used by the dashboard API (`capgo/
 | `decrypt_fail` | Decryption failed (encrypted bundle) |
 | `update_fail` | Bundle installed but app never called `notifyAppReady()`; rollback triggered |
 | `download_zip_*` with no subsequent `set` | Download finished but install phase never completed |
+
+### Runtime / platform events
+| Code(s) | Meaning |
+|--------|---------|
+| `app_crash`, `app_crash_native` | Crash events from JavaScript or native runtime layers. Metadata often includes stack, source, and active version info. |
+| `app_anr` | Android reported an Application Not Responding. |
+| `app_killed_low_memory`, `app_killed_excessive_resource_usage` | App process termination due to memory or resource limits. |
+| `app_initialization_failure`, `app_memory_warning` | Startup was interrupted or memory pressure was observed before normal runtime. |
+| `webview_javascript_error`, `webview_unhandled_rejection`, `webview_resource_error`, `webview_security_policy_violation`, `webview_unclean_restart`, `webview_render_process_gone`, `webview_content_process_terminated` | WebView lifecycle and rendering/JS errors. |
+| `os_version_changed`, `native_app_version_changed` | OS or native app version changed; this helps separate platform-level rollout effects from web bundle behavior. |
 
 ➡️ Need deeper per-code guidance? See **[Full Log Code Reference and Debugging Guide](/docs/plugins/updater/debugging/#understanding-cloud-logs)**.
 

--- a/apps/docs/src/content/docs/docs/webapp/logs.mdx
+++ b/apps/docs/src/content/docs/docs/webapp/logs.mdx
@@ -167,17 +167,17 @@ These codes come from the `stats_action` enum used by the dashboard API (`capgo/
 | `invalidIp` | Capgo detected traffic that looks like bot traffic (Google/cloud infrastructure IP). | Ignore on real users; retry from real devices and normal networks, or check after some time. |
 | `needPlanUpgrade` | Organization reached plan/device limit. | Upgrade plan in dashboard or wait for next billing cycle. |
 | `semver_error` | Native app version in config is missing or not valid semver (`x.y.z`). | Set `plugins.CapacitorUpdater.version` to valid semver, then verify it in the [SemVer tester](https://capgo.app/semver_tester/) and rebuild the app. |
-| `disablePlatformIos` | iOS is disabled in channel policy. | Enable iOS in that channel and republish routing. |
-| `disablePlatformAndroid` | Android is disabled in channel policy. | Enable Android in that channel and republish routing. |
+| `disablePlatformIos` | iOS is disabled in channel policy. | If this was accidental, enable iOS in that channel and republish routing. If you intentionally block iOS in this track, keep it off and move iOS builds to a separate channel. |
+| `disablePlatformAndroid` | Android is disabled in channel policy. | If this was accidental, enable Android in that channel and republish routing. If you intentionally block Android in this track, keep it off and move Android builds to a separate channel. |
 | `disableAutoUpdate` | Channel auto-update mode blocks this update style. | Change channel auto-update policy (major/minor/patch/metadata/none) to allow your intended rollout. |
 | `disableAutoUpdateUnderNative` | Channel is set to block updates older than the device baseline. | Push a version at or above the native baseline, or disable that under-native protection. |
 | `disableAutoUpdateMetadata` | Channel requires `min_update_version` metadata and the app is older. | Set `min_update_version` for the target bundle or release from a newer native version. |
 | `disableAutoUpdateToMajor` | The channel blocks major version jumps. | Keep major versions in the same channel strategy, or allow major jumps for this track. |
 | `disableAutoUpdateToMinor` | The channel blocks minor version jumps. | Keep minor versions in the same channel strategy, or allow minor jumps for this track. |
 | `disableAutoUpdateToPatch` | The channel blocks patch-level jumps for this flow. | Align your release cadence, or open patch jumps in channel policy for this track. |
-| `disableEmulator` | Emulator updates are not allowed for this channel. | Turn on emulator updates only if you test emulators in this channel. |
-| `disableDevBuild` | Dev builds are blocked for this channel. | If this is a dev build, allow dev updates or test on a build without this restriction. |
-| `disableProdBuild` | A device build in production mode called `/updates`, while your channel blocked it. | Allow production updates in that channel, or build your app as non-production. |
+| `disableEmulator` | Emulator updates are not allowed for this channel. | If this was accidental, turn on emulator updates in a test channel where you validate emulators. If intentional, keep this channel emulator-blocked and use another channel for emulator builds. |
+| `disableDevBuild` | Dev builds are blocked for this channel. | If this was accidental, allow dev updates or move this device to a dev-enabled channel. If this is intentional, keep this channel locked to release builds only. |
+| `disableProdBuild` | A device build in production mode called `/updates`, while your channel blocked it. | If this was accidental, allow production updates in that channel and republish. If this is intentional, keep the restriction and send production builds to the proper channel/build. |
 | `cannotGetBundle` | Capgo could not build a valid download URL for the selected bundle. | Re-upload the bundle or regenerate manifests and check R2/public bundle settings. |
 | `cannotUpdateViaPrivateChannel` | App tried to self-switch to a private channel that does not allow self-assignment. | Enable `allow_device_self_set` on the channel or switch to a public/allowed channel. |
 | `channelMisconfigured` | Channel auto-update rule is missing required data (`version_number` without `min_update_version`). | Fill the missing config for that rule or switch to a simpler auto-update mode. |
@@ -185,8 +185,8 @@ These codes come from the `stats_action` enum used by the dashboard API (`capgo/
 | `NoChannelOrOverride` | No channel matched this device (no cloud default + no config fallback + no override). | Set a channel default in dashboard or keep a test `defaultChannel` in that build. |
 | `rateLimited` | Too many update/channel calls in a short time (often render-loop `setChannel`/`getChannel`). | Stop calling in render. Only call on user action. Use `defaultChannel` in `capacitor.config`. |
 | `keyMismatch` | The app and bundle encryption key IDs differ (`device_key_id` vs `bundle_key_id`). | In the console, compare device and bundle key IDs. If they differ, publish with the same key and matching CLI/plugin version; key encoding can differ between versions. |
-| `disableDevice` | A real phone/tablet was blocked because this channel is set to block real devices. | Turn on real-device updates for that channel. |
-| `disablePlatformElectron` | Electron is blocked in this channel. | Enable Electron in this channel or move Electron users to a different channel. |
+| `disableDevice` | A real phone/tablet was blocked because this channel is set to block real devices. | If accidental, turn on real-device updates in that channel. If intentional, keep it blocked and route real devices to another channel. |
+| `disablePlatformElectron` | Electron is blocked in this channel. | If this was accidental, enable Electron in this channel and republish routing. If intentional, keep it blocked and send Electron users to a dedicated channel. |
 | `customIdBlocked` | A custom device ID was sent, but this app does not accept custom IDs. | Turn off custom ID sending or enable custom IDs only if your workflow requires it. |
 | `blocked_by_server_url` | The app has `server.url` configured, so Capacitor serves remote URL instead of local files. | Remove/clear `server.url` for production builds and keep update payloads local. |
 | `backend_refusal` | The updater is `v4`, which the backend no longer accepts. | Upgrade plugin/CLI to `v5`+ (prefer `v8`), with Capacitor `v5`+, then rebuild and republish bundle metadata. |

--- a/apps/docs/src/content/docs/docs/webapp/logs.mdx
+++ b/apps/docs/src/content/docs/docs/webapp/logs.mdx
@@ -166,7 +166,7 @@ These codes come from the `stats_action` enum used by the dashboard API (`capgo/
 |------|------------------|-------------|
 | `invalidIp` | Capgo detected traffic that looks like bot traffic (Google/cloud infrastructure IP). | Ignore on real users; retry from real devices and normal networks, or check after some time. |
 | `needPlanUpgrade` | Organization reached plan/device limit. | Upgrade plan in dashboard or wait for next billing cycle. |
-| `semver_error` | Native app version in config is missing or not valid semver (`x.y.z`). | Set `plugins.CapacitorUpdater.version` to valid semver and rebuild the app. |
+| `semver_error` | Native app version in config is missing or not valid semver (`x.y.z`). | Set `plugins.CapacitorUpdater.version` to valid semver, then verify it in the [SemVer tester](https://capgo.app/semver_tester/) and rebuild the app. |
 | `disablePlatformIos` | iOS is disabled in channel policy. | Enable iOS in that channel and republish routing. |
 | `disablePlatformAndroid` | Android is disabled in channel policy. | Enable Android in that channel and republish routing. |
 | `disableAutoUpdate` | Channel auto-update mode blocks this update style. | Change channel auto-update policy (major/minor/patch/metadata/none) to allow your intended rollout. |


### PR DESCRIPTION
## Summary
- Expanded docs quick-fix guidance for updater stats events in two user-facing docs pages.
- Added non-technical, actionable fixes for: invalidIp, needPlanUpgrade, semver_error, platform/build blocks, auto-update policies, channel/targeting issues, missing download payload, rate limits, key mismatch, custom-id blockers, blocked server URL, backend_refusal, and webview_* events.
- Removed duplicate quick-fix row and aligned invalidIp casing.
- Docs-only change.

## Notes
- This PR is in draft while CI is running.
