### PR TITLE
fix(hero): adjust spacing for xl and 2xl screens

### DIFF
--- a/apps/web/src/components/Hero.astro
+++ b/apps/web/src/components/Hero.astro
@@ -180,7 +180,7 @@ const teamUrl = 'https://book.capgo.app/demo/'
           </div>
         </div>
       </div>
-      <div class="relative z-10 mx-auto max-w-4xl px-4 pt-4 text-center sm:px-6 sm:pt-6 lg:px-0 lg:pt-8">
+      <div class="relative z-10 mx-auto max-w-4xl px-4 pt-4 text-center sm:px-6 sm:pt-6 lg:px-0 lg:pt-8 xl:pt-20 2xl:pt-36">
         <a
           id="hero-whatsnew-pill"
           href={nativeBuildUrl}

--- a/apps/web/src/components/Hero.astro
+++ b/apps/web/src/components/Hero.astro
@@ -11,7 +11,7 @@ const teamUrl = 'https://book.capgo.app/demo/'
   <div class="relative overflow-hidden">
     <div class="relative mx-auto max-w-7xl pb-8 md:pb-32">
       <!-- Background Grid of Squares -->
-      <div class="pointer-events-none absolute inset-0 flex w-full flex-col justify-center gap-4 blur-sm select-none sm:blur-none">
+      <div class="pointer-events-none absolute inset-0 flex w-full flex-col justify-start gap-4 blur-sm select-none sm:blur-none">
         <!-- Row 0 -->
         <div class="grid w-full grid-cols-12 gap-4">
           <!-- Left -->
@@ -180,7 +180,7 @@ const teamUrl = 'https://book.capgo.app/demo/'
           </div>
         </div>
       </div>
-      <div class="relative z-10 mx-auto max-w-4xl px-4 pt-16 text-center sm:px-6 sm:pt-24 lg:px-0 lg:pt-32">
+      <div class="relative z-10 mx-auto max-w-4xl px-4 pt-4 text-center sm:px-6 sm:pt-6 lg:px-0 lg:pt-8">
         <a
           id="hero-whatsnew-pill"
           href={nativeBuildUrl}


### PR DESCRIPTION
## Summary

- Add `xl:pt-20` for large screens (≥1280px)
- Add `2xl:pt-36` for 16-inch screens (≥1536px, ~1728px CSS)

## Test plan

- [ ] Check hero spacing on xl screens (1280px+)
- [ ] Check hero spacing on MacBook Pro 16-inch (1728px CSS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted hero section's content alignment to start from the left instead of center.
  * Reduced hero section's top spacing to create a more compact layout with responsive adjustments for larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->