### PR TITLE
fix(blog): consolidate duplicate and SEO keyword tags

### DIFF
--- a/apps/web/src/constants/blogTags.ts
+++ b/apps/web/src/constants/blogTags.ts
@@ -1,0 +1,164 @@
+export const BLOG_TAGS = [
+  'Development',
+  'Mobile',
+  'Updates',
+  'Security',
+  'Tutorial',
+  'Technology',
+  'CI/CD',
+  'Alternatives',
+  'App Store',
+  'Solution',
+  'Best Practices',
+  'Capacitor',
+  'Migration',
+  'Story',
+  'IAP',
+  'Android',
+  'Product',
+  'News',
+  'Open Source',
+  'Marketing',
+  'ASO',
+  'Guides',
+  'Monetization',
+  'Case Study',
+  'Company',
+  'Configuration',
+  'DeepLinking',
+  'Optimisation',
+  'Web Development',
+  'Cloud',
+  'iOS',
+  'Google Play',
+] as const
+
+export type BlogTag = (typeof BLOG_TAGS)[number]
+
+const BLOG_TAG_SET = new Set<string>(BLOG_TAGS)
+
+const TAG_ALIASES: Record<string, BlogTag> = {
+  development: 'Development',
+  mobile: 'Mobile',
+  updates: 'Updates',
+  security: 'Security',
+  tutorial: 'Tutorial',
+  technology: 'Technology',
+  'ci/cd': 'CI/CD',
+  alternatives: 'Alternatives',
+  'app store': 'App Store',
+  solution: 'Solution',
+  'best practices': 'Best Practices',
+  capacitor: 'Capacitor',
+  migration: 'Migration',
+  story: 'Story',
+  iap: 'IAP',
+  android: 'Android',
+  product: 'Product',
+  news: 'News',
+  'open source': 'Open Source',
+  marketing: 'Marketing',
+  aso: 'ASO',
+  guides: 'Guides',
+  monetization: 'Monetization',
+  'case study': 'Case Study',
+  company: 'Company',
+  configuration: 'Configuration',
+  deeplinking: 'DeepLinking',
+  optimisation: 'Optimisation',
+  optimization: 'Optimisation',
+  'web development': 'Web Development',
+  cloud: 'Cloud',
+  ios: 'iOS',
+  'google play': 'Google Play',
+  cordova: 'Capacitor',
+  'cross-platform': 'Mobile',
+  capacitorjs: 'Capacitor',
+  electronjs: 'Technology',
+  jest: 'Development',
+  'react native': 'Mobile',
+  expo: 'Mobile',
+  devops: 'CI/CD',
+  'mobile development': 'Development',
+  'mobile app development': 'Development',
+  'cross-platform apps': 'Mobile',
+  'live updates': 'Updates',
+  'ci/cd automation': 'CI/CD',
+  'ci/cd pipeline': 'CI/CD',
+}
+
+const INFERENCE_RULES: Array<[RegExp, BlogTag]> = [
+  [/\bsecurity\b|privacy|gdpr|soc.?2|encrypt|compliance|audit|data privacy|webhook security/, 'Security'],
+  [/\bci\/?cd\b|devops|continuous deployment|pipeline|automated testing/, 'CI/CD'],
+  [/\blive update|ota\b|app update|over.the.air/, 'Updates'],
+  [/\bapp store|review management|submission/, 'App Store'],
+  [/\bgoogle play\b/, 'Google Play'],
+  [/\bandroid\b/, 'Android'],
+  [/\biphone\b|\bios\b/, 'iOS'],
+  [/\btutorial\b|how to|step.by.step/, 'Tutorial'],
+  [/\bguide\b/, 'Guides'],
+  [/\bcapacitor|capgo|cordova|ionic/, 'Capacitor'],
+  [/\bopen source\b/, 'Open Source'],
+  [/\bproduct\b|retention|analytics|metrics|saas|user adoption/, 'Product'],
+  [/\barchitecture|microservice|monolithic|edge network|edge computing/, 'Technology'],
+  [/\bperformance|latency|optimization|optimisation/, 'Best Practices'],
+  [/\bmarketing\b|\baso\b/, 'Marketing'],
+  [/\balternatives\b|\bvs\b|compare/, 'Alternatives'],
+  [/\bcloud\b/, 'Cloud'],
+  [/\bweb development\b|node\.js|yarn/, 'Web Development'],
+  [/\bquality assurance\b|\bqa\b|software testing|unit test/, 'Tutorial'],
+  [/\bmigration\b/, 'Migration'],
+  [/\bmonetization\b|\biap\b/, 'Monetization'],
+  [/\bstory\b|case study/, 'Story'],
+  [/\bconfiguration\b/, 'Configuration'],
+  [/\bsolution\b/, 'Solution'],
+  [/\bnews\b/, 'News'],
+  [/\bcompany\b/, 'Company'],
+]
+
+export function isCanonicalBlogTag(tag: string): tag is BlogTag {
+  return BLOG_TAG_SET.has(tag)
+}
+
+export function normalizeBlogTag(tag: string): BlogTag | null {
+  const trimmed = tag.trim()
+  if (!trimmed) return null
+  if (isCanonicalBlogTag(trimmed)) return trimmed
+  return TAG_ALIASES[trimmed.toLowerCase()] ?? null
+}
+
+export function inferBlogTags(title: string, keywords = ''): BlogTag[] {
+  const text = `${title} ${keywords}`.toLowerCase()
+  const tags = new Set<BlogTag>()
+
+  for (const [pattern, tag] of INFERENCE_RULES) {
+    if (pattern.test(text)) tags.add(tag)
+  }
+
+  if (tags.size === 0) tags.add('Development')
+
+  tags.add('Mobile')
+
+  return BLOG_TAGS.filter((tag) => tags.has(tag)).slice(0, 3)
+}
+
+export function normalizeBlogTags(rawTags: string[], title = '', keywords = ''): string {
+  const raw = rawTags.map((tag) => tag.trim()).filter(Boolean)
+  if (raw.length === 0) return inferBlogTags(title, keywords).join(', ')
+
+  const hadNonCanonical = raw.some((tag) => normalizeBlogTag(tag) === null)
+
+  if (hadNonCanonical) {
+    const inferred = inferBlogTags(title, keywords)
+    const tagCount = raw.length >= 3 ? 3 : Math.max(raw.length, 1)
+    return inferred.slice(0, tagCount).join(', ')
+  }
+
+  const result: BlogTag[] = []
+  for (const tag of raw) {
+    const normalized = normalizeBlogTag(tag)
+    if (normalized && !result.includes(normalized)) result.push(normalized)
+  }
+
+  return result.join(', ')
+}

--- a/apps/web/src/content.config.ts
+++ b/apps/web/src/content.config.ts
@@ -1,6 +1,7 @@
 import { glob } from 'astro/loaders'
 import { z } from 'astro/zod'
 import { defineCollection } from 'astro:content'
+import { normalizeBlogTags } from './constants/blogTags'
 import { locales, type Locales } from './services/locale'
 
 const localeSchema = z.custom<Locales>((value) => typeof value === 'string' && locales.includes(value as Locales), { message: 'Invalid locale' })
