### PR TITLE
docs(builder): document iOS app-specific password upload option

### DIFF
--- a/apps/docs/src/content/docs/docs/builder/configuration.mdx
+++ b/apps/docs/src/content/docs/docs/builder/configuration.mdx
@@ -53,11 +53,11 @@ For CI/CD pipelines, environment variables are usually the most convenient. For 
 | `--apple-key-content <content>` | `APPLE_KEY_CONTENT` | `APPLE_KEY_CONTENT` | — | Base64-encoded App Store Connect API key (`.p8` file) |
 | `--app-store-connect-team-id <id>` | `APP_STORE_CONNECT_TEAM_ID` | `APP_STORE_CONNECT_TEAM_ID` | — | App Store Connect Team ID |
 
-<Aside type="note">
-**Alternative authentication (app-specific password):** Instead of an App Store Connect API key you can upload with an Apple ID + app-specific password. This is the method used by Ionic Appflow, which makes it convenient when migrating from Appflow. API keys remain the recommended option for CI/CD.
+<Aside type="caution" title="Not recommended">
+**App-specific password authentication is discouraged and its use is advised against.** It exists only as a compatibility path for teams migrating from Ionic Appflow (which relied on it). It is tied to a personal Apple ID with no granular permissions, cannot query App Store Connect (so build numbers fall back to a timestamp), and only covers the TestFlight upload itself. Prefer an App Store Connect API key (`.p8`) instead: it is the recommended, more capable, and more secure option for CI/CD.
 </Aside>
 
-#### App-specific password authentication
+#### App-specific password authentication (not recommended)
 
 | CLI Flag | Env Variable | Credential Key | Default | Description |
 |----------|-------------|----------------|---------|-------------|

--- a/apps/docs/src/content/docs/docs/builder/configuration.mdx
+++ b/apps/docs/src/content/docs/docs/builder/configuration.mdx
@@ -54,7 +54,19 @@ For CI/CD pipelines, environment variables are usually the most convenient. For 
 | `--app-store-connect-team-id <id>` | `APP_STORE_CONNECT_TEAM_ID` | `APP_STORE_CONNECT_TEAM_ID` | — | App Store Connect Team ID |
 
 <Aside type="note">
