### PR TITLE
Show SOC 2 and uptime SLA in Enterprise pricing highlights

### DIFF
--- a/apps/web/src/components/pricing/Plans.astro
+++ b/apps/web/src/components/pricing/Plans.astro
@@ -32,8 +32,9 @@ function planHighlights(plan: Database['public']['Tables']['plans']['Row']) {
     `${numberWithSpaces(plan.mau)}${plan.name === 'Enterprise' ? '+' : ''} ${m.monthly_active_users({}, { locale: Astro.locals.locale })}`,
     `${numberWithSpaces(plan.bandwidth)}${plan.name === 'Enterprise' ? '+' : ''} GiB/${m.month({}, { locale: Astro.locals.locale })} ${m.of_bandwidth({}, { locale: Astro.locals.locale })}`,
     `${numberWithSpaces(plan.storage)}${plan.name === 'Enterprise' ? '+' : ''} GiB storage`,
-    m.unlimited_live_updates({}, { locale: Astro.locals.locale }),
-    m.mcp_server({}, { locale: Astro.locals.locale }),
+    ...(plan.name === 'Enterprise'
+      ? [m.soc2_compliance_short({}, { locale: Astro.locals.locale }), m.enterprise_uptime_sla({}, { locale: Astro.locals.locale })]
+      : [m.unlimited_live_updates({}, { locale: Astro.locals.locale }), m.mcp_server({}, { locale: Astro.locals.locale })]),
   ]
 
   if (plan.build_time_unit && plan.build_time_unit > 0) {


### PR DESCRIPTION
## Summary
- Replace "Unlimited Live Updates" and "MCP Server" in the Enterprise plan card highlights with "SOC 2 Type II Compliant" and "99.9% uptime SLA"
- Keeps other plan cards unchanged so above-the-fold enterprise messaging focuses on compliance and reliability

## Test plan
- [ ] Open `/pricing/` and confirm the Enterprise card shows SOC 2 Type II Compliant and 99.9% uptime SLA in the Includes list
- [ ] Confirm Solo, Maker, and Team cards still show Unlimited Live Updates and MCP Server
- [ ] Verify localized pricing pages render the updated Enterprise highlights correctly


Made with [Cursor](https://cursor.com)