### PR TITLE
fix(web): unify talk-to-team avatars

### DIFF
--- a/apps/web/src/components/Hero.astro
+++ b/apps/web/src/components/Hero.astro
@@ -1,6 +1,7 @@
 ---
 import m from '@/copy/messages'
 import { getRelativeLocaleUrl } from 'astro:i18n'
+import TeamAvatars from '@/components/TeamAvatars.astro'
 
 const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. ${m.no_credit_card_required({}, { locale: Astro.locals.locale })}`
 const nativeBuildUrl = getRelativeLocaleUrl(Astro.locals.locale, 'native-build')
@@ -219,11 +220,7 @@ const teamUrl = 'https://book.capgo.app/demo/'
             </div>
           </div>
           <div class="font-inter flex flex-col items-center justify-center gap-3 text-sm text-gray-400 sm:flex-row">
-            <div class="flex -space-x-2" aria-hidden="true">
-              <img src="/martin-avatar.png" alt="" width="36" height="36" class="h-9 w-9 rounded-full border-2 border-gray-950 object-cover shadow-sm" />
-              <img src="/michael-profile.webp" alt="" width="36" height="36" class="h-9 w-9 rounded-full border-2 border-gray-950 object-cover shadow-sm" />
-              <img src="/valeria-avatar.jpg" alt="" width="36" height="36" class="h-9 w-9 rounded-full border-2 border-gray-950 object-cover shadow-sm" />
-            </div>
+            <TeamAvatars size="lg" border="border-gray-950" shadow loading={false} />
             <p>
               Enterprise needs?
               <a

--- a/apps/web/src/components/TeamAvatars.astro
+++ b/apps/web/src/components/TeamAvatars.astro
@@ -1,0 +1,34 @@
+---
+interface Props {
+  size?: 'sm' | 'lg'
+  border?: string
+  shadow?: boolean
+  loading?: 'lazy' | 'eager' | false
+}
+
+const { size = 'sm', border = 'border-white', shadow = false, loading = 'lazy' } = Astro.props
+
+const members = [
+  { src: '/jordan-avatar.jpg' },
+  { src: '/martin-avatar.png' },
+  { src: '/valeria-avatar.jpg' },
+]
+
+const sizeClasses = size === 'lg' ? 'h-9 w-9' : 'h-6 w-6'
+const pixelSize = size === 'lg' ? 36 : 24
+---
+
+<span class="flex -space-x-2" aria-hidden="true">
+  {
+    members.map((member) => (
+      <img
+        class:list={[sizeClasses, 'rounded-full border-2 object-cover', border, shadow && 'shadow-sm']}
+        src={member.src}
+        alt=""
+        width={pixelSize}
+        height={pixelSize}
+        loading={loading || undefined}
+      />
+    ))
+  }
+</span>

--- a/apps/web/src/components/pricing/Plans.astro
+++ b/apps/web/src/components/pricing/Plans.astro
@@ -3,6 +3,7 @@ import { numberWithSpaces } from '@/services/misc'
 import type { Database } from '@/services/supabase.types'
 import { getRelativeLocaleUrl } from 'astro:i18n'
 import m from '@/copy/messages'
+import TeamAvatars from '@/components/TeamAvatars.astro'
 
 interface Props {
   pricing: Database['public']['Tables']['plans']['Row'][]
@@ -124,11 +125,7 @@ function buildTimeDisplay(buildTimeSeconds: number) {
                 class="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-full border border-gray-200 bg-gray-100 px-4 py-3 text-sm font-semibold whitespace-nowrap text-gray-900 transition-colors hover:bg-blue-50 hover:text-blue-700 focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:outline-none"
                 role="button"
               >
-                <span class="flex -space-x-2" aria-hidden="true">
-                  <img class="h-6 w-6 rounded-full border-2 border-white object-cover" src="/martin-avatar.png" alt="" width="24" height="24" loading="lazy" />
-                  <img class="h-6 w-6 rounded-full border-2 border-white object-cover" src="/valeria-avatar.jpg" alt="" width="24" height="24" loading="lazy" />
-                  <img class="h-6 w-6 rounded-full border-2 border-white object-cover" src="/jordan-avatar.jpg" alt="" width="24" height="24" loading="lazy" />
-                </span>
+                <TeamAvatars />
                 <span>Talk to our team</span>
               </a>
             )}

--- a/apps/web/src/components/solutions/SolutionAppExample.astro
+++ b/apps/web/src/components/solutions/SolutionAppExample.astro
@@ -4,6 +4,7 @@ import { solutionAppExamples, type SolutionAppExampleKey } from '@/config/soluti
 import { solutionStoreApps } from '@/config/solutionStoreApps'
 import { renameCat, shortNumber } from '@/services/misc'
 import { getRelativeLocaleUrl } from 'astro:i18n'
+import TeamAvatars from '@/components/TeamAvatars.astro'
 
 interface Props {
   solution: SolutionAppExampleKey
@@ -59,11 +60,7 @@ const showExampleCtas = solution === 'enterprise'
                   aria-label={copy('solutions_talk_to_team')}
                   class="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-white/10 bg-white px-5 py-3 text-sm font-bold text-gray-950 transition-colors hover:bg-blue-50 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white"
                 >
-                  <span class="flex -space-x-2" aria-hidden="true">
-                    <img class="h-6 w-6 rounded-full border-2 border-white object-cover" src="/martin-avatar.png" alt="" width="24" height="24" loading="lazy" />
-                    <img class="h-6 w-6 rounded-full border-2 border-white object-cover" src="/valeria-avatar.jpg" alt="" width="24" height="24" loading="lazy" />
-                    <img class="h-6 w-6 rounded-full border-2 border-white object-cover" src="/jordan-avatar.jpg" alt="" width="24" height="24" loading="lazy" />
-                  </span>
+                  <TeamAvatars />
                   <span>{copy('solutions_talk_to_team')}</span>
                 </a>
               </div>

--- a/apps/web/src/pages/enterprise.astro
+++ b/apps/web/src/pages/enterprise.astro
@@ -3,6 +3,7 @@ import Layout from '@/layouts/Layout.astro'
 import { getRelativeLocaleUrl } from 'astro:i18n'
 import m from '@/copy/messages'
 import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
+import TeamAvatars from '@/components/TeamAvatars.astro'
 import type { Database } from '@/services/supabase.types'
 import { createLdJsonGraph, createServiceLdJson, createProductLdJson } from '@/lib/ldJson'
 import { numberWithSpaces } from '@/services/misc'
@@ -365,11 +366,7 @@ const enterpriseBeforeAfterRows = [
               aria-label={m.enterprise_talk_to_team({}, { locale })}
               class="inline-flex min-h-11 items-center justify-center gap-2 rounded-full bg-gray-950 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-gray-800 focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:outline-none"
             >
-              <span class="flex -space-x-2" aria-hidden="true">
-                <img class="h-6 w-6 rounded-full border-2 border-white object-cover" src="/martin-avatar.png" alt="" width="24" height="24" loading="lazy" />
-                <img class="h-6 w-6 rounded-full border-2 border-white object-cover" src="/valeria-avatar.jpg" alt="" width="24" height="24" loading="lazy" />
-                <img class="h-6 w-6 rounded-full border-2 border-white object-cover" src="/jordan-avatar.jpg" alt="" width="24" height="24" loading="lazy" />
-              </span>
+              <TeamAvatars />
               <span>{m.enterprise_talk_to_team({}, { locale })}</span>
             </a>
             <a
@@ -715,11 +712,7 @@ const enterpriseBeforeAfterRows = [
             aria-label={m.enterprise_talk_to_team({}, { locale })}
             class="inline-flex min-h-11 w-fit items-center justify-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-gray-950 transition-colors hover:bg-blue-50 hover:text-blue-700 focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-slate-950 focus:outline-none"
           >
-            <span class="flex -space-x-2" aria-hidden="true">
-              <img class="h-6 w-6 rounded-full border-2 border-white object-cover" src="/martin-avatar.png" alt="" width="24" height="24" loading="lazy" />
-              <img class="h-6 w-6 rounded-full border-2 border-white object-cover" src="/valeria-avatar.jpg" alt="" width="24" height="24" loading="lazy" />
-              <img class="h-6 w-6 rounded-full border-2 border-white object-cover" src="/jordan-avatar.jpg" alt="" width="24" height="24" loading="lazy" />
-            </span>
+            <TeamAvatars />
             <span>{m.enterprise_talk_to_team({}, { locale })}</span>
           </a>
         </div>

--- a/apps/web/src/pages/ionic-enterprise-plugins.astro
+++ b/apps/web/src/pages/ionic-enterprise-plugins.astro
@@ -3,6 +3,7 @@ import ProductTestimonials from '@/components/ProductTestimonials.astro'
 import { productTestimonials } from '@/config/productTestimonials'
 import Layout from '@/layouts/Layout.astro'
 import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
+import TeamAvatars from '@/components/TeamAvatars.astro'
 import m from '@/copy/messages'
 import { pluginCountLabel } from '@/config/plugins'
 import { getRelativeLocaleUrl } from 'astro:i18n'
@@ -81,11 +82,7 @@ const content = { title, description, image: `${Astro.locals.runtimeConfig.publi
               aria-label={m.enterprise_talk_to_team({}, { locale })}
               class="inline-flex items-center justify-center gap-2 rounded-xl border border-emerald-400/50 bg-emerald-500/10 px-8 py-4 text-base font-semibold text-emerald-100 transition-all duration-200 hover:bg-emerald-500/20 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
             >
-              <span class="flex -space-x-2" aria-hidden="true">
-                <img class="h-6 w-6 rounded-full border-2 border-gray-950 object-cover" src="/martin-avatar.png" alt="" width="24" height="24" loading="lazy" />
-                <img class="h-6 w-6 rounded-full border-2 border-gray-950 object-cover" src="/valeria-avatar.jpg" alt="" width="24" height="24" loading="lazy" />
-                <img class="h-6 w-6 rounded-full border-2 border-gray-950 object-cover" src="/jordan-avatar.jpg" alt="" width="24" height="24" loading="lazy" />
-              </span>
+              <TeamAvatars border="border-gray-950" />
               <span>{m.enterprise_talk_to_team({}, { locale })}</span>
             </a>
             <a
@@ -481,11 +478,7 @@ const content = { title, description, image: `${Astro.locals.runtimeConfig.publi
               aria-label={m.enterprise_talk_to_team({}, { locale })}
               class="inline-flex items-center justify-center gap-2 rounded-xl border border-emerald-400/50 px-8 py-4 text-base font-semibold text-gray-200 transition-all duration-200 hover:bg-emerald-500/10"
             >
-              <span class="flex -space-x-2" aria-hidden="true">
-                <img class="h-6 w-6 rounded-full border-2 border-emerald-950 object-cover" src="/martin-avatar.png" alt="" width="24" height="24" loading="lazy" />
-                <img class="h-6 w-6 rounded-full border-2 border-emerald-950 object-cover" src="/valeria-avatar.jpg" alt="" width="24" height="24" loading="lazy" />
-                <img class="h-6 w-6 rounded-full border-2 border-emerald-950 object-cover" src="/jordan-avatar.jpg" alt="" width="24" height="24" loading="lazy" />
-              </span>
+              <TeamAvatars border="border-emerald-950" />
               <span>{m.enterprise_talk_to_team({}, { locale })}</span>
             </a>
           </div>


### PR DESCRIPTION
## Summary
- Add shared `TeamAvatars` component with Jordan → Martin → Valeria order
- Replace duplicated avatar stacks on hero, pricing, enterprise, solutions, and ionic plugins pages
- Fix hero markup wrapper around the team CTA avatars

## Test plan
- [ ] Open homepage hero and confirm avatars show Jordan (left), Martin (center), Valeria (right)
- [ ] Check Enterprise plan CTA on pricing page
- [ ] Check enterprise and ionic-enterprise-plugins talk-to-team buttons
- [ ] Verify solution app example enterprise CTA


Made with [Cursor](https://cursor.com)