-**Alternative authentication:** You can also use Apple ID + app-specific password instead of API keys. Pass `--apple-id <email>` and `--apple-app-specific-password <password>` (env vars: `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`). API keys are recommended for CI/CD.
+**Alternative authentication (app-specific password):** Instead of an App Store Connect API key you can upload with an Apple ID + app-specific password. This is the method used by Ionic Appflow, which makes it convenient when migrating from Appflow. API keys remain the recommended option for CI/CD.
+</Aside>
+
+#### App-specific password authentication
+
+| CLI Flag | Env Variable | Credential Key | Default | Description |
+|----------|-------------|----------------|---------|-------------|
+| `--apple-id <email>` | `FASTLANE_USER` | `FASTLANE_USER` | — | Apple ID email of the account that owns the app |
+| `--apple-app-specific-password <password>` | `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD` | `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD` | — | App-specific password (`xxxx-xxxx-xxxx-xxxx`) generated at [appleid.apple.com](https://appleid.apple.com) |
+| `--apple-app-id <id>` | `APPLE_APP_ID` | `APPLE_APP_ID` | — | Numeric App Store Connect app ID (e.g. `1234567890`) |
+
+<Aside type="caution">
+All three fields are required together. The numeric `APPLE_APP_ID` (found in App Store Connect → your app → App Information → Apple ID) is mandatory: without it fastlane falls back to an interactive 2FA login that cannot complete on the build runner. When this method is used the build number falls back to a timestamp-based value, because App Store Connect is not queried for the latest build number.
 </Aside>
 
 ### iOS Build Settings
@@ -161,6 +173,12 @@ APPLE_KEY_ID="ABC1234567"
 APPLE_ISSUER_ID="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 APPLE_KEY_CONTENT="<base64-encoded .p8 key>"
 APP_STORE_CONNECT_TEAM_ID="TEAM123456"
+
+# Alternative to the App Store Connect API key above: Apple ID + app-specific
+# password (e.g. when migrating from Ionic Appflow). All three are required.
+# FASTLANE_USER="apple-id@example.com"
+# FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD="xxxx-xxxx-xxxx-xxxx"
+# APPLE_APP_ID="1234567890"
 
 # Optional iOS settings
 CAPGO_IOS_SCHEME="App"

--- a/apps/docs/src/content/docs/docs/builder/credentials.mdx
+++ b/apps/docs/src/content/docs/docs/builder/credentials.mdx
@@ -158,8 +158,8 @@ bunx @capgo/cli@latest build credentials save \
 - **`ad_hoc` mode**: These options are **not required** — no App Store submission takes place. See [Ad-Hoc Distribution Mode](/docs/builder/ios/#ad-hoc-distribution-mode) for details.
 </Aside>
 
-<Aside type="note" title="² App-specific password (alternative to the API key)">
-Instead of an App Store Connect API key you can authenticate uploads with an Apple ID + app-specific password. This is the method Ionic Appflow uses, which makes it handy when migrating from Appflow. All three options (`--apple-id`, `--apple-app-specific-password`, and `--apple-app-id`) are required together. The numeric `--apple-app-id` (App Store Connect → your app → App Information → Apple ID) lets the upload run without an interactive 2FA prompt; with this method the build number falls back to a timestamp because App Store Connect is not queried. API keys remain recommended for CI/CD.
+<Aside type="caution" title="² App-specific password (not recommended)">
+**This method is discouraged and advised against.** It exists only as a compatibility path for teams migrating from Ionic Appflow. Prefer an App Store Connect API key (`.p8`), which is the recommended, more capable, and more secure option for CI/CD. If you must use it, all three options (`--apple-id`, `--apple-app-specific-password`, and `--apple-app-id`) are required together. The numeric `--apple-app-id` (App Store Connect → your app → App Information → Apple ID) lets the upload run without an interactive 2FA prompt; with this method the build number falls back to a timestamp because App Store Connect is not queried.
 </Aside>
 
 ### What Gets Stored

--- a/apps/docs/src/content/docs/docs/builder/credentials.mdx
+++ b/apps/docs/src/content/docs/docs/builder/credentials.mdx
@@ -145,6 +145,9 @@ bunx @capgo/cli@latest build credentials save \
 | `--apple-key-id <id>` | App Store Connect API Key ID | See note¹ |
 | `--apple-issuer-id <id>` | App Store Connect API Issuer ID (UUID) | See note¹ |
 | `--apple-team-id <id>` | App Store Connect Team ID | Yes |
+| `--apple-id <email>` | Apple ID email for app-specific password upload (alternative to the API key) | See note² |
+| `--apple-app-specific-password <password>` | App-specific password (`xxxx-xxxx-xxxx-xxxx`) | See note² |
+| `--apple-app-id <id>` | Numeric App Store Connect app ID (e.g. `1234567890`) | See note² |
 | `--ios-distribution <mode>` | Distribution mode: `app_store` (default) or `ad_hoc` | No |
 | `--output-upload` | Enable a time-limited Capgo download link for the build artifact | No (default: `false`) |
 | `--output-retention <seconds>` | How long to keep build outputs (e.g. `3600s`) | No (default: `3600s`) |
@@ -153,6 +156,10 @@ bunx @capgo/cli@latest build credentials save \
 <Aside type="note" title="¹ App Store Connect API Key Requirements">
 - **`app_store` mode** (default): All three API key options are **required** unless you pass `--output-upload` or `--skip-build-number-bump` (which bypass the need for API-driven submission).
 - **`ad_hoc` mode**: These options are **not required** — no App Store submission takes place. See [Ad-Hoc Distribution Mode](/docs/builder/ios/#ad-hoc-distribution-mode) for details.
+</Aside>
+
+<Aside type="note" title="² App-specific password (alternative to the API key)">
+Instead of an App Store Connect API key you can authenticate uploads with an Apple ID + app-specific password. This is the method Ionic Appflow uses, which makes it handy when migrating from Appflow. All three options (`--apple-id`, `--apple-app-specific-password`, and `--apple-app-id`) are required together. The numeric `--apple-app-id` (App Store Connect → your app → App Information → Apple ID) lets the upload run without an interactive 2FA prompt; with this method the build number falls back to a timestamp because App Store Connect is not queried. API keys remain recommended for CI/CD.
 </Aside>
 
 ### What Gets Stored

--- a/apps/docs/src/content/docs/docs/cli/reference/build.mdx
+++ b/apps/docs/src/content/docs/docs/cli/reference/build.mdx
@@ -47,8 +47,9 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--build-mode** | <code>string</code> | Build mode: debug or release (default: release) |
 | **--build-certificate-base64** | <code>string</code> | iOS: Base64-encoded .p12 certificate |
 | **--p12-password** | <code>string</code> | iOS: Certificate password (optional if cert has no password) |
-| **--apple-id** | <code>string</code> | iOS: Apple ID email |
-| **--apple-app-specific-password** | <code>string</code> | iOS: App-specific password |
+| **--apple-id** | <code>string</code> | iOS: Apple ID email for app-specific password uploads (alternative to App Store Connect API key) |
+| **--apple-app-specific-password** | <code>string</code> | iOS: App-specific password (xxxx-xxxx-xxxx-xxxx) for TestFlight uploads |
+| **--apple-app-id** | <code>string</code> | iOS: Numeric App Store Connect app id (required together with --apple-id and --apple-app-specific-password) |
 | **--apple-key-id** | <code>string</code> | iOS: App Store Connect API Key ID |
 | **--apple-issuer-id** | <code>string</code> | iOS: App Store Connect Issuer ID |
 | **--apple-key-content** | <code>string</code> | iOS: Base64-encoded App Store Connect API key (.p8) |


### PR DESCRIPTION
## Why

Document the **Apple ID + app-specific password** upload path as an alternative to the App Store Connect API key for iOS cloud builds, used by apps migrating from **Ionic Appflow**.

## What

- **`builder/configuration.mdx`**: corrected the existing stub note that referenced the **wrong** env var names (`APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD`) and omitted the required numeric app id. Added a dedicated table + caution note. Real keys: `FASTLANE_USER`, `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD`, `APPLE_APP_ID`.
- **`builder/credentials.mdx`**: added the `--apple-id` / `--apple-app-specific-password` / `--apple-app-id` flags to the `credentials save` table with a note that all three are required together and that the build number falls back to a timestamp when no API key is queried.
- **`cli/reference/build.mdx`**: aligned the `build request` reference with the new `--apple-app-id` flag and the full dependency.

## Test plan

- [x] Env var names and CLI flags match the implementation exactly (verified against the CLI/builder diffs).
- [ ] Docs site preview renders the MDX tables/asides (CI preview).

## Related

- CLI support: Cap-go/capgo#2556
- Builder support: Cap-go/capgo_builder#141

https://claude.ai/code/session_01AZWP4JPPHfZ3CyECJesm3S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked iOS “App Store Connect Authentication” docs to cover the discouraged Apple ID + app-specific password alternative flow.
  * Updated the Environment Variable Quick Reference with the relevant variables (`FASTLANE_USER`, `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD`, `APPLE_APP_ID`).
  * Expanded iOS credentials/build documentation to include the required CLI flags (`--apple-id`, `--apple-app-specific-password`, `--apple-app-id`).
  * Clarified that build number fallback uses a timestamp when App Store Connect isn’t queried.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->