### PR TITLE
Fix Meta CompleteRegistration by opening console in new tab

### DIFF
--- a/apps/web/src/pages/register.astro
+++ b/apps/web/src/pages/register.astro
@@ -282,7 +282,7 @@ const content = {
       })
     }
     const consoleUrl = `https://console.capgo.app/login/?access_token=${session.data.session?.access_token}&refresh_token=${session.data.session?.refresh_token}&to=/app`
-    window.open(consoleUrl, '_blank', 'noopener,noreferrer')
-    submitButton.disabled = false
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    window.location.href = consoleUrl
   })
 </script>

--- a/apps/web/src/pages/register.astro
+++ b/apps/web/src/pages/register.astro
@@ -281,6 +281,8 @@ const content = {
         last_name: lastName.value,
       })
     }
-    window.location.href = `https://console.capgo.app/login/?access_token=${session.data.session?.access_token}&refresh_token=${session.data.session?.refresh_token}&to=/app`
+    const consoleUrl = `https://console.capgo.app/login/?access_token=${session.data.session?.access_token}&refresh_token=${session.data.session?.refresh_token}&to=/app`
+    window.open(consoleUrl, '_blank', 'noopener,noreferrer')
+    submitButton.disabled = false
   })
 </script>


### PR DESCRIPTION
## Summary
- After successful signup on `/register/`, open the Capgo console in a new tab instead of redirecting the current page
- Re-enable the submit button so users can retry if the popup is blocked
- Keeps the landing page loaded long enough for the Facebook Pixel `CompleteRegistration` event to complete

## Test plan
- [ ] Sign up on https://capgo.app/register/
- [ ] Confirm the console opens in a new tab with a valid session
- [ ] Confirm the register page stays open
- [ ] Verify `CompleteRegistration` appears in Meta Events Manager (or Meta Pixel Helper)


Made with [Cursor](https://cursor.com)