@@ -19,17 +20,18 @@ const blog = defineCollection({
     head_image: z.string().optional(),
     head_image_alt: z.string().optional(),
     keywords: z.string().optional(),
-    tag: z.string().transform((value) =>
-      value
-        .trim()
-        .split(',')
-        .map((item) => item.trim())
-        .join(','),
-    ),
+    tag: z.string(),
     published: z.boolean().optional(),
     locale: localeSchema,
     next_blog: z.string().optional().nullable(),
-  }),
+  }).transform((data) => ({
+    ...data,
+    tag: normalizeBlogTags(
+      data.tag.split(',').map((item) => item.trim()).filter(Boolean),
+      data.title,
+      data.keywords ?? '',
+    ),
+  })),
 })
 
 const plugin = defineCollection({

--- a/apps/web/src/content/blog/en/app-access-management.md
+++ b/apps/web/src/content/blog/en/app-access-management.md
@@ -1,16 +1,21 @@
 ---
 slug: app-access-management
 title: 'Mastering App Access Management: RBAC & SSO in 2026'
-description: 'Gain expertise in app access management for 2026. Master RBAC, SSO, and secure implementation across mobile and desktop apps. A practical guide for enterprise'
+description: >-
+  Gain expertise in app access management for 2026. Master RBAC, SSO, and secure
+  implementation across mobile and desktop apps. A practical guide for
+  enterprise
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-04T07:29:46.915Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/app-access-management.webp
-head_image_alt: "'Mastering App Access Management: RBAC & SSO in 2026' Capgo blog illustration"
-keywords: 'app access management, identity management, application security, capacitor security, enterprise mobility'
-tag: 'app access management, identity management, application security, capacitor security, enterprise mobility'
+head_image_alt: '''Mastering App Access Management: RBAC & SSO in 2026'' Capgo blog illustration'
+keywords: >-
+  app access management, identity management, application security, capacitor
+  security, enterprise mobility
+tag: 'Mobile, Security, Capacitor'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/app-performance-optimization.md
+++ b/apps/web/src/content/blog/en/app-performance-optimization.md
@@ -1,16 +1,21 @@
 ---
 slug: app-performance-optimization
 title: App Performance Optimization for Capacitor & Electron
-description: 'A practical guide to app performance optimization for Capacitor, Ionic, and Electron. Learn to measure, diagnose, and fix performance issues with expert tips.'
+description: >-
+  A practical guide to app performance optimization for Capacitor, Ionic, and
+  Electron. Learn to measure, diagnose, and fix performance issues with expert
+  tips.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-28T07:24:57.222Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/app-performance-optimization.webp
-head_image_alt: "App Performance Optimization for Capacitor & Electron Capgo blog illustration"
-keywords: 'app performance optimization, capacitorjs, electronjs, ionic framework, mobile performance'
-tag: 'app performance optimization, capacitorjs, electronjs, ionic framework, mobile performance'
+head_image_alt: App Performance Optimization for Capacitor & Electron Capgo blog illustration
+keywords: >-
+  app performance optimization, capacitorjs, electronjs, ionic framework, mobile
+  performance
+tag: 'Mobile, Best Practices, Capacitor'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/app-quality-assurance.md
+++ b/apps/web/src/content/blog/en/app-quality-assurance.md
@@ -1,16 +1,18 @@
 ---
 slug: app-quality-assurance
 title: 'App Quality Assurance: A Practical Guide for 2026'
-description: 'A complete guide to app quality assurance. Learn the QA lifecycle, test types, automation strategy, CI/CD integration, key metrics, and recovery patterns.'
+description: >-
+  A complete guide to app quality assurance. Learn the QA lifecycle, test types,
+  automation strategy, CI/CD integration, key metrics, and recovery patterns.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-27T07:23:02.972Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/app-quality-assurance.webp
-head_image_alt: "'App Quality Assurance: A Practical Guide for 2026' Capgo blog illustration"
+head_image_alt: '''App Quality Assurance: A Practical Guide for 2026'' Capgo blog illustration'
 keywords: 'app quality assurance, mobile qa, software testing, ci/cd, capacitorjs'
-tag: 'app quality assurance, mobile qa, software testing, ci/cd, capacitorjs'
+tag: 'Mobile, Tutorial, CI/CD'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/app-store-review-management.md
+++ b/apps/web/src/content/blog/en/app-store-review-management.md
@@ -1,16 +1,21 @@
 ---
 slug: app-store-review-management
 title: 'App Store Review Management: A Complete Playbook'
-description: 'Master app store review management with our step-by-step playbook. Learn to prepare submissions, handle rejections, and use live updates to ship fixes faster.'
+description: >-
+  Master app store review management with our step-by-step playbook. Learn to
+  prepare submissions, handle rejections, and use live updates to ship fixes
+  faster.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-11T09:07:48.209Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/app-store-review-management.webp
-head_image_alt: "'App Store Review Management: A Complete Playbook' Capgo blog illustration"
-keywords: 'app store review management, mobile app release, capacitorjs, app store submission, live updates'
-tag: 'app store review management, mobile app release, capacitorjs, app store submission, live updates'
+head_image_alt: '''App Store Review Management: A Complete Playbook'' Capgo blog illustration'
+keywords: >-
+  app store review management, mobile app release, capacitorjs, app store
+  submission, live updates
+tag: 'Mobile, Updates, App Store'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/app-update-notification.md
+++ b/apps/web/src/content/blog/en/app-update-notification.md
@@ -1,16 +1,18 @@
 ---
 slug: app-update-notification
 title: Effective App Update Notification Strategies
-description: 'Implement a robust app update notification for Capacitor & Electron. Learn UX patterns, Capgo, silent/forced updates, and CI/CD strategies.'
+description: >-
+  Implement a robust app update notification for Capacitor & Electron. Learn UX
+  patterns, Capgo, silent/forced updates, and CI/CD strategies.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-20T07:08:46.263Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/app-update-notification.webp
-head_image_alt: "Effective App Update Notification Strategies Capgo blog illustration"
+head_image_alt: Effective App Update Notification Strategies Capgo blog illustration
 keywords: 'app update notification, capacitorjs, electronjs, capgo, live updates'
-tag: 'app update notification, capacitorjs, electronjs, capgo, live updates'
+tag: 'Mobile, Updates, Capacitor'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/app-user-experience.md
+++ b/apps/web/src/content/blog/en/app-user-experience.md
@@ -1,16 +1,22 @@
 ---
 slug: app-user-experience
 title: 'App User Experience: A Guide for Capacitor & Electron Teams'
-description: 'Master app user experience for cross-platform apps. Learn core components, key metrics, and how to improve UX with reliable updates for Capacitor & Electron.'
+description: >-
+  Master app user experience for cross-platform apps. Learn core components, key
+  metrics, and how to improve UX with reliable updates for Capacitor & Electron.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-18T06:45:55.489Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/app-user-experience.webp
-head_image_alt: "'App User Experience: A Guide for Capacitor & Electron Teams' Capgo blog illustration"
-keywords: 'app user experience, capacitorjs, mobile ux, cross-platform apps, user retention'
-tag: 'app user experience, capacitorjs, mobile ux, cross-platform apps, user retention'
+head_image_alt: >-
+  'App User Experience: A Guide for Capacitor & Electron Teams' Capgo blog
+  illustration
+keywords: >-
+  app user experience, capacitorjs, mobile ux, cross-platform apps, user
+  retention
+tag: 'Mobile, Capacitor, Product'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/app-user-retention.md
+++ b/apps/web/src/content/blog/en/app-user-retention.md
@@ -1,16 +1,21 @@
 ---
 slug: app-user-retention
 title: 'App User Retention: A Guide to Keeping Users Hooked'
-description: 'Learn to improve app user retention with key metrics, cohort analysis, and developer-focused tactics. A practical guide for building apps users stick with.'
+description: >-
+  Learn to improve app user retention with key metrics, cohort analysis, and
+  developer-focused tactics. A practical guide for building apps users stick
+  with.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-05T07:40:06.551Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/app-user-retention.webp
-head_image_alt: "'App User Retention: A Guide to Keeping Users Hooked' Capgo blog illustration"
-keywords: 'app user retention, mobile app metrics, user engagement, capacitorjs, product management'
-tag: 'app user retention, mobile app metrics, user engagement, capacitorjs, product management'
+head_image_alt: '''App User Retention: A Guide to Keeping Users Hooked'' Capgo blog illustration'
+keywords: >-
+  app user retention, mobile app metrics, user engagement, capacitorjs, product
+  management
+tag: 'Mobile, Capacitor, Product'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/application-release-notes.md
+++ b/apps/web/src/content/blog/en/application-release-notes.md
@@ -1,16 +1,21 @@
 ---
 slug: application-release-notes
 title: 'Application Release Notes: A Complete Guide for 2026'
-description: 'Learn how to write and automate effective application release notes. This guide covers templates, formatting, CI/CD integration, and best practices for any app.'
+description: >-
+  Learn how to write and automate effective application release notes. This
+  guide covers templates, formatting, CI/CD integration, and best practices for
+  any app.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-06T07:14:58.916Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/application-release-notes.webp
-head_image_alt: "'Application Release Notes: A Complete Guide for 2026' Capgo blog illustration"
-keywords: 'application release notes, software releases, changelog best practices, product communication, CI/CD automation'
-tag: 'application release notes, software releases, changelog best practices, product communication, CI/CD automation'
+head_image_alt: '''Application Release Notes: A Complete Guide for 2026'' Capgo blog illustration'
+keywords: >-
+  application release notes, software releases, changelog best practices,
+  product communication, CI/CD automation
+tag: 'Mobile, CI/CD, Product'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/barcode-scanner-cordova.md
+++ b/apps/web/src/content/blog/en/barcode-scanner-cordova.md
@@ -1,16 +1,21 @@
 ---
 slug: barcode-scanner-cordova
 title: 'Build a Barcode Scanner Cordova App: 2026 Guide'
-description: 'Build a powerful barcode scanner cordova app in 2026. This comprehensive guide covers plugin choice, Android/iOS setup, code examples, and Capacitor migration.'
+description: >-
+  Build a powerful barcode scanner cordova app in 2026. This comprehensive guide
+  covers plugin choice, Android/iOS setup, code examples, and Capacitor
+  migration.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-12T09:44:44.975Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/barcode-scanner-cordova.webp
-head_image_alt: "'Build a Barcode Scanner Cordova App: 2026 Guide' Capgo blog illustration"
-keywords: 'barcode scanner cordova, cordova plugins, cross-platform development, mobile barcode scanning, ionic capacitor'
-tag: 'barcode scanner cordova, cordova plugins, cross-platform development, mobile barcode scanning, ionic capacitor'
+head_image_alt: '''Build a Barcode Scanner Cordova App: 2026 Guide'' Capgo blog illustration'
+keywords: >-
+  barcode scanner cordova, cordova plugins, cross-platform development, mobile
+  barcode scanning, ionic capacitor
+tag: 'Mobile, Capacitor, Guides'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/birth-of-capgo-revolutionizing-capacitor-app-updates.md
+++ b/apps/web/src/content/blog/en/birth-of-capgo-revolutionizing-capacitor-app-updates.md
@@ -11,9 +11,11 @@ author_url: 'https://x.com/martindonadieu'
 created_at: 2024-07-13T00:00:00.000Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /capgo-birth-story.webp
-head_image_alt: "How a GitHub Issue Evolved into a business Capgo blog illustration"
-keywords: mobile app development, live updates, OTA updates, continuous integration, mobile app updates
-tag: development
+head_image_alt: How a GitHub Issue Evolved into a business Capgo blog illustration
+keywords: >-
+  mobile app development, live updates, OTA updates, continuous integration,
+  mobile app updates
+tag: Development
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/capgo-purpose.md
+++ b/apps/web/src/content/blog/en/capgo-purpose.md
@@ -10,9 +10,11 @@ author_url: 'https://x.com/anikdhabal'
 created_at: 2023-09-10T00:00:00.000Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/capgo-purpose.webp
-head_image_alt: "Purpose of Capgo Capgo blog illustration"
-keywords: mobile app development, live updates, OTA updates, continuous integration, mobile app updates
-tag: SOLUTION
+head_image_alt: Purpose of Capgo Capgo blog illustration
+keywords: >-
+  mobile app development, live updates, OTA updates, continuous integration,
+  mobile app updates
+tag: Solution
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/cordova-hybrid-app-development.md
+++ b/apps/web/src/content/blog/en/cordova-hybrid-app-development.md
@@ -12,9 +12,13 @@ author_url: 'https://x.com/martindonadieu'
 created_at: 2024-06-02T00:00:00.000Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /what-is-cordova-phone-gap.webp
-head_image_alt: "'Ultimate Guide to Apache Cordova: Hybrid App Development Made Easy' Capgo blog illustration"
-keywords: Cordova, hybrid app development, mobile app development, live updates, OTA updates, continuous integration, mobile app updates
-tag: cordova
+head_image_alt: >-
+  'Ultimate Guide to Apache Cordova: Hybrid App Development Made Easy' Capgo
+  blog illustration
+keywords: >-
+  Cordova, hybrid app development, mobile app development, live updates, OTA
+  updates, continuous integration, mobile app updates
+tag: Capacitor
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/cross-platform-messaging-apps.md
+++ b/apps/web/src/content/blog/en/cross-platform-messaging-apps.md
@@ -1,16 +1,21 @@
 ---
 slug: cross-platform-messaging-apps
 title: 10 Best Cross Platform Messaging Apps for 2026
-description: 'Explore the 10 best cross platform messaging apps for developers and enterprise use. Compare SDKs, APIs, security, and pricing to find the right solution.'
+description: >-
+  Explore the 10 best cross platform messaging apps for developers and
+  enterprise use. Compare SDKs, APIs, security, and pricing to find the right
+  solution.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-21T06:51:25.623Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/cross-platform-messaging-apps.webp
-head_image_alt: "10 Best Cross Platform Messaging Apps for 2026 Capgo blog illustration"
-keywords: 'cross platform messaging, messaging sdk, team chat apps, enterprise messaging, chat api'
-tag: 'cross platform messaging, messaging sdk, team chat apps, enterprise messaging, chat api'
+head_image_alt: 10 Best Cross Platform Messaging Apps for 2026 Capgo blog illustration
+keywords: >-
+  cross platform messaging, messaging sdk, team chat apps, enterprise messaging,
+  chat api
+tag: 'Development, Mobile'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/cross-platform-mobile-app-development-guide-2024.md
+++ b/apps/web/src/content/blog/en/cross-platform-mobile-app-development-guide-2024.md
@@ -10,9 +10,13 @@ author_url: 'https://x.com/martindonadieu'
 created_at: 2024-06-15T00:00:00.000Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /cross-platform-app-dev-2024.webp
-head_image_alt: "The Ultimate Guide to Cross-Platform Mobile App Development in 2024 Capgo blog illustration"
-keywords: cross-platform, mobile app development, live updates, OTA updates, continuous integration, mobile app updates
-tag: cross-platform
+head_image_alt: >-
+  The Ultimate Guide to Cross-Platform Mobile App Development in 2024 Capgo blog
+  illustration
+keywords: >-
+  cross-platform, mobile app development, live updates, OTA updates, continuous
+  integration, mobile app updates
+tag: Mobile
 published: true
 locale: en
 next_blog: top-cross-platform-frameworks-compared-2024

--- a/apps/web/src/content/blog/en/developer-experience-tools.md
+++ b/apps/web/src/content/blog/en/developer-experience-tools.md
@@ -1,16 +1,20 @@
 ---
 slug: developer-experience-tools
 title: 10 Top Developer Experience Tools for 2026
-description: 'Explore the top 10 developer experience tools for 2026. A curated list for Capacitor & Electron teams covering CI/CD, live updates, and observability.'
+description: >-
+  Explore the top 10 developer experience tools for 2026. A curated list for
+  Capacitor & Electron teams covering CI/CD, live updates, and observability.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-16T07:02:18.525Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/developer-experience-tools.webp
-head_image_alt: "10 Top Developer Experience Tools for 2026 Capgo blog illustration"
-keywords: 'developer experience tools, capacitorjs, electronjs, mobile ci/cd, live updates'
-tag: 'developer experience tools, capacitorjs, electronjs, mobile ci/cd, live updates'
+head_image_alt: 10 Top Developer Experience Tools for 2026 Capgo blog illustration
+keywords: >-
+  developer experience tools, capacitorjs, electronjs, mobile ci/cd, live
+  updates
+tag: 'Mobile, Updates, CI/CD'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/expo-development-client.md
+++ b/apps/web/src/content/blog/en/expo-development-client.md
@@ -1,16 +1,20 @@
 ---
 slug: expo-development-client
 title: Your Guide to the Expo Development Client
-description: 'Create, build, and use the Expo development client with this complete guide. Learn EAS builds, debugging, CI/CD integration, and fixes for common issues.'
+description: >-
+  Create, build, and use the Expo development client with this complete guide.
+  Learn EAS builds, debugging, CI/CD integration, and fixes for common issues.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-03T07:30:28.903Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/expo-development-client.webp
-head_image_alt: "Your Guide to the Expo Development Client Capgo blog illustration"
-keywords: 'expo development client, expo dev client, react native, eas build, mobile development'
-tag: 'expo development client, expo dev client, react native, eas build, mobile development'
+head_image_alt: Your Guide to the Expo Development Client Capgo blog illustration
+keywords: >-
+  expo development client, expo dev client, react native, eas build, mobile
+  development
+tag: 'Mobile, Guides'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/how-hard-is-it-to-create-an-app.md
+++ b/apps/web/src/content/blog/en/how-hard-is-it-to-create-an-app.md
@@ -1,16 +1,20 @@
 ---
 slug: how-hard-is-it-to-create-an-app
 title: 'How Hard Is It to Create an App: 2026 Reality Check'
-description: 'Wondering how hard is it to create an app? Get a realistic breakdown of costs, timelines, and skills needed, from simple concepts to complex platforms.'
+description: >-
+  Wondering how hard is it to create an app? Get a realistic breakdown of costs,
+  timelines, and skills needed, from simple concepts to complex platforms.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-10T08:48:45.910Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/how-hard-is-it-to-create-an-app.webp
-head_image_alt: "'How Hard Is It to Create an App: 2026 Reality Check' Capgo blog illustration"
-keywords: 'how hard is it to create an app, app development cost, app development timeline, mobile app development, capacitorjs'
-tag: 'how hard is it to create an app, app development cost, app development timeline, mobile app development, capacitorjs'
+head_image_alt: '''How Hard Is It to Create an App: 2026 Reality Check'' Capgo blog illustration'
+keywords: >-
+  how hard is it to create an app, app development cost, app development
+  timeline, mobile app development, capacitorjs
+tag: 'Mobile, Capacitor'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/how-to-change-the-app-icon-on-iphone.md
+++ b/apps/web/src/content/blog/en/how-to-change-the-app-icon-on-iphone.md
@@ -1,16 +1,22 @@
 ---
 slug: how-to-change-the-app-icon-on-iphone
 title: 'How to Change the App Icon on iPhone: Customize Your Look'
-description: 'Master how to change the app icon on iPhone in 2026. This guide covers user methods (Shortcuts, iOS 18) & developer insights for a custom look.'
+description: >-
+  Master how to change the app icon on iPhone in 2026. This guide covers user
+  methods (Shortcuts, iOS 18) & developer insights for a custom look.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-31T07:30:18.219Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/how-to-change-the-app-icon-on-iphone.webp
-head_image_alt: "'How to Change the App Icon on iPhone: Customize Your Look' Capgo blog illustration"
-keywords: 'how to change app icon on iphone, iphone app icons, capacitor alternate icons, ios developer, ios 18 customization'
-tag: 'how to change app icon on iphone, iphone app icons, capacitor alternate icons, ios developer, ios 18 customization'
+head_image_alt: >-
+  'How to Change the App Icon on iPhone: Customize Your Look' Capgo blog
+  illustration
+keywords: >-
+  how to change app icon on iphone, iphone app icons, capacitor alternate icons,
+  ios developer, ios 18 customization
+tag: 'Mobile, Tutorial, Capacitor'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/how-to-implement-feature-flags.md
+++ b/apps/web/src/content/blog/en/how-to-implement-feature-flags.md
@@ -1,16 +1,20 @@
 ---
 slug: how-to-implement-feature-flags
 title: 'How to Implement Feature Flags: Dev Workflow in 2026'
-description: 'Learn how to implement feature flags in your dev workflow. Get a 2026 guide on architecture, targeting, rollouts, & CI/CD for JS, Capacitor, & Electron apps.'
+description: >-
+  Learn how to implement feature flags in your dev workflow. Get a 2026 guide on
+  architecture, targeting, rollouts, & CI/CD for JS, Capacitor, & Electron apps.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-13T10:09:53.896Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/how-to-implement-feature-flags.webp
-head_image_alt: "'How to Implement Feature Flags: Dev Workflow in 2026' Capgo blog illustration"
-keywords: 'how to implement feature flags, feature toggles, capacitorjs, ci/cd, live updates'
-tag: 'how to implement feature flags, feature toggles, capacitorjs, ci/cd, live updates'
+head_image_alt: '''How to Implement Feature Flags: Dev Workflow in 2026'' Capgo blog illustration'
+keywords: >-
+  how to implement feature flags, feature toggles, capacitorjs, ci/cd, live
+  updates
+tag: 'Mobile, Updates, Tutorial'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/how-to-send-specific-version-to-users.md
+++ b/apps/web/src/content/blog/en/how-to-send-specific-version-to-users.md
@@ -10,9 +10,11 @@ author_url: 'https://x.com/martindonadieu'
 created_at: 2022-06-17T00:00:00.000Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /capgo_select_update.webp
-head_image_alt: "How to send specific update to one user or a group Capgo blog illustration"
-keywords: mobile app development, live updates, OTA updates, continuous integration, mobile app updates
-tag: alternatives
+head_image_alt: How to send specific update to one user or a group Capgo blog illustration
+keywords: >-
+  mobile app development, live updates, OTA updates, continuous integration,
+  mobile app updates
+tag: Alternatives
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/ionic-action-sheet.md
+++ b/apps/web/src/content/blog/en/ionic-action-sheet.md
@@ -1,16 +1,18 @@
 ---
 slug: ionic-action-sheet
 title: 'Ionic Action Sheet: A Complete Guide for 2026'
-description: 'Learn to implement, style, and troubleshoot the Ionic Action Sheet in Angular, React, & Vue. A complete guide with code examples and advanced tips for 2026.'
+description: >-
+  Learn to implement, style, and troubleshoot the Ionic Action Sheet in Angular,
+  React, & Vue. A complete guide with code examples and advanced tips for 2026.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-17T06:51:40.561Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/ionic-action-sheet.webp
-head_image_alt: "'Ionic Action Sheet: A Complete Guide for 2026' Capgo blog illustration"
+head_image_alt: '''Ionic Action Sheet: A Complete Guide for 2026'' Capgo blog illustration'
 keywords: 'ionic action sheet, ionic components, capacitorjs, ionic angular, ionic react'
-tag: 'ionic action sheet, ionic components, capacitorjs, ionic angular, ionic react'
+tag: 'Mobile, Capacitor, Guides'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/monolithic-vs-microservice-architecture.md
+++ b/apps/web/src/content/blog/en/monolithic-vs-microservice-architecture.md
@@ -1,16 +1,20 @@
 ---
 slug: monolithic-vs-microservice-architecture
 title: 'Monolithic vs Microservice Architecture: 2026 Guide'
-description: Decide between monolithic vs microservice architecture with our 2026 decision framework for Capacitor and enterprise mobile app development teams.
+description: >-
+  Decide between monolithic vs microservice architecture with our 2026 decision
+  framework for Capacitor and enterprise mobile app development teams.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-13T06:53:18.319Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/monolithic-vs-microservice-architecture.webp
-head_image_alt: "'Monolithic vs Microservice Architecture: 2026 Guide' Capgo blog illustration"
-keywords: 'monolithic vs microservice, software architecture, capacitor, mobile development, backend development'
-tag: 'monolithic vs microservice, software architecture, capacitor, mobile development, backend development'
+head_image_alt: '''Monolithic vs Microservice Architecture: 2026 Guide'' Capgo blog illustration'
+keywords: >-
+  monolithic vs microservice, software architecture, capacitor, mobile
+  development, backend development
+tag: 'Mobile, Technology, Alternatives'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/native-applications-vs-web-applications.md
+++ b/apps/web/src/content/blog/en/native-applications-vs-web-applications.md
@@ -1,16 +1,20 @@
 ---
 slug: native-applications-vs-web-applications
 title: 'Native Applications vs Web Applications: 2026 Guide'
-description: 'Native applications vs web applications - Deciding between native vs web applications? This 2026 guide compares performance, cost, security, and update'
+description: >-
+  Native applications vs web applications - Deciding between native vs web
+  applications? This 2026 guide compares performance, cost, security, and update
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-09T08:28:06.638Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/native-applications-vs-web-applications.webp
-head_image_alt: "'Native Applications vs Web Applications: 2026 Guide' Capgo blog illustration"
-keywords: 'native vs web apps, mobile app development, capacitorjs, cross-platform apps, application architecture'
-tag: 'native vs web apps, mobile app development, capacitorjs, cross-platform apps, application architecture'
+head_image_alt: '''Native Applications vs Web Applications: 2026 Guide'' Capgo blog illustration'
+keywords: >-
+  native vs web apps, mobile app development, capacitorjs, cross-platform apps,
+  application architecture
+tag: 'Mobile, Technology, Alternatives'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/open-source-advantages.md
+++ b/apps/web/src/content/blog/en/open-source-advantages.md
@@ -1,16 +1,21 @@
 ---
 slug: open-source-advantages
 title: Open Source Advantages for Modern Software Teams
-description: 'Explore the key open source advantages for enterprises. Our guide covers technical flexibility, TCO, security, and how to use open source in production.'
+description: >-
+  Explore the key open source advantages for enterprises. Our guide covers
+  technical flexibility, TCO, security, and how to use open source in
+  production.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-07T07:24:09.210Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/open-source-advantages.webp
-head_image_alt: "Open Source Advantages for Modern Software Teams Capgo blog illustration"
-keywords: 'open source advantages, open source software, software development, enterprise software, capacitorjs'
-tag: 'open source advantages, open source software, software development, enterprise software, capacitorjs'
+head_image_alt: Open Source Advantages for Modern Software Teams Capgo blog illustration
+keywords: >-
+  open source advantages, open source software, software development, enterprise
+  software, capacitorjs
+tag: 'Mobile, Capacitor, Open Source'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/privacy-policy-for-android-apps.md
+++ b/apps/web/src/content/blog/en/privacy-policy-for-android-apps.md
@@ -1,16 +1,20 @@
 ---
 slug: privacy-policy-for-android-apps
 title: 'Privacy Policy for Android Apps: A 2026 Guide'
-description: 'Create a compliant privacy policy for Android apps. Our guide covers Google Play, GDPR, CCPA, live updates, and provides sample clauses for developers.'
+description: >-
+  Create a compliant privacy policy for Android apps. Our guide covers Google
+  Play, GDPR, CCPA, live updates, and provides sample clauses for developers.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-15T07:07:10.732Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/privacy-policy-for-android-apps.webp
-head_image_alt: "'Privacy Policy for Android Apps: A 2026 Guide' Capgo blog illustration"
-keywords: 'privacy policy for android apps, android development, google play policy, gdpr compliance, app privacy'
-tag: 'privacy policy for android apps, android development, google play policy, gdpr compliance, app privacy'
+head_image_alt: '''Privacy Policy for Android Apps: A 2026 Guide'' Capgo blog illustration'
+keywords: >-
+  privacy policy for android apps, android development, google play policy, gdpr
+  compliance, app privacy
+tag: 'Mobile, Security, Android'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/rapid-app-dev.md
+++ b/apps/web/src/content/blog/en/rapid-app-dev.md
@@ -1,16 +1,18 @@
 ---
 slug: rapid-app-dev
 title: 'Master Rapid App Dev: Build Apps Faster'
-description: 'Master rapid app dev. Learn principles, methods, & tools to build & update apps faster, without sacrificing quality or control. Get our guide!'
+description: >-
+  Master rapid app dev. Learn principles, methods, & tools to build & update
+  apps faster, without sacrificing quality or control. Get our guide!
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-23T07:08:33.313Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/rapid-app-dev.webp
-head_image_alt: "'Master Rapid App Dev: Build Apps Faster' Capgo blog illustration"
+head_image_alt: '''Master Rapid App Dev: Build Apps Faster'' Capgo blog illustration'
 keywords: 'rapid app dev, agile development, low-code, application development, ci/cd'
-tag: 'rapid app dev, agile development, low-code, application development, ci/cd'
+tag: 'Mobile, CI/CD'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/react-feature-flags.md
+++ b/apps/web/src/content/blog/en/react-feature-flags.md
@@ -1,16 +1,19 @@
 ---
 slug: react-feature-flags
 title: 'React Feature Flags: A Complete Implementation Guide'
-description: 'Learn how to implement React feature flags with our complete guide. Covers architecture patterns, rollout strategies, CI/CD, and best practices for modern apps.'
+description: >-
+  Learn how to implement React feature flags with our complete guide. Covers
+  architecture patterns, rollout strategies, CI/CD, and best practices for
+  modern apps.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-19T06:50:10.784Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/react-feature-flags.webp
-head_image_alt: "'React Feature Flags: A Complete Implementation Guide' Capgo blog illustration"
+head_image_alt: '''React Feature Flags: A Complete Implementation Guide'' Capgo blog illustration'
 keywords: 'react feature flags, reactjs, feature management, devops, capacitorjs'
-tag: 'react feature flags, reactjs, feature management, devops, capacitorjs'
+tag: 'Mobile, CI/CD, Capacitor'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/secure-database-storage.md
+++ b/apps/web/src/content/blog/en/secure-database-storage.md
@@ -1,16 +1,23 @@
 ---
 slug: secure-database-storage
 title: 'Secure Database Storage: A Complete Guide for Developers'
-description: 'A complete guide to secure database storage. Learn best practices for encryption, access control, key management, and compliance to protect your data in 2026.'
+description: >-
+  A complete guide to secure database storage. Learn best practices for
+  encryption, access control, key management, and compliance to protect your
+  data in 2026.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-25T07:12:53.642Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/secure-database-storage.webp
-head_image_alt: "'Secure Database Storage: A Complete Guide for Developers' Capgo blog illustration"
-keywords: 'secure database storage, data encryption, database security, access control, data compliance'
-tag: 'secure database storage, data encryption, database security, access control, data compliance'
+head_image_alt: >-
+  'Secure Database Storage: A Complete Guide for Developers' Capgo blog
+  illustration
+keywords: >-
+  secure database storage, data encryption, database security, access control,
+  data compliance
+tag: 'Mobile, Security, Guides'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/splash-screen-in-react-native.md
+++ b/apps/web/src/content/blog/en/splash-screen-in-react-native.md
@@ -1,16 +1,21 @@
 ---
 slug: splash-screen-in-react-native
 title: 'Splash Screen in React Native: A Complete Guide for 2026'
-description: 'Learn how to implement a professional splash screen in React Native for Expo & CLI. This guide covers asset prep, native setup, performance, and common fixes.'
+description: >-
+  Learn how to implement a professional splash screen in React Native for Expo &
+  CLI. This guide covers asset prep, native setup, performance, and common
+  fixes.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-24T07:15:52.262Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/splash-screen-in-react-native.webp
-head_image_alt: "'Splash Screen in React Native: A Complete Guide for 2026' Capgo blog illustration"
+head_image_alt: >-
+  'Splash Screen in React Native: A Complete Guide for 2026' Capgo blog
+  illustration
 keywords: 'react native, splash screen, expo, react native cli, mobile development'
-tag: 'react native, splash screen, expo, react native cli, mobile development'
+tag: 'Mobile, Guides'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/test-flight-android.md
+++ b/apps/web/src/content/blog/en/test-flight-android.md
@@ -1,16 +1,20 @@
 ---
 slug: test-flight-android
 title: 'Test Flight Android: Alternatives for Beta Testing'
-description: 'Why doesn''t test flight android exist? Discover top 2026 alternatives like Google Play Tracks, Firebase & Capgo for seamless beta testing.'
+description: >-
+  Why doesn't test flight android exist? Discover top 2026 alternatives like
+  Google Play Tracks, Firebase & Capgo for seamless beta testing.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-30T06:58:17.170Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/test-flight-android.webp
-head_image_alt: "'Test Flight Android: Alternatives for Beta Testing' Capgo blog illustration"
-keywords: 'test flight android, android beta testing, firebase app distribution, google play console, capacitorjs'
-tag: 'test flight android, android beta testing, firebase app distribution, google play console, capacitorjs'
+head_image_alt: '''Test Flight Android: Alternatives for Beta Testing'' Capgo blog illustration'
+keywords: >-
+  test flight android, android beta testing, firebase app distribution, google
+  play console, capacitorjs
+tag: 'Mobile, Alternatives, Capacitor'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/types-of-builds.md
+++ b/apps/web/src/content/blog/en/types-of-builds.md
@@ -1,16 +1,19 @@
 ---
 slug: types-of-builds
 title: 'Types of Builds Explained: From Local to Production'
-description: 'Confused by all the types of builds? This guide explains everything from local, CI, debug, and release builds to signing, distribution, and rollback strategies.'
+description: >-
+  Confused by all the types of builds? This guide explains everything from
+  local, CI, debug, and release builds to signing, distribution, and rollback
+  strategies.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-15T08:08:25.848Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/types-of-builds.webp
-head_image_alt: "'Types of Builds Explained: From Local to Production' Capgo blog illustration"
+head_image_alt: '''Types of Builds Explained: From Local to Production'' Capgo blog illustration'
 keywords: 'types of builds, software builds, ci/cd, app distribution, capacitorjs'
-tag: 'types of builds, software builds, ci/cd, app distribution, capacitorjs'
+tag: 'Mobile, CI/CD, Capacitor'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/unit-testing-react.md
+++ b/apps/web/src/content/blog/en/unit-testing-react.md
@@ -1,16 +1,20 @@
 ---
 slug: unit-testing-react
 title: 'Unit Testing React: A Practical End-to-End Guide'
-description: 'Master unit testing React from setup to CI/CD. This guide covers Jest, RTL, hooks, async code, mocking, and best practices for robust cross-platform apps.'
+description: >-
+  Master unit testing React from setup to CI/CD. This guide covers Jest, RTL,
+  hooks, async code, mocking, and best practices for robust cross-platform apps.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-08T08:14:55.865Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/unit-testing-react.webp
-head_image_alt: "'Unit Testing React: A Practical End-to-End Guide' Capgo blog illustration"
-keywords: 'unit testing react, react testing library, jest, capacitor testing, ci/cd pipeline'
-tag: 'unit testing react, react testing library, jest, capacitor testing, ci/cd pipeline'
+head_image_alt: '''Unit Testing React: A Practical End-to-End Guide'' Capgo blog illustration'
+keywords: >-
+  unit testing react, react testing library, jest, capacitor testing, ci/cd
+  pipeline
+tag: 'Mobile, Tutorial, CI/CD'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/unit-tests-javascript.md
+++ b/apps/web/src/content/blog/en/unit-tests-javascript.md
@@ -1,16 +1,18 @@
 ---
 slug: unit-tests-javascript
 title: 'Unit Tests JavaScript: Comprehensive 2026 Guide'
-description: 'Master unit tests javascript with our 2026 guide. Covers Jest, Mocha, setup, mocking, CI, and tips for Capacitor & Electron apps.'
+description: >-
+  Master unit tests javascript with our 2026 guide. Covers Jest, Mocha, setup,
+  mocking, CI, and tips for Capacitor & Electron apps.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-29T07:21:33.612Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/unit-tests-javascript.webp
-head_image_alt: "'Unit Tests JavaScript: Comprehensive 2026 Guide' Capgo blog illustration"
+head_image_alt: '''Unit Tests JavaScript: Comprehensive 2026 Guide'' Capgo blog illustration'
 keywords: 'unit tests javascript, javascript testing, jest, capacitorjs, electronjs'
-tag: 'unit tests javascript, javascript testing, jest, capacitorjs, electronjs'
+tag: 'Mobile, Tutorial, Capacitor'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/user-adoption-metrics.md
+++ b/apps/web/src/content/blog/en/user-adoption-metrics.md
@@ -1,16 +1,20 @@
 ---
 slug: user-adoption-metrics
 title: 'User Adoption Metrics: The Definitive Guide for 2026'
-description: 'Your complete guide to user adoption metrics. Learn to calculate and interpret key metrics like DAU/MAU, retention, and churn to drive real product growth.'
+description: >-
+  Your complete guide to user adoption metrics. Learn to calculate and interpret
+  key metrics like DAU/MAU, retention, and churn to drive real product growth.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-18T09:04:54.462Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/user-adoption-metrics.webp
-head_image_alt: "'User Adoption Metrics: The Definitive Guide for 2026' Capgo blog illustration"
-keywords: 'user adoption metrics, product analytics, saas metrics, retention rate, mobile app analytics'
-tag: 'user adoption metrics, product analytics, saas metrics, retention rate, mobile app analytics'
+head_image_alt: '''User Adoption Metrics: The Definitive Guide for 2026'' Capgo blog illustration'
+keywords: >-
+  user adoption metrics, product analytics, saas metrics, retention rate, mobile
+  app analytics
+tag: 'Mobile, Product, Guides'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/web-hook-example.md
+++ b/apps/web/src/content/blog/en/web-hook-example.md
@@ -1,16 +1,23 @@
 ---
 slug: web-hook-example
 title: 'A Practical Web Hook Example: Secure Implementation Guide'
-description: 'Find a complete web hook example with code for Node.js, Python, and Go. Learn to securely verify signatures, prevent replay attacks, and debug your endpoints.'
+description: >-
+  Find a complete web hook example with code for Node.js, Python, and Go. Learn
+  to securely verify signatures, prevent replay attacks, and debug your
+  endpoints.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-01T07:11:14.581Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/web-hook-example.webp
-head_image_alt: "'A Practical Web Hook Example: Secure Implementation Guide' Capgo blog illustration"
-keywords: 'web hook example, webhook security, node.js webhook, python webhook, webhook implementation'
-tag: 'web hook example, webhook security, node.js webhook, python webhook, webhook implementation'
+head_image_alt: >-
+  'A Practical Web Hook Example: Secure Implementation Guide' Capgo blog
+  illustration
+keywords: >-
+  web hook example, webhook security, node.js webhook, python webhook, webhook
+  implementation
+tag: 'Mobile, Security, Guides'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/what-is-a-portrait-orientation.md
+++ b/apps/web/src/content/blog/en/what-is-a-portrait-orientation.md
@@ -1,16 +1,20 @@
 ---
 slug: what-is-a-portrait-orientation
 title: 'What Is a Portrait Orientation: Guide for 2026'
-description: 'Discover what is a portrait orientation, its differences from landscape, and importance for photography, print & UI in 2026. Get code examples and UX tips.'
+description: >-
+  Discover what is a portrait orientation, its differences from landscape, and
+  importance for photography, print & UI in 2026. Get code examples and UX tips.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-14T09:50:54.053Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/what-is-a-portrait-orientation.webp
-head_image_alt: "'What Is a Portrait Orientation: Guide for 2026' Capgo blog illustration"
-keywords: 'portrait orientation, responsive design, mobile ui, capacitorjs, css media queries'
-tag: 'portrait orientation, responsive design, mobile ui, capacitorjs, css media queries'
+head_image_alt: '''What Is a Portrait Orientation: Guide for 2026'' Capgo blog illustration'
+keywords: >-
+  portrait orientation, responsive design, mobile ui, capacitorjs, css media
+  queries
+tag: 'Mobile, Capacitor, Guides'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/what-is-automated-testing.md
+++ b/apps/web/src/content/blog/en/what-is-automated-testing.md
@@ -1,16 +1,21 @@
 ---
 slug: what-is-automated-testing
 title: 'What Is Automated Testing: Automated Testing Explained'
-description: 'Learn what is automated testing, from the testing pyramid to CI/CD. A practical guide for teams on what, when, and how to automate effectively in 2026.'
+description: >-
+  Learn what is automated testing, from the testing pyramid to CI/CD. A
+  practical guide for teams on what, when, and how to automate effectively in
+  2026.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-22T07:24:57.104Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/what-is-automated-testing.webp
-head_image_alt: "'What Is Automated Testing: Automated Testing Explained' Capgo blog illustration"
+head_image_alt: >-
+  'What Is Automated Testing: Automated Testing Explained' Capgo blog
+  illustration
 keywords: 'automated testing, capacitorjs, electron js, mobile testing, ci/cd'
-tag: 'automated testing, capacitorjs, electron js, mobile testing, ci/cd'
+tag: 'Mobile, CI/CD, Capacitor'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/what-is-continuous-deployment.md
+++ b/apps/web/src/content/blog/en/what-is-continuous-deployment.md
@@ -1,16 +1,18 @@
 ---
 slug: what-is-continuous-deployment
 title: What Is Continuous Deployment? Your 2026 Guide
-description: 'Understand what is continuous deployment in 2026. Explore differences from CD, pipeline components, deployment patterns, & implementation for modern apps.'
+description: >-
+  Understand what is continuous deployment in 2026. Explore differences from CD,
+  pipeline components, deployment patterns, & implementation for modern apps.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-02T07:17:10.119Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/what-is-continuous-deployment.webp
-head_image_alt: "What Is Continuous Deployment? Your 2026 Guide Capgo blog illustration"
+head_image_alt: What Is Continuous Deployment? Your 2026 Guide Capgo blog illustration
 keywords: 'what is continuous deployment, ci/cd, capacitorjs, electronjs, devops'
-tag: 'what is continuous deployment, ci/cd, capacitorjs, electronjs, devops'
+tag: 'Mobile, CI/CD, Capacitor'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/what-is-edge-network.md
+++ b/apps/web/src/content/blog/en/what-is-edge-network.md
@@ -1,16 +1,19 @@
 ---
 slug: what-is-edge-network
 title: 'What Is Edge Network: A 2026 Guide to Faster Apps'
-description: 'Discover what is edge network and how it boosts application speed & reliability. Learn its benefits, like low latency, & differences from CDNs in 2026.'
+description: >-
+  Discover what is edge network and how it boosts application speed &
+  reliability. Learn its benefits, like low latency, & differences from CDNs in
+  2026.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-16T08:21:18.437Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/what-is-edge-network.webp
-head_image_alt: "'What Is Edge Network: A 2026 Guide to Faster Apps' Capgo blog illustration"
+head_image_alt: '''What Is Edge Network: A 2026 Guide to Faster Apps'' Capgo blog illustration'
 keywords: 'what is edge network, edge network, edge computing, cdn vs edge, low latency'
-tag: 'what is edge network, edge network, edge computing, cdn vs edge, low latency'
+tag: 'Mobile, Technology, Alternatives'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/what-is-network-latency.md
+++ b/apps/web/src/content/blog/en/what-is-network-latency.md
@@ -1,16 +1,20 @@
 ---
 slug: what-is-network-latency
 title: 'What Is Network Latency: A Developer''s 2026 Guide'
-description: 'Understand what is network latency, how it affects application speed in 2026, and the best technical strategies to measure and reduce it for your users.'
+description: >-
+  Understand what is network latency, how it affects application speed in 2026,
+  and the best technical strategies to measure and reduce it for your users.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-14T06:50:28.488Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/what-is-network-latency.webp
-head_image_alt: "'What Is Network Latency: A Developer''s 2026 Guide' Capgo blog illustration"
-keywords: 'what is network latency, network performance, mobile app speed, live updates, capacitorjs'
-tag: 'what is network latency, network performance, mobile app speed, live updates, capacitorjs'
+head_image_alt: '''What Is Network Latency: A Developer''''s 2026 Guide'' Capgo blog illustration'
+keywords: >-
+  what is network latency, network performance, mobile app speed, live updates,
+  capacitorjs
+tag: 'Mobile, Updates, Best Practices'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/what-is-soc-2-certification.md
+++ b/apps/web/src/content/blog/en/what-is-soc-2-certification.md
@@ -1,16 +1,20 @@
 ---
 slug: what-is-soc-2-certification
 title: 'What Is SOC 2 Certification: Your 2026 Guide'
-description: 'Discover what is soc 2 certification, exploring Trust Services Criteria, Type I vs. Type II reports, and the 2026 process for SaaS & mobile app teams.'
+description: >-
+  Discover what is soc 2 certification, exploring Trust Services Criteria, Type
+  I vs. Type II reports, and the 2026 process for SaaS & mobile app teams.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-05-26T07:20:25.523Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/what-is-soc-2-certification.webp
-head_image_alt: "'What Is SOC 2 Certification: Your 2026 Guide' Capgo blog illustration"
-keywords: 'soc 2 certification, soc 2 compliance, security audits, saas security, data privacy'
-tag: 'soc 2 certification, soc 2 compliance, security audits, saas security, data privacy'
+head_image_alt: '''What Is SOC 2 Certification: Your 2026 Guide'' Capgo blog illustration'
+keywords: >-
+  soc 2 certification, soc 2 compliance, security audits, saas security, data
+  privacy
+tag: 'Mobile, Security, Product'
 published: true
 locale: en
 next_blog: ''

--- a/apps/web/src/content/blog/en/yarn-clear-cache.md
+++ b/apps/web/src/content/blog/en/yarn-clear-cache.md
@@ -1,16 +1,20 @@
 ---
 slug: yarn-clear-cache
 title: 'How to Yarn Clear Cache: A Guide for V1, Berry, and CI/CD'
-description: 'Learn how to yarn clear cache for v1 and Berry (v2+). Fix broken builds with step-by-step commands, CI/CD best practices, and troubleshooting tips.'
+description: >-
+  Learn how to yarn clear cache for v1 and Berry (v2+). Fix broken builds with
+  step-by-step commands, CI/CD best practices, and troubleshooting tips.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://github.com/riderx'
 created_at: 2026-06-17T08:37:56.714Z
 updated_at: 2026-06-18T14:21:30.000Z
 head_image: /blog-images/yarn-clear-cache.webp
-head_image_alt: "'How to Yarn Clear Cache: A Guide for V1, Berry, and CI/CD' Capgo blog illustration"
+head_image_alt: >-
+  'How to Yarn Clear Cache: A Guide for V1, Berry, and CI/CD' Capgo blog
+  illustration
 keywords: 'yarn clear cache, yarn cache, yarn berry, node.js, ci/cd'
-tag: 'yarn clear cache, yarn cache, yarn berry, node.js, ci/cd'
+tag: 'Mobile, Tutorial, CI/CD'
 published: true
 locale: en
 next_blog: ''

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "blogs:sync_seobot": "bun run scripts/blogs/sync_seobot.js",
     "clean:unused": "bun run scripts/clean_not_used.tsx",
     "generate:plugins-readme": "bun run scripts/generate-plugins-readme.ts",
-    "generate:blog-images": "bun run scripts/generate-blog-images.ts"
+    "generate:blog-images": "bun run scripts/generate-blog-images.ts",
+    "blogs:normalize_tags": "bun run scripts/blogs/normalize_tags.ts"
   },
   "dependencies": {
     "@astrojs/cloudflare": "13.7.0",

--- a/scripts/blogs/import_outrank.ts
+++ b/scripts/blogs/import_outrank.ts
@@ -2,6 +2,7 @@ import matter from 'gray-matter'
 import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join, resolve, sep } from 'node:path'
 import { commonReplacements } from '../commonReplacements'
+import { normalizeBlogTags } from '../../apps/web/src/constants/blogTags'
 
 const DEFAULT_BLOG_DIR = 'apps/web/src/content/blog/en'
 const DEFAULT_AUTHOR = 'Martin Donadieu'
@@ -168,10 +169,10 @@ function writeArticle(article: OutrankArticle, payloadTimestamp: Date, blogDirec
   const markdown = normalizeMarkdown(article.content_markdown, title)
   const createdAt = toDate(article.created_at, toDate(existingFrontmatter.created_at as Date | string | undefined, payloadTimestamp))
   const updatedAt = new Date(payloadTimestamp)
-  const tag = tags.length > 0 ? tags.join(', ') : 'Development'
-  const headImage = article.image_url ? normalizeHeadImage(article.image_url) : frontmatterString(existingFrontmatter, 'head_image') || DEFAULT_HEAD_IMAGE
   const keywords = Array.isArray(article.tags) ? tags.join(', ') : existingKeywords || tags.join(', ')
-
+  const tag = normalizeBlogTags(tags, title, keywords || article.meta_description?.trim() || '')
+  const headImage = article.image_url ? normalizeHeadImage(article.image_url) : frontmatterString(existingFrontmatter, 'head_image') || DEFAULT_HEAD_IMAGE
+  
   const frontmatter = {
     slug,
     title,

--- a/scripts/blogs/normalize_tags.ts
+++ b/scripts/blogs/normalize_tags.ts
@@ -1,0 +1,34 @@
+import matter from 'gray-matter'
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { normalizeBlogTags } from '../../apps/web/src/constants/blogTags'
+
+const blogDirectory = process.env.OUTRANK_BLOG_DIR || 'apps/web/src/content/blog/en'
+
+function main(): void {
+  const files = readdirSync(blogDirectory).filter((file) => file.endsWith('.md'))
+  let changed = 0
+
+  for (const file of files) {
+    const filePath = join(blogDirectory, file)
+    const content = readFileSync(filePath, 'utf8')
+    const { data, content: body } = matter(content)
+    const rawTags = String(data.tag ?? '')
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean)
+    const title = typeof data.title === 'string' ? data.title : ''
+    const keywords = typeof data.keywords === 'string' ? data.keywords : ''
+    const tag = normalizeBlogTags(rawTags, title, keywords)
+
+    if (tag === data.tag) continue
+
+    writeFileSync(filePath, matter.stringify(body, { ...data, tag }), 'utf8')
+    console.log(`${file}: ${data.tag} -> ${tag}`)
+    changed++
+  }
+
+  console.log(`Updated ${changed} file(s).`)
+}
+
+main()


### PR DESCRIPTION
## Summary
- Add canonical blog tag taxonomy (`blogTags.ts`) with casing aliases and title/keyword inference for SEO-style tags
- Normalize tags at content load time and in the Outrank import pipeline so future posts reuse existing categories
- Remap 42 blog posts that used long-tail SEO keywords as sidebar categories (191 tags → 32)

## Test plan
- [x] `bun run blogs:normalize_tags` is idempotent (0 further changes)
- [x] `cd apps/web && bun run check` passes
- [ ] Verify https://capgo.app/blog/ sidebar shows ~32 clean categories after deploy (no casing duplicates like `Development` / `development` or `CI/CD` / `ci/cd`)
- [ ] Spot-check a few remapped posts (e.g. Outrank imports) still appear under sensible categories


Made with [Cursor](https://cursor.com)