### PR TITLE
docs(updater): reorganize debugging log codes into TOC sections

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/updater/debugging.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/updater/debugging.mdx
@@ -7,127 +7,692 @@ sidebar:
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-## Understanding cloud logs:
+## Understanding cloud logs
 
-If you get a cloud refusal code and need concrete remediation steps, see [Common Update Problems](/docs/plugins/updater/commonproblems/).
+If you get a cloud refusal code and need deeper remediation walkthroughs, see [Common Update Problems](/docs/plugins/updater/commonproblems/).
 
-Capgo logs can include metadata for the event. In the dashboard, use the action filter to filter by the snake_case action code listed below, and click the metadata cell to copy the full JSON payload. Metadata is especially useful for crash and WebView events because it can include context such as the error message, source URL, line and column, process state, memory pressure, or platform-specific reason. Older logs can still show the legacy camelCase aliases listed in parentheses.
+Capgo logs can include metadata for the event. In the dashboard, filter by the snake_case action code, and click the metadata cell to copy the full JSON payload. Metadata is especially useful for crash and WebView events because it can include the error message, source URL, line and column, process state, memory pressure, or platform-specific reason. Older logs can still show legacy camelCase aliases listed in parentheses.
 
-### Sent from the backend
+Each code below is a dedicated section so you can link directly from the console logs table of contents on this page.
 
-| code                                                                  | Description                                                                                                                                                                                                                                                |
-| --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **invalid_ip** (**InvalidIp**)                                        | The user is located in a Google data center and the update is less than 4 hours old. This is done to prevent Google bots' devices from counting as devices in your account.                                                                               |
-| **need_plan_upgrade** (**needPlanUpgrade**, previously **needUpgrade**) | Indicates that you have reached the limit of your plan, and the device will not receive updates until you upgrade or until the next month.                                                                                                                 |
-| **no_new_version_available** (**noNew**)                              | The device has the latest available version.                                                                                                                                                                                                               |
-| **semver_error**                                                      | The native version does not follow the expected semantic version format.                                                                                                                                                                                   |
-| **disabled_platform_ios** (**disablePlatformIos**)                    | The device is on the iOS platform, but that is disabled in the channel settings.                                                                                                                                                                           |
-| **disabled_platform_android** (**disablePlatformAndroid**)            | The device is on the Android platform, but that is disabled in the channel settings.                                                                                                                                                                       |
-| **disable_auto_update** (**disableAutoUpdate**)                       | Auto-update is disabled by compatibility policy. Metadata includes `auto_update` with a matching rule such as `major`, `minor`, `patch`, `metadata`, or `none`.                                                                                            |
-| **disable_auto_update_under_native** (**disableAutoUpdateUnderNative**) | The device has version (`1.2.3`), and the channel has an update (`1.2.2`) under the device version to send, but that is disabled in the channel settings.                                                                                                  |
-| **disable_dev_build** (**disableDevBuild**)                           | The device has a dev build, but that is disabled in the channel settings.                                                                                                                                                                                  |
-| **disable_emulator** (**disableEmulator**)                            | The device is an emulator, but that is disabled in the channel settings.                                                                                                                                                                                   |
-| **cannot_get_bundle** (**cannotGetBundle**)                           | Failed to generate a valid signed URL for the bundle download. This occurs when the bundle URL generation fails or returns an invalid URL and there is no manifest available as a fallback.                                                                |
-| **cannot_update_via_private_channel** (**cannotUpdateViaPrivateChannel**) | The device tried to self-associate with a private channel, but the channel settings do not allow device self-association (`allow_device_self_set` is false) and the channel is not public.                                                                 |
-| **misconfigured_channel** (**channelMisconfigured**)                  | The channel is configured to disable auto-update by version number (`disable_auto_update: 'version_number'`), but the bundle's `min_update_version` field is null, making it impossible to determine which devices should receive the update.              |
-| **disable_auto_update_to_metadata** (**disableAutoUpdateMetadata**)   | Auto-update is disabled by version number metadata. The channel requires the device's version to be at least `min_update_version`, but the device's current version is lower than this threshold.                                                           |
-| **disable_auto_update_to_major** (**disableAutoUpdateToMajor**)       | Channel setting `disable_auto_update: 'major'` prevents updates that would increase the major version number, such as blocking `1.x.x` from updating to `2.x.x`.                                                                                           |
-| **disable_auto_update_to_minor** (**disableAutoUpdateToMinor**)       | Channel setting `disable_auto_update: 'minor'` blocks target bundles whose major or minor differs from the device native baseline (`version_build`), such as `1.2.3 -> 1.3.0`.                                                                              |
-| **disable_auto_update_to_patch** (**disableAutoUpdateToPatch**)       | Channel setting `disable_auto_update: 'patch'` blocks any major, minor, or patch number change from `version_build`; only suffix changes are allowed while `MAJOR.MINOR.PATCH` stays identical, such as `1.0.0-beta.1 -> 1.0.0-beta.2`.                  |
-| **missing_bundle** (**missingBundle**)                                | The bundle assigned to this channel has no downloadable content. This means the bundle has no `external_url`, no `r2_path`, it is not a built-in version, and there are no manifest entries available for download.                                        |
-| **no_channel** (**NoChannelOrOverride**)                              | No default channel is configured for this app and the device has no specific channel override assigned. At least one must be present for updates to work.                                                                                                   |
-| **rate_limited** (**rateLimited**)                                    | The device has been rate limited due to excessive requests.                                                                                                                                                                                                |
-| **key_id_mismatch** (**keyMismatch**)                                 | The device's encryption public key does not match the public key used to encrypt the bundle. Metadata includes `device_key_id`, `bundle_key_id`, and `version` to help identify the mismatch.                                                              |
-| **disable_prod_build** (**disableProdBuild**)                          | A production build called `/updates` was blocked by channel policy.                                                                                                            |
-| **disable_device** (**disableDevice**)                                 | A normal phone/tablet was blocked because this channel blocks real devices.                                                                                                                  |
-| **disable_platform_electron** (**disablePlatformElectron**)             | Electron is blocked in this channel.                                                                                                                                                                                     |
-| **customIdBlocked**                                                  | A custom device ID was sent, but this app does not accept custom IDs, so it is ignored.                                                                     |
-| **backend_refusal**                                                  | `v4` of the updater is not supported anymore. Upgrade to updater `v5` at least (with Capacitor `v5`), and prefer `v8` because old Capacitor versions can no longer be updated through app store pipelines.                                                                                            |
+## Plan limits and normal responses
 
