### PR TITLE
Add Appflow app-password vs Capgo .p8 credentials comparison

### DIFF
--- a/apps/shared/copy/messages.ts
+++ b/apps/shared/copy/messages.ts
@@ -138,6 +138,21 @@ const messages = {
   appflow_credit_p2:
     'Capgo was built to make that workflow independent: open source, affordable, focused on live updates, and flexible enough for teams that need more than the basic Appflow path.',
   appflow_credit_p3: 'So yes, respect to Ionic. But Capgo is not a clone of what is shutting down. It is the mature independent path that others now copy.',
+  appflow_credentials_appflow_label: 'Appflow approach:',
+  appflow_credentials_appflow_li1: 'Requires your Apple ID and an app-specific password stored in Appflow',
+  appflow_credentials_appflow_li2: 'Breaks when someone resets their Apple ID password, rotates 2FA, or revokes the app password',
+  appflow_credentials_appflow_li3: 'Gives a third-party service broad account access instead of a scoped API key with explicit roles',
+  appflow_credentials_appflow_li4: 'A frequent support issue: "Invalid application specific password provided"',
+  appflow_credentials_capgo_label: 'Capgo approach:',
+  appflow_credentials_capgo_li1: 'Native builds use an App Store Connect API key (<code class="text-blue-300">.p8</code>) with Key ID and Issuer ID',
+  appflow_credentials_capgo_li2: 'Keys are scoped in App Store Connect (App Manager, Developer, etc.) and revoked independently',
+  appflow_credentials_capgo_li3: 'Credentials stay on your machine by default; cloud builds stream them into an ephemeral environment and wipe them after the job',
+  appflow_credentials_capgo_li4: '<code class="text-blue-300">capgo build init</code> generates signing assets from a single .p8 file',
+  appflow_credentials_desc:
+    'To upload iOS builds to App Store Connect, Appflow asks for your Apple ID and an <strong class="text-white">app-specific password</strong>. That is the legacy Apple login flow — not the modern App Store Connect API key (<code class="text-blue-300">.p8</code>) that Apple recommends for automation.',
+  appflow_credentials_note:
+    '<a href="https://ionic.io/docs/appflow/destinations/apple" class="text-blue-300 hover:underline" target="_blank" rel="noopener noreferrer">Appflow\'s Apple destination docs</a> list an app-specific password as a required field. <a href="{url}" class="text-emerald-300 hover:underline">Capgo Builder</a> follows Apple\'s API-key model instead.',
+  appflow_credentials_title: 'App Store credentials: API keys, not app passwords',
   appflow_credit_title: "Let's give credit, then be clear about what changed",
   appflow_cta_book_migration: 'Book migration call',
   appflow_cta_questions:
@@ -167,6 +182,9 @@ const messages = {
   appflow_faq_q2: 'What about native builds?',
   appflow_faq_q3: 'Will this save money?',
   appflow_faq_q4: "How's the reliability?",
+  appflow_faq_q5: 'How do App Store credentials compare for native builds?',
+  appflow_faq_a5:
+    'Appflow stores your Apple ID and app-specific password to upload binaries. Capgo uses App Store Connect API keys (.p8): scoped, revocable, and independent of personal Apple ID password changes. For cloud builds, credentials are only used in ephemeral environments — not parked on a vendor server indefinitely.',
   appflow_faq_title: 'Common questions',
   appflow_focus_desc:
     'Appflow bundled live updates, CI/CD, and native builds. Capgo focuses on the live-update system itself: automatic setup in 5 minutes when you want the easy path, plus manual and half-manual flows when your release logic is more advanced.',

--- a/apps/web/src/pages/ionic-appflow.astro
+++ b/apps/web/src/pages/ionic-appflow.astro
@@ -18,6 +18,7 @@ const migrationGuideUrl = getRelativeLocaleUrl(locale, 'docs/upgrade/from-appflo
 const enterprisePluginsUrl = getRelativeLocaleUrl(locale, 'ionic-enterprise-plugins')
 const supportUrl = getRelativeLocaleUrl(locale, 'premium-support')
 const migrationServicesUrl = getRelativeLocaleUrl(locale, 'consulting')
+const nativeBuildUrl = getRelativeLocaleUrl(locale, 'native-build')
 ---
 
 <Layout content={content}>
@@ -93,6 +94,35 @@ const migrationServicesUrl = getRelativeLocaleUrl(locale, 'consulting')
             <p class="text-sm text-gray-400">
               {m.appflow_pricing_note({}, { locale })}
             </p>
+          </div>
+
+          <!-- App Store Credentials -->
+          <div class="rounded-lg border border-gray-700 bg-gray-800/50 p-6">
+            <h3 class="mb-3 text-xl font-semibold text-gray-100">
+              {m.appflow_credentials_title({}, { locale })}
+            </h3>
+            <p class="mb-4 text-gray-300" set:html={m.appflow_credentials_desc({}, { locale })} />
+            <div class="grid gap-6 md:grid-cols-2">
+              <div>
+                <p class="mb-2 font-medium text-rose-300">{m.appflow_credentials_appflow_label({}, { locale })}</p>
+                <ul class="ml-6 list-disc space-y-1 text-sm text-gray-400">
+                  <li>{m.appflow_credentials_appflow_li1({}, { locale })}</li>
+                  <li>{m.appflow_credentials_appflow_li2({}, { locale })}</li>
+                  <li>{m.appflow_credentials_appflow_li3({}, { locale })}</li>
+                  <li>{m.appflow_credentials_appflow_li4({}, { locale })}</li>
+                </ul>
+              </div>
+              <div>
+                <p class="mb-2 font-medium text-emerald-300">{m.appflow_credentials_capgo_label({}, { locale })}</p>
+                <ul class="ml-6 list-disc space-y-1 text-sm text-gray-400">
+                  <li set:html={m.appflow_credentials_capgo_li1({}, { locale })} />
+                  <li>{m.appflow_credentials_capgo_li2({}, { locale })}</li>
+                  <li>{m.appflow_credentials_capgo_li3({}, { locale })}</li>
+                  <li set:html={m.appflow_credentials_capgo_li4({}, { locale })} />
+                </ul>
+              </div>
+            </div>
+            <p class="mt-4 text-sm text-gray-400" set:html={m.appflow_credentials_note({ url: nativeBuildUrl }, { locale })} />
           </div>
 
           <!-- Open Source -->
@@ -353,6 +383,10 @@ const migrationServicesUrl = getRelativeLocaleUrl(locale, 'consulting')
           <div>
             <dt class="text-lg font-semibold text-white">{m.appflow_faq_q4({}, { locale })}</dt>
             <dd class="mt-2 text-gray-300" set:html={m.appflow_faq_a4({}, { locale })} />
+          </div>
+          <div>
+            <dt class="text-lg font-semibold text-white">{m.appflow_faq_q5({}, { locale })}</dt>
+            <dd class="mt-2 text-gray-300">{m.appflow_faq_a5({}, { locale })}</dd>
           </div>
         </dl>
       </div>


### PR DESCRIPTION
## Summary
- Adds an "App Store credentials: API keys, not app passwords" section to `/ionic-appflow/` comparing Appflow's Apple ID + app-specific password requirement with Capgo's App Store Connect API key (`.p8`) approach.
- Highlights why app passwords are fragile for CI/CD (password resets, 2FA changes, broad account access, common support failures).
- Adds a FAQ entry on native build credential handling and links to Appflow's Apple destination docs plus Capgo Builder.

## Test plan
- [ ] Open `/ionic-appflow/` and verify the new credentials comparison card renders after pricing
- [ ] Confirm the Appflow docs link and Capgo Builder link work
- [ ] Check the new FAQ item appears at the bottom of the FAQ section
- [ ] Run `bun run build` in `apps/web` if needed before deploy


Made with [Cursor](https://cursor.com)