### PR TITLE
feat(analytics): track hero "What's new?" pill clicks

### DIFF
--- a/apps/web/src/components/Hero.astro
+++ b/apps/web/src/components/Hero.astro
@@ -182,6 +182,7 @@ const teamUrl = 'https://book.capgo.app/demo/'
       </div>
       <div class="relative z-10 mx-auto max-w-4xl px-4 pt-16 text-center sm:px-6 sm:pt-24 lg:px-0 lg:pt-32">
         <a
+          id="hero-whatsnew-pill"
           href={nativeBuildUrl}
           class="font-inter mb-8 inline-flex min-h-10 max-w-full items-center gap-2 rounded-full border border-white/15 bg-white/5 px-2 py-1 pr-4 text-sm font-semibold text-slate-300 transition-colors hover:border-blue-400/40 hover:bg-white/10 hover:text-white focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 focus-visible:outline-none"
         >
@@ -388,3 +389,15 @@ const teamUrl = 'https://book.capgo.app/demo/'
     </div>
   </div>
 </section>
+
+<script>
+  // Analytics only — no visual/markup change to the pill itself.
+  // Fires a named PostHog event when the hero "What's new?" pill is clicked.
+  const pill = document.getElementById('hero-whatsnew-pill')
+  pill?.addEventListener('click', () => {
+    ;(window as any).posthog?.capture('home_whatsnew_pill_click', {
+      location: 'hero',
+      destination: 'native-build',
+    })
+  })
+</script>


### PR DESCRIPTION
Adds PostHog tracking to the hero "What's new?" announcement pill **without changing its design**.

## What
- Fires a named PostHog event `home_whatsnew_pill_click` when the pill is clicked, with `{ location: "hero", destination: "native-build" }`.

## Why
We want to measure engagement with the hero announcement pill. The site previously had only autocapture and no named events for it, making this click hard to chart reliably (autocapture breaks if copy/href changes).

## Design impact: none
Martin asked not to change the button. This PR does **not** touch the pill's markup structure, classes, or styles. The only changes are:
1. An `id="hero-whatsnew-pill"` attribute on the existing `<a>` (invisible).
2. A small client `<script>` appended to the component that attaches a click listener.

No pixels move. `astro check` passes (0 errors).

## Notes
- PostHog is already loaded site-wide (`posthog.astro`), so `window.posthog` is available; the handler no-ops safely if it isn't.
- Event name `home_whatsnew_pill_click` establishes a convention we can reuse for other named CTA events.

## Test plan
- [ ] Load the homepage, open PostHog (or devtools network), click the pill, confirm a `home_whatsnew_pill_click` event with the expected properties.
- [ ] Confirm the pill looks and behaves identically to before (navigates to the native-build page).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced infrastructure for interaction tracking on the home page "What's new?" link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->