-### Quick fixes for policy / configuration issues
+Backend refusals related to billing, throttling, or non-error states.
 
-| Code | Why this happens | What to do next |
-| ---- | ---------------- | ------------- |
-| `invalidIp` | Capgo detected traffic that looks like bot traffic (Google/cloud infrastructure IP). | Ignore on real users; retry from real devices and normal networks, or check after some time. |
-| `needPlanUpgrade` | Organization reached plan/device limit. | Upgrade plan in dashboard or wait for next billing cycle. |
-| `semver_error` | Native app version in config is missing or not valid semver (`x.y.z`). | Set `plugins.CapacitorUpdater.version` to valid semver, then verify it in the [SemVer tester](https://capgo.app/semver_tester/) and rebuild the app. |
-| `disablePlatformIos` | iOS is disabled in channel policy. | If this was accidental, enable iOS in that channel and republish routing. If you intentionally block iOS in this track, keep it off and move iOS builds to a separate channel. |
-| `disablePlatformAndroid` | Android is disabled in channel policy. | If this was accidental, enable Android in that channel and republish routing. If you intentionally block Android in this track, keep it off and move Android builds to a separate channel. |
-| `disableAutoUpdate` | Channel auto-update mode blocks this update style. | Change channel auto-update policy (major/minor/patch/metadata/none) to allow your intended rollout. |
-| `disableAutoUpdateUnderNative` | Channel is set to block updates older than the device baseline. | Push a version at or above the native baseline, or disable that under-native protection. |
-| `disableAutoUpdateMetadata` | Channel requires `min_update_version` metadata and the app is older. | Set `min_update_version` for the target bundle or release from a newer native version. |
-| `disableAutoUpdateToMajor` | The channel blocks major version jumps. | Keep major versions in the same channel strategy, or allow major jumps for this track. |
-| `disableAutoUpdateToMinor` | The channel blocks minor version jumps. | Keep minor versions in the same channel strategy, or allow minor jumps for this track. |
-| `disableAutoUpdateToPatch` | The channel blocks patch-level jumps for this flow. | Align your release cadence, or open patch jumps in channel policy for this track. |
-| `disableEmulator` | Emulator updates are not allowed for this channel. | If this was accidental, turn on emulator updates in a test channel where you validate emulators. If intentional, keep this channel emulator-blocked and use another channel for emulator builds. |
-| `disableDevBuild` | Dev builds are blocked for this channel. | If this was accidental, allow dev updates or move this device to a dev-enabled channel. If this is intentional, keep this channel locked to release builds only. |
-| `disableProdBuild` | A device build in production mode called `/updates`, while your channel blocked it. | If this was accidental, allow production updates in that channel and republish. If this is intentional, keep the restriction and send production builds to the proper channel/build. |
-| `cannotGetBundle` | Capgo could not build a valid download URL for the selected bundle. | Re-upload the bundle or regenerate manifests and check R2/public bundle settings. |
-| `cannotUpdateViaPrivateChannel` | App tried to self-switch to a private channel that does not allow self-assignment. | Enable `allow_device_self_set` on the channel or switch to a public/allowed channel. |
-| `channelMisconfigured` | Channel auto-update rule is missing required data (`version_number` without `min_update_version`). | Fill the missing config for that rule or switch to a simpler auto-update mode. |
-| `missingBundle` | Bundle has no downloadable payload (missing `external_url`/`r2_path` and no manifest). | Rebuild/re-upload the version and verify the bundle has real file content. |
-| `NoChannelOrOverride` | No channel matched this device (no cloud default + no config fallback + no override). | Set a channel default in dashboard or keep a test `defaultChannel` in that build. |
-| `rateLimited` | Too many update/channel calls in a short time (often render-loop `setChannel`/`getChannel`). | Stop calling in render. Only call on user action. Use `defaultChannel` in `capacitor.config`. |
-| `keyMismatch` | The app and bundle encryption key IDs differ (`device_key_id` vs `bundle_key_id`). | In the console, compare device and bundle key IDs. If they differ, publish with the same key and matching CLI/plugin version; key encoding can differ between versions. |
-| `disableDevice` | A real phone/tablet was blocked because this channel is set to block real devices. | If accidental, turn on real-device updates in that channel. If intentional, keep it blocked and route real devices to another channel. |
-| `disablePlatformElectron` | Electron is blocked in this channel. | If this was accidental, enable Electron in this channel and republish routing. If intentional, keep it blocked and send Electron users to a dedicated channel. |
-| `customIdBlocked` | A custom device ID was sent, but this app does not accept custom IDs. | Turn off custom ID sending or enable custom IDs only if your workflow requires it. |
-| `blocked_by_server_url` | The app has `server.url` configured, so Capacitor serves remote URL instead of local files. | Remove/clear `server.url` for production builds and keep update payloads local. |
-| `backend_refusal` | The updater is `v4`, which the backend no longer accepts. | Upgrade plugin/CLI to `v5`+ (prefer `v8`), with Capacitor `v5`+, then rebuild and republish bundle metadata. |
+### `invalid_ip (InvalidIp)`
 
-### Sent from the device
+**What it means**
 
-| code  | Description                                                                       |
-| --------------------- | --------------------------------------------------------------------------------- |
-| **ping**              | Internal test action used to verify the stats system is working correctly.        |
-| **get**               | Info for downloading the new version has been sent to the device.                 |
-| **delete**            | One bundle has been deleted on the device.                                        |
-| **set**               | A bundle has been set on the device.                                              |
-| **set_fail**          | The bundle failed to set.                                                         |
-| **reset**             | The device reset to the `builtin` bundle.                                         |
-| **download_0**        | The download sequence started at 0% progress.                                    |
-| **download_XX**       | A new bundle has been downloaded - progress indicated by XX% (increments of 10%). |
-| **download_complete** | The new bundle has finished downloading.                                          |
-| **download_manifest_start** | The device started downloading the update manifest.                             |
-| **download_manifest_complete** | The device finished downloading the update manifest.                          |
-| **download_zip_start** | The device started downloading the bundle archive.                                   |
-| **download_zip_complete** | The device finished downloading the bundle archive.                                 |
-| **download_manifest_file_fail** | One manifest entry failed to download; the stats payload puts `version_name` in the form `version:fileName` to pinpoint the asset. |
-| **download_manifest_checksum_fail** | The manifest file failed checksum validation.                           |
-| **download_manifest_brotli_fail** | The manifest file failed to decompress using Brotli.                       |
-| **download_fail**     | The new bundle failed to download.                                                |
-| **update_fail**       | The new bundle has been installed but failed to call `notifyAppReady`.            |
-| **checksum_fail**     | The new bundle failed to validate the checksum. This can happen for several reasons: **1) Checksum type mismatch:** The latest version of the CLI and plugins (version 5.10.0+, 6.25.0+ or 7+) use SHA256 checksums, while older plugins used CRC32. If you see a checksum fail, check if the checksum is CRC32 (a shorter hash) rather than SHA256. This usually indicates the bundle was uploaded with an old version of the CLI. Verify your bundle version in the Capgo dashboard - bundles created since version 5.10.0/6.25.0/7 should use SHA256. If you're seeing CRC32 checksums, ensure you have the latest plugin version installed locally (the CLI checks your local plugin version to determine which checksum type to upload), then upgrade your CLI and re-upload the bundle. **2) Encryption key mismatch (on plugin versions below 8.3.0 or 5/6/7.38.0):** On older plugin versions, if the device's public key doesn't match the key used to encrypt the bundle, the decryption will fail silently and cause a checksum failure. If you're using encryption and see `checksum_fail`, verify that the public key in your app's `capacitor.config.json` matches the private key used to upload the bundle. Upgrading to plugin version 8.3.0+ (or 5/6/7.38.0+) will give you a proper `keyMismatch` error from the server instead, making this issue easier to diagnose. |
-| **windows_path_fail** | The zip has files who contain windows path who are illegal                        |
-| **canonical_path_fail** | The path of files is not canonical                                              |
-| **directory_path_fail** | There is an error in the path of zip files                                         |
-| **unzip_fail**          | unzip failed                                                                   |
-| **low_mem_fail** | Download failed because of low memory in the device                                    |
-| **app_moved_to_background** | The application entered the background state.                                   |
-| **app_moved_to_foreground** | The application entered the foreground state.                                   |
-| **app_crash** | The app reported a crash detected from the JavaScript or Capacitor layer. Metadata can include the message, stack, source, and active bundle context. |
-| **app_crash_native** | The native layer reported a platform crash. Metadata can include platform, reason, stack, and process details when available. |
-| **app_anr** | Android reported an Application Not Responding event. Metadata can include the ANR reason, thread, or trace summary when available. |
-| **app_killed_low_memory** | The app process was killed after low-memory pressure. Metadata can include available memory and platform signals when available. |
-| **app_killed_excessive_resource_usage** | The OS killed the app for excessive resource use. Metadata can include the resource type or platform reason when available. |
-| **app_initialization_failure** | The updater or app startup flow failed before normal runtime was ready. Metadata can include the failing step and error message. |
-| **app_memory_warning** | iOS reported a memory warning. Metadata can include the active bundle and memory context when available. |
-| **webview_javascript_error** | The WebView reported an uncaught JavaScript error. Metadata can include the message, source URL, line, column, and stack. Install Sentry in both places: JS SDK in your web app and native SDK in iOS/Android, then compare sessions to fix the exact line causing the error. |
-| **webview_unhandled_rejection** | The WebView reported an unhandled promise rejection. Metadata can include the rejection reason, source URL, and stack. Install Sentry in both places (JS + native) so async failures are visible with user/device/session context. |
-| **webview_resource_error** | A WebView resource failed to load. Metadata can include the URL, status code, resource type, and error message. Install Sentry (JS + native) to capture the failing URL and environment context, then patch broken asset loading faster. |
-| **webview_security_policy_violation** | The WebView reported a content security policy violation. Metadata can include the blocked URI, directive, and document URL. Install Sentry (JS + native) to see when and where CSP blocks happen in real sessions and update rules safely. |
-| **webview_unclean_restart** | The app detected a previous WebView session that did not shut down cleanly. This can help identify crash loops after an update. Add Sentry in both JS and native sides to connect restart events with surrounding errors. |
-| **webview_render_process_gone** | Android reported that the WebView renderer process exited. Metadata can include whether the renderer crashed and the renderer priority. Install Sentry (JS + native) to tie renderer exits to recent crashes and device logs. |
-| **webview_content_process_terminated** | iOS reported that the WebView content process terminated. Metadata can include the active bundle and page URL when available. Install Sentry on JS and native layers so you get timing, URL, and session context around each content-process end. |
-| **decrypt_fail**        | Failed to decrypt the downloaded bundle.                                          |
-| **os_version_changed** | The device OS version changed between checks. This is used to correlate update behavior with OS-level changes. |
-| **native_app_version_changed** | The native app version changed (for example from a native rollout), helping separate native and web-view behavior changes. |
-| **get_channel** (**getChannel**) | The current channel for the device was queried.                                   |
-| **set_channel** (**setChannel**) | A channel was successfully set for the device.                                    |
-| **uninstall**           | The application was uninstalled or Capgo data cleared.                            |
-| **blocked_by_server_url** | Server.url is present in your capacitor config, this make Capacitor serve remote url and ignore local files, while our updater is made to function with local file, Server.url Is consider by Capacitor Makers as bad practice in production and will lead to many issue and plugin not working correctly.                         |
+Capgo detected traffic that looks like it comes from Google or cloud infrastructure. Updates less than four hours old are ignored so bot traffic does not count as billable devices.
 
