### PR TITLE
[codex] adjust hero spacing

### DIFF
--- a/apps/web/src/components/Hero.astro
+++ b/apps/web/src/components/Hero.astro
@@ -11,7 +11,7 @@ const teamUrl = 'https://book.capgo.app/demo/'
   <div class="relative overflow-hidden">
     <div class="relative mx-auto max-w-7xl pb-8 md:pb-32">
       <!-- Background Grid of Squares -->
-      <div class="pointer-events-none absolute inset-0 flex w-full flex-col justify-center gap-4 blur-sm select-none sm:blur-none">
+      <div class="pointer-events-none absolute inset-0 flex w-full flex-col justify-start gap-4 blur-sm select-none sm:blur-none">
         <!-- Row 0 -->
         <div class="grid w-full grid-cols-12 gap-4">
           <!-- Left -->
@@ -180,7 +180,7 @@ const teamUrl = 'https://book.capgo.app/demo/'
           </div>
         </div>
       </div>
-      <div class="relative z-10 mx-auto max-w-4xl px-4 pt-16 text-center sm:px-6 sm:pt-24 lg:px-0 lg:pt-32">
+      <div class="relative z-10 mx-auto max-w-4xl px-4 pt-4 text-center sm:px-6 sm:pt-6 lg:px-0 lg:pt-8">
         <a
           id="hero-whatsnew-pill"
           href={nativeBuildUrl}


### PR DESCRIPTION
## Summary

Adjusts the homepage hero spacing so the background square grid starts at the top and the hero content sits higher in the first viewport.

## Impact

This tightens the landing hero layout without changing copy, links, or behavior.

## Validation

- `bunx prettier --write apps/web/src/components/Hero.astro`
- `bun run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted hero section background grid alignment from centered to top positioning for improved visual hierarchy.
  * Reduced top padding on hero content wrapper to create tighter spacing and better layout proportions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->