### PR TITLE
docs: remove false 24h credential retention claim

### DIFF
--- a/apps/docs/src/content/docs/docs/builder/credentials.mdx
+++ b/apps/docs/src/content/docs/docs/builder/credentials.mdx
@@ -31,7 +31,6 @@ If you don't have your certificates and credentials yet, check these comprehensi
 **Your credentials are NEVER stored permanently on Capgo servers:**
 - ✅ Used ONLY during the active build process
 - ✅ Automatically deleted after build completion
-- ✅ Maximum retention: 24 hours (even if build fails)
 - ✅ Apps are sent directly to App Store/Play Store - we store NOTHING
 - ✅ Transmitted securely over HTTPS
 </Aside>


### PR DESCRIPTION
## Summary

Removes the line `✅ Maximum retention: 24 hours (even if build fails)` from the Security Guarantee aside on the Managing Credentials page (`/docs/builder/credentials/`).

This claim is factually wrong and directly contradicts the bullet above it:
- **Current (wrong):** credentials may linger for 24h even on build failure
- **Actual behavior:** credentials are deleted after build completion

Keeping it misleads users into thinking their signing keys/keystores linger on Capgo servers for up to 24 hours.

## Test plan

- [ ] `/docs/builder/credentials/` no longer shows the 24h retention bullet
- [ ] Remaining bullets in the Security Guarantee aside are still accurate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated credentials documentation regarding security guarantees and data protection. Modified the security caution section to adjust information about credential retention policies and timeframes. The updates maintain clarity on how credentials are used during active builds, deleted after build completion, and protected throughout their lifecycle with refined security messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->