-### Bundle status
+**What to do**
+
+Ignore this on real users. Retry from normal networks and real devices, or wait and check again later.
+
+### `need_plan_upgrade (needPlanUpgrade, needUpgrade)`
+
+**What it means**
+
+Your organization reached its plan or device limit. The device will not receive updates until you upgrade or the next billing cycle resets usage.
+
+**What to do**
+
+Upgrade your plan in the dashboard or wait for the next billing cycle.
+
+### `no_new_version_available (noNew)`
+
+**What it means**
+
+The device already has the latest bundle available for its channel. This is a normal state, not a failure.
+
+### `rate_limited (rateLimited)`
+
+**What it means**
+
+The device sent too many update or channel requests in a short window.
+
+**What to do**
+
+Stop calling update APIs inside render loops. Call `setChannel` / `getChannel` only from user actions, and set `defaultChannel` in `capacitor.config`.
+## Version format
+
+Backend refusals caused by invalid native version metadata.
+
+### `semver_error`
+
+**What it means**
+
+The native app version in config is missing or not valid semver (`x.y.z`).
+
+**What to do**
+
+Set `plugins.CapacitorUpdater.version` to valid semver, verify it in the [SemVer tester](https://capgo.app/semver_tester/), then rebuild and reinstall the native app.
+## Platform and build targeting
+
+Backend refusals when channel policy blocks a platform, build type, or device class.
+
+### `disabled_platform_ios (disablePlatformIos)`
+
+**What it means**
+
+The device runs iOS, but iOS updates are disabled for this channel.
+
+**What to do**
+
+Enable iOS in the channel if this was accidental, or route iOS builds to a dedicated channel when blocking is intentional.
+
+### `disabled_platform_android (disablePlatformAndroid)`
+
+**What it means**
+
+The device runs Android, but Android updates are disabled for this channel.
+
+**What to do**
+
+Enable Android in the channel if this was accidental, or route Android builds to a dedicated channel when blocking is intentional.
+
+### `disable_platform_electron (disablePlatformElectron)`
+
+**What it means**
+
+The device runs Electron, but Electron updates are disabled for this channel.
+
+**What to do**
+
+Enable Electron in the channel if this was accidental, or route Electron builds to a dedicated channel when blocking is intentional.
+
+### `disable_dev_build (disableDevBuild)`
+
+**What it means**
+
+The device is a development build, but dev builds are blocked for this channel.
+
+**What to do**
+
+Allow dev builds in a test channel, or keep this channel release-only and move dev devices elsewhere.
+
+### `disable_prod_build (disableProdBuild)`
+
+**What it means**
+
+A production build called `/updates`, but production updates are blocked for this channel.
+
+**What to do**
+
+Allow production updates in the channel if this was accidental, or route production builds to the correct channel.
+
+### `disable_device (disableDevice)`
+
+**What it means**
+
+A real phone or tablet was blocked because this channel blocks real devices.
+
+**What to do**
+
+Enable real-device updates if this was accidental, or keep the restriction and route real devices to another channel.
+
+### `disable_emulator (disableEmulator)`
+
+**What it means**
+
+The device is an emulator, but emulator updates are disabled for this channel.
+
+**What to do**
+
+Enable emulator updates in a test channel, or keep this channel emulator-blocked and use another channel for emulator validation.
+## Auto-update compatibility rules
+
+Backend refusals when semver or metadata rules block the target bundle.
+
+### `disable_auto_update (disableAutoUpdate)`
+
+**What it means**
+
+Auto-update is disabled by channel compatibility policy. Metadata includes `auto_update` with a matching rule such as `major`, `minor`, `patch`, `metadata`, or `none`.
+
+**What to do**
+
+Change the channel auto-update policy to allow your intended rollout.
+
+### `disable_auto_update_under_native (disableAutoUpdateUnderNative)`
+
+**What it means**
+
+The channel has a bundle older than the device baseline and blocks sending updates under the native version.
+
+**What to do**
+
+Publish a bundle at or above the native baseline, or disable under-native protection in the channel.
+
+### `disable_auto_update_to_metadata (disableAutoUpdateMetadata)`
+
+**What it means**
+
+The channel requires `min_update_version`, but the device native version is below that threshold.
+
+**What to do**
+
+Set `min_update_version` on the target bundle or release from a newer native version.
+
+### `disable_auto_update_to_major (disableAutoUpdateToMajor)`
+
+**What it means**
+
+The channel blocks major version jumps, for example `1.x.x` to `2.x.x`.
+
+**What to do**
+
+Align channel strategy with your major rollout plan, or allow major jumps for this track. See [Common Update Problems](/docs/plugins/updater/commonproblems/#disable_auto_update_to_major).
+
+### `disable_auto_update_to_minor (disableAutoUpdateToMinor)`
+
+**What it means**
+
+The channel blocks minor version jumps relative to the device native baseline (`version_build`), for example `1.2.3` to `1.3.0`.
+
+**What to do**
+
+Align channel strategy with your minor rollout plan, or allow minor jumps for this track.
+
+### `disable_auto_update_to_patch (disableAutoUpdateToPatch)`
+
+**What it means**
+
+The channel blocks patch-level changes while keeping the same `MAJOR.MINOR.PATCH` prefix; only suffix changes are allowed.
+
+**What to do**
+
+Align release cadence with channel policy, or allow patch jumps for this track.
+## Channel setup
+
+Backend refusals caused by missing or incompatible channel configuration.
+
+### `cannot_update_via_private_channel (cannotUpdateViaPrivateChannel)`
+
+**What it means**
+
+The device tried to self-associate with a private channel that does not allow device self-assignment (`allow_device_self_set` is false) and the channel is not public.
+
+**What to do**
+
+Enable `allow_device_self_set` on the channel or switch the device to a public or allowed channel.
+
+### `misconfigured_channel (channelMisconfigured)`
+
+**What it means**
+
+The channel uses `disable_auto_update: "version_number"` but the bundle `min_update_version` is null, so Capgo cannot decide which devices should update.
+
+**What to do**
+
+Fill the missing config for that rule or switch to a simpler auto-update mode.
+
+### `no_channel (NoChannelOrOverride)`
+
+**What it means**
+
+No default channel is configured and the device has no channel override.
+
+**What to do**
+
+Set a default channel in the dashboard or configure `defaultChannel` in the build.
+## Bundle delivery and encryption
+
+Backend refusals when Capgo cannot serve or decrypt the bundle.
+
+### `cannot_get_bundle (cannotGetBundle)`
+
+**What it means**
+
+Capgo failed to generate a valid signed download URL and no manifest fallback was available.
+
+**What to do**
+
+Re-upload the bundle, regenerate manifests, and verify R2 or public bundle settings.
+
+### `missing_bundle (missingBundle)`
+
+**What it means**
+
+The bundle assigned to the channel has no downloadable content: no `external_url`, no `r2_path`, not a built-in version, and no manifest entries.
+
+**What to do**
+
+Rebuild and re-upload the version, then confirm the bundle has real file content.
+
+### `key_id_mismatch (keyMismatch)`
+
+**What it means**
+
+The device encryption public key does not match the key used to encrypt the bundle. Metadata can include `device_key_id`, `bundle_key_id`, and `version`.
+
+**What to do**
+
+Compare device and bundle key IDs in the console. Publish with the same key and matching CLI/plugin versions.
+## App configuration and legacy clients
+
+Backend refusals caused by app configuration or unsupported updater versions.
+
+### `customIdBlocked`
+
+**What it means**
+
+The app sent a custom device ID, but this app does not accept custom IDs, so the ID is ignored.
+
+**What to do**
+
+Stop sending custom IDs, or enable custom IDs only when your workflow requires them.
+
+### `blocked_by_server_url`
+
+**What it means**
+
+`server.url` is set in Capacitor config, so the WebView loads a remote URL instead of local bundle files. Capgo live updates require local files and `server.url` is discouraged in production.
+
+**What to do**
+
+Remove or clear `server.url` for production builds and keep update payloads local. This code can appear as a backend refusal or as a device-side stat.
+
+### `backend_refusal`
+
+**What it means**
+
+The updater plugin is v4, which the backend no longer accepts.
+
+**What to do**
+
+Upgrade plugin and CLI to v5+ (prefer v8) with Capacitor v5+, rebuild, and republish bundle metadata.
+## Update lifecycle
+
+Device-side events for normal update flow, activation, and rollback.
+
+### `ping`
+
+**What it means**
+
+Internal test action used to verify the stats pipeline.
+
+### `get`
+
+**What it means**
+
+Capgo sent download information for a new version to the device.
+
+### `set`
+
+**What it means**
+
+A bundle was activated on the device.
+
+### `set_fail`
+
+**What it means**
+
+A bundle failed to activate on the device.
+
+**What to do**
+
+Check native logs with `npx @capgo/cli@latest app debug` and verify bundle integrity, paths, and `notifyAppReady` flow.
+
+### `reset`
+
+**What it means**
+
+The device reset to the built-in bundle.
+
+### `delete`
+
+**What it means**
+
+One bundle was deleted on the device.
+## Download and install failures
+
+Device-side events for download progress, archive validation, and install errors.
+
+### `download_0 to download_90`
+
+**What it means**
+
+Download progress events emitted in 10% steps (`download_0`, `download_10`, …, `download_90`).
+
+### `download_complete`
+
+**What it means**
+
+The bundle download finished successfully.
+
+### `download_manifest_start`
+
+**What it means**
+
+The device started downloading the update manifest.
+
+### `download_manifest_complete`
+
+**What it means**
+
+The device finished downloading the update manifest.
+
+### `download_zip_start`
+
+**What it means**
+
+The device started downloading the bundle archive.
+
+### `download_zip_complete`
+
+**What it means**
+
+The device finished downloading the bundle archive.
+
+### `download_manifest_file_fail`
+
+**What it means**
+
+One manifest entry failed to download. `version_name` uses `version:fileName` to identify the asset.
+
+**What to do**
+
+Fix the missing or blocked asset, regenerate the manifest, and re-upload the bundle.
+
+### `download_manifest_checksum_fail`
+
+**What it means**
+
+A manifest file failed checksum validation.
+
+**What to do**
+
+Re-upload the bundle with a current CLI version and verify manifest checksums.
+
+### `download_manifest_brotli_fail`
+
+**What it means**
+
+A manifest file failed Brotli decompression.
+
+**What to do**
+
+Verify compression settings and re-upload affected assets.
+
+### `download_fail`
+
+**What it means**
+
+The bundle failed to download.
+
+**What to do**
+
+Check network connectivity, signed URL expiry, CDN reachability, and device storage.
+
+### `update_fail`
+
+**What it means**
+
+The bundle installed but the app never called `notifyAppReady`, so Capgo rolled back.
+
+**What to do**
+
+Call `notifyAppReady()` after your app finishes bootstrapping. Native log text `notifyAppReady was not called, roll back current bundle` maps to this code.
+
+### `checksum_fail`
+
+**What it means**
+
+The downloaded bundle failed checksum validation. Common causes: CRC32 vs SHA256 mismatch from an old CLI upload, or encryption key mismatch on older plugins that surface decryption failure as checksum failure.
+
+**What to do**
+
+Re-upload with a current CLI/plugin (SHA256). If using encryption, verify the app public key matches the upload key, or upgrade to plugin 8.3.0+ for explicit `keyMismatch` errors.
+
+### `decrypt_fail`
+
+**What it means**
+
+The downloaded bundle failed to decrypt.
+
+**What to do**
+
+Verify encryption keys and re-upload the bundle with the matching key pair.
+
+### `windows_path_fail`
+
+**What it means**
+
+The zip contains illegal Windows-style paths.
+
+**What to do**
+
+Rebuild the bundle on Unix paths or sanitize archive paths before upload.
+
+### `canonical_path_fail`
+
+**What it means**
+
+File paths inside the zip are not canonical.
+
+**What to do**
+
+Fix archive path generation before upload.
+
+### `directory_path_fail`
+
+**What it means**
+
+The zip contains invalid directory paths.
+
+**What to do**
+
+Fix archive structure before upload.
+
+### `unzip_fail`
+
+**What it means**
+
+The device failed to unzip the downloaded bundle.
+
+**What to do**
+
+Verify archive integrity and supported compression.
+
+### `low_mem_fail`
+
+**What it means**
+
+Download failed because the device ran out of memory.
+
+**What to do**
+
+Reduce bundle size or retry on a device with more free memory.
+## App health and WebView events
+
+Device-side crash, memory, and WebView diagnostics. Always inspect metadata JSON in the dashboard.
+
+### `app_moved_to_background`
+
+**What it means**
+
+The app entered the background.
+
+### `app_moved_to_foreground`
+
+**What it means**
+
+The app entered the foreground.
+
+### `app_crash`
+
+**What it means**
+
+JavaScript or Capacitor layer crash. Metadata can include message, stack, source, and active bundle context.
+
+**What to do**
+
+Inspect metadata and native logs. Pair JS and native error reporting (for example Sentry) to locate the failing code path.
+
+### `app_crash_native`
+
+**What it means**
+
+Native platform crash. Metadata can include platform, reason, stack, and process details.
+
+**What to do**
+
+Use Xcode or Logcat crash logs and correlate with the active bundle from metadata.
+
+### `app_anr`
+
+**What it means**
+
+Android Application Not Responding event.
+
+**What to do**
+
+Inspect ANR traces in Logcat and reduce main-thread blocking work after updates.
+
+### `app_killed_low_memory`
+
+**What it means**
+
+The OS killed the app after memory pressure.
+
+**What to do**
+
+Reduce memory use after update activation and inspect metadata for available memory signals.
+
+### `app_killed_excessive_resource_usage`
+
+**What it means**
+
+The OS killed the app for excessive resource use.
+
+**What to do**
+
+Inspect metadata for the resource type or platform reason.
+
+### `app_initialization_failure`
+
+**What it means**
+
+Updater or startup failed before normal runtime was ready.
+
+**What to do**
+
+Inspect metadata for the failing step and error message.
+
+### `app_memory_warning`
+
+**What it means**
+
+iOS memory warning.
+
+**What to do**
+
+Inspect memory context in metadata and reduce peak usage after updates.
+
+### `webview_javascript_error`
+
+**What it means**
+
+Uncaught JavaScript error in the WebView. Metadata can include message, source URL, line, column, and stack.
+
+**What to do**
+
+Install error reporting in JS and native layers to capture the exact failing line in production.
+
+### `webview_unhandled_rejection`
+
+**What it means**
+
+Unhandled promise rejection in the WebView.
+
+**What to do**
+
+Capture async failures with JS and native error reporting.
+
+### `webview_resource_error`
+
+**What it means**
+
+A WebView resource failed to load.
+
+**What to do**
+
+Use metadata URL and status details to fix broken assets or network rules.
+
+### `webview_security_policy_violation`
+
+**What it means**
+
+Content security policy blocked a resource.
+
+**What to do**
+
+Adjust CSP using metadata directive and blocked URI details.
+
+### `webview_unclean_restart`
+
+**What it means**
+
+Previous WebView session did not shut down cleanly, which can indicate crash loops after an update.
+
+**What to do**
+
+Correlate with crash and WebView error events before and after restart.
+
+### `webview_render_process_gone`
+
+**What it means**
+
+Android WebView renderer process exited.
+
+**What to do**
+
+Inspect renderer crash signals in metadata and native logs.
+
+### `webview_content_process_terminated`
+
+**What it means**
+
+iOS WebView content process terminated.
+
+**What to do**
+
+Inspect active bundle and page URL from metadata.
+## Environment and channel context
+
+Device-side context events that help correlate update behavior with OS, native version, or channel changes.
+
+### `os_version_changed`
+
+**What it means**
+
+Device OS version changed between checks.
+
+### `native_app_version_changed`
+
+**What it means**
+
+Native app store version changed, helping separate native vs web bundle changes.
+
+### `get_channel (getChannel)`
+
+**What it means**
+
+The device queried its current channel.
+
+### `set_channel (setChannel)`
+
+**What it means**
+
+A channel was set successfully for the device.
+
+### `uninstall`
+
+**What it means**
+
+The app was uninstalled or Capgo data was cleared.
+## Bundle status
 
 * `SUCCESS`: install bundle done
 * `ERROR`: install or download failed
@@ -135,9 +700,9 @@ Capgo logs can include metadata for the event. In the dashboard, use the action 
 * `DELETED`: Bundle deleted, still presented for stats
 * `DOWNLOADING`: Currently downloading a bundle
 
-## Understanding device logs:
+## Understanding device logs
 
-### Debug command:
+### Debug command
 
 There is a debug command for Capgo cloud users.
 
@@ -147,7 +712,7 @@ npx @capgo/cli@latest app debug
 
 This will allow you to check all events happening in the app and find a solution if updates don't happen.
 
-### IOS
+### iOS native logs
 
 to find your logs on Xcode
 
@@ -156,7 +721,7 @@ to find your logs on Xcode
     href="https://intercom.help/deploygate/en/articles/4682692-getting-the-device-log-in-xcode"
 />
 
-### Android:
+### Android native logs
 
 to find your logs on Android studio
 
@@ -165,12 +730,12 @@ to find your logs on Android studio
     href="https://developer.android.com/studio/debug/am-logcat"
 />
 
-### Explanations Logs
+### Native log phrase mapping
 
-* `Failed to download from` **=>** same as **download\_fail**
-* `notifyAppReady was not called, roll back current bundle` => same as as **update\_fail**
+* `Failed to download from` maps to **`download_fail`**
+* `notifyAppReady was not called, roll back current bundle` maps to **`update_fail`**
 
-## Finding the downloaded bundle in your device
+## Finding the downloaded bundle on a device
 
 ### iOS
 
@@ -231,3 +796,4 @@ On Android, all versions are stored in one folder, unlike IOS where it has to be
 ## Keep going from Debugging
 
 If you are using **Debugging** to plan native plugin work, connect it with [Using @capgo/capacitor-updater](/plugins/capacitor-updater/) for the native capability in Using @capgo/capacitor-updater, [Capgo Plugin Directory](/plugins/) for the product workflow in Capgo Plugin Directory, [Capacitor Plugins by Capgo](/docs/plugins/) for the implementation detail in Capacitor Plugins by Capgo, [Adding or Updating Plugins](/docs/contributing/adding-plugins/) for the implementation detail in Adding or Updating Plugins, and [Ionic Enterprise Plugin Alternatives](/ionic-enterprise-plugins/) for the product workflow in Ionic Enterprise Plugin Alternatives.
+


### PR DESCRIPTION
## Summary (AI generated)

- Replaced the three large markdown tables on the Debugging page with grouped `##` sections and per-code `###` entries.
- Merged the duplicate "Sent from the backend" and "Quick fixes" content into single sections with **What it means** and **What to do** blocks.
- Kept device-side codes, bundle status, native log tooling, and bundle inspection guides, with clearer subtitles for the table of contents.

## Motivation (AI generated)

Console log rows link to the Debugging docs, but the old page used tables without per-row anchors and duplicated backend explanations in two places. This restructure makes each log code linkable from the page TOC and easier to scan.

## Business Impact (AI generated)

Support and self-serve debugging improve: customers can jump from a log action to the exact explanation and fix without hunting through duplicate tables.

## Test Plan (AI generated)

- [ ] Open `/docs/plugins/updater/debugging/` locally and confirm the right-hand TOC lists grouped sections and individual log codes.
- [ ] Click several TOC entries (for example `set_fail`, `need_plan_upgrade`, `checksum_fail`) and verify the page scrolls to the correct section.
- [ ] Confirm redirects from `/docs/plugin/debugging/` still reach the page.
- [ ] Spot-check that images and LinkCards in the device log / bundle inspection sections still render.

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized debugging documentation for improved clarity and navigation
  * Cloud logs section restructured with categorized, directly linkable error code subsections
  * Device logs section redesigned with structured event code flow and bundle status reference
  * Added native log phrase mapping to correlate native messages with event codes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->