### PR TITLE
feat: add visual diff tooling for PRs with UI changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ seo-report.txt
 seo-report.json
 seo-report.sarif
 .wrangler
+
+# Visual regression artifacts (local only)
+.visual-diff/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,57 @@ bunx @tailwindcss/upgrade --force
 - Register documented plugins in `apps/docs/src/config/llmsCustomSets.ts` so they appear in the docs search and LLM sets.
 - Refresh metadata after adding a plugin with `bun run fetch:stars` and `bun run fetch:downloads`.
 - Validate the change with `bunx prettier --write <touched-files>` and `NODE_OPTIONS=--max-old-space-size=16384 bunx astro check` in both `apps/web` and `apps/docs`, or `bun run check` from the repo root.
+
+## Visual Diff For PRs
+
+Use the visual diff tool whenever a PR changes page layout, styling, components, or marketing copy that affects rendered HTML.
+
+### When To Run
+
+- **Before starting visual work:** capture a `before` baseline from `main` (or the PR base branch).
+- **Before opening the PR:** capture `after`, compare, and paste the report into the PR description.
+- **After each new push** to the PR when the author or reviewer asked for visual verification: rebuild, re-capture `after`, re-compare, and post an updated report as a new PR comment.
+
+### Setup (once per machine)
+
+```bash
+bun install
+bun run visual-diff:setup
+```
+
+Requires ImageMagick (`compare` CLI) for pixel diffs.
+
+### Workflow
+
+```bash
+# 1. Baseline (on main or base branch, before your changes)
+bun run build
+bun run visual-diff:capture:before
+
+# 2. After your visual changes
+bun run build
+bun run visual-diff:capture:after
+
+# 3. Compare + PR markdown
+bun run visual-diff:compare
+bun run visual-diff:report
+```
+
+Paste the `## Visual diff` section from `bun run visual-diff:report` into the PR description. On follow-up pushes with visual changes, run steps 2–3 again and post the updated markdown in a new comment.
+
+### Focused captures
+
+Default routes live in `visual-diff.config.json`. Override for a targeted PR:
+
+```bash
+bun run visual-diff:capture:before -- --suite web --routes /,/pricing/
+bun run visual-diff:capture:after -- --suite web --routes /,/pricing/
+```
+
+### Agent checklist
+
+1. Confirm the PR includes visual/UI changes (or the user explicitly requested visual verification).
+2. Run the workflow above before marking the PR ready.
+3. Include the visual diff markdown in the PR body.
+4. After subsequent pushes that change visuals, re-run `capture:after`, `compare`, and `report`; post the fresh results.
+5. Do not commit `.visual-diff/` artifacts — they are gitignored.

--- a/bun.lock
+++ b/bun.lock
@@ -57,6 +57,7 @@
         "js-yaml": "^4.2.0",
         "linkify-it": "^5.0.1",
         "nanospinner": "^1.2.2",
+        "playwright": "^1.61.0",
         "prettier": "^3.8.4",
         "prettier-plugin-astro": "^0.14.1",
         "prettier-plugin-organize-imports": "^4.3.0",
@@ -1096,7 +1097,7 @@
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1561,6 +1562,10 @@
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
     "pkg-up": ["pkg-up@3.1.0", "", { "dependencies": { "find-up": "^3.0.0" } }, "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA=="],
+
+    "playwright": ["playwright@1.61.0", "", { "dependencies": { "playwright-core": "1.61.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ=="],
+
+    "playwright-core": ["playwright-core@1.61.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA=="],
 
     "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
 
@@ -2060,6 +2065,8 @@
 
     "prettier-plugin-astro/prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
+    "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "sitemap/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "starlight-llms-txt/@astrojs/mdx": ["@astrojs/mdx@5.0.6", "", { "dependencies": { "@astrojs/markdown-remark": "7.1.2", "@mdx-js/mdx": "^3.1.1", "acorn": "^8.16.0", "es-module-lexer": "^2.0.0", "estree-util-visit": "^2.0.0", "hast-util-to-html": "^9.0.5", "piccolore": "^0.1.3", "rehype-raw": "^7.0.0", "remark-gfm": "^4.0.1", "remark-smartypants": "^3.0.2", "source-map": "^0.7.6", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "astro": "^6.0.0" } }, "sha512-4dKe0ZMmqujofPNDHahzClkwinn9f8jHPcaXcgdGvPAlboD2mjzkUCofli2cBnxYAkdfhC6d50gBJ8i/cH8gHw=="],
@@ -2070,11 +2077,15 @@
 
     "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "vite/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "vite-plugin-static-copy/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "volar-service-typescript/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "wrangler/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "yaml-language-server/prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
@@ -2211,6 +2222,8 @@
     "starlight-llms-txt/@astrojs/mdx/@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.1.2", "", { "dependencies": { "@astrojs/internal-helpers": "0.9.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "retext-smartypants": "^6.2.0", "shiki": "^4.0.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q=="],
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "vite-plugin-static-copy/chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "vite-plugin-static-copy/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,13 @@
     "clean:unused": "bun run scripts/clean_not_used.tsx",
     "generate:plugins-readme": "bun run scripts/generate-plugins-readme.ts",
     "generate:blog-images": "bun run scripts/generate-blog-images.ts",
-    "blogs:normalize_tags": "bun run scripts/blogs/normalize_tags.ts"
+    "blogs:normalize_tags": "bun run scripts/blogs/normalize_tags.ts",
+    "visual-diff:setup": "bun run scripts/visual-diff.mjs install",
+    "visual-diff:capture:before": "bun run scripts/visual-diff.mjs capture before",
+    "visual-diff:capture:after": "bun run scripts/visual-diff.mjs capture after",
+    "visual-diff:compare": "bun run scripts/visual-diff.mjs compare",
+    "visual-diff:report": "bun run scripts/visual-diff.mjs report",
+    "visual-diff": "bun run scripts/visual-diff.mjs"
   },
   "dependencies": {
     "@astrojs/cloudflare": "13.7.0",
@@ -107,6 +113,7 @@
     "js-yaml": "^4.2.0",
     "linkify-it": "^5.0.1",
     "nanospinner": "^1.2.2",
+    "playwright": "^1.61.0",
     "prettier": "^3.8.4",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-organize-imports": "^4.3.0",

--- a/scripts/visual-diff.mjs
+++ b/scripts/visual-diff.mjs
@@ -1,0 +1,443 @@
+#!/usr/bin/env bun
+/**
+ * Visual regression helper for PRs with UI changes.
+ *
+ * Usage:
+ *   bun run visual-diff:setup
+ *   bun run build && bun run visual-diff:capture:before
+ *   # apply visual changes, rebuild
+ *   bun run build && bun run visual-diff:capture:after
+ *   bun run visual-diff:compare
+ *   bun run visual-diff:report
+ *
+ * Override routes for a focused PR:
+ *   bun run visual-diff:capture:before -- --suite web --routes /,/pricing/
+ */
+import { spawn, spawnSync } from 'node:child_process'
+import { access, mkdir, readdir, readFile, rm, stat } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { chromium } from 'playwright'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '..')
+const DEFAULT_CONFIG_PATH = path.join(ROOT, 'visual-diff.config.json')
+
+function parseArgs(argv) {
+  const args = {
+    configPath: DEFAULT_CONFIG_PATH,
+    suite: null,
+    routes: null,
+    strict: false,
+    label: null,
+    command: null,
+  }
+
+  const positional = []
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--config') {
+      args.configPath = path.resolve(ROOT, argv[++i])
+      continue
+    }
+    if (arg === '--suite') {
+      args.suite = argv[++i]
+      continue
+    }
+    if (arg === '--routes') {
+      args.routes = argv[++i].split(',').map((route) => route.trim()).filter(Boolean)
+      continue
+    }
+    if (arg === '--strict') {
+      args.strict = true
+      continue
+    }
+    positional.push(arg)
+  }
+
+  args.command = positional[0] ?? null
+  args.label = positional[1] ?? null
+  return args
+}
+
+async function loadConfig(configPath) {
+  const raw = await readFile(configPath, 'utf8')
+  return JSON.parse(raw)
+}
+
+function contentType(filePath) {
+  if (filePath.endsWith('.html')) return 'text/html; charset=utf-8'
+  if (filePath.endsWith('.css')) return 'text/css; charset=utf-8'
+  if (filePath.endsWith('.js')) return 'text/javascript; charset=utf-8'
+  if (filePath.endsWith('.webp')) return 'image/webp'
+  if (filePath.endsWith('.png')) return 'image/png'
+  if (filePath.endsWith('.jpg') || filePath.endsWith('.jpeg')) return 'image/jpeg'
+  if (filePath.endsWith('.svg')) return 'image/svg+xml'
+  if (filePath.endsWith('.woff2')) return 'font/woff2'
+  if (filePath.endsWith('.woff')) return 'font/woff'
+  if (filePath.endsWith('.json')) return 'application/json'
+  return 'application/octet-stream'
+}
+
+function routeSlug(route) {
+  return route.replaceAll('/', '_').replace(/^_/, '') || 'home'
+}
+
+function screenshotName(route, viewportName, suiteName) {
+  return `${suiteName}__${routeSlug(route)}__${viewportName}.png`
+}
+
+async function ensureDir(dir) {
+  await mkdir(dir, { recursive: true })
+}
+
+async function pathExists(target) {
+  try {
+    await access(target)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function assertDistReady(distDir) {
+  const indexPath = path.join(ROOT, distDir, 'index.html')
+  if (!(await pathExists(indexPath))) {
+    throw new Error(`Missing build output at ${distDir}/index.html. Run "bun run build" first.`)
+  }
+}
+
+function resolveSuites(config, args) {
+  let suites = config.suites
+  if (args.suite) {
+    suites = suites.filter((suite) => suite.name === args.suite)
+    if (suites.length === 0) {
+      throw new Error(`Unknown suite "${args.suite}". Available: ${config.suites.map((s) => s.name).join(', ')}`)
+    }
+  }
+
+  if (args.routes) {
+    suites = suites.map((suite) => ({ ...suite, routes: args.routes }))
+  }
+
+  return suites
+}
+
+async function startStaticServer(distDir, port) {
+  const absoluteDist = path.join(ROOT, distDir)
+  const server = createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url || '/', `http://127.0.0.1:${port}`)
+      let pathname = decodeURIComponent(url.pathname)
+      if (pathname.endsWith('/')) pathname += 'index.html'
+      const filePath = path.join(absoluteDist, pathname)
+      const data = await readFile(filePath)
+      res.writeHead(200, { 'Content-Type': contentType(filePath) })
+      res.end(data)
+    } catch {
+      res.writeHead(404).end('Not found')
+    }
+  })
+
+  await new Promise((resolve) => server.listen(port, '127.0.0.1', resolve))
+  return server
+}
+
+async function captureSuite({ label, suite, config, outputDir }) {
+  await assertDistReady(suite.distDir)
+  const server = await startStaticServer(suite.distDir, suite.port)
+  const browser = await chromium.launch()
+  const context = await browser.newContext({ deviceScaleFactor: 1 })
+  const captures = []
+
+  try {
+    for (const viewport of config.viewports) {
+      const page = await context.newPage()
+      await page.setViewportSize({ width: viewport.width, height: viewport.height })
+
+      for (const route of suite.routes) {
+        const fileName = screenshotName(route, viewport.name, suite.name)
+        const outPath = path.join(outputDir, fileName)
+
+        await page.goto(`http://127.0.0.1:${suite.port}${route}`, {
+          waitUntil: config.capture.waitUntil,
+          timeout: config.capture.navigationTimeoutMs,
+        })
+        await page.waitForTimeout(config.capture.settleMs)
+
+        const title = await page.title()
+        if (!title || title.toLowerCase().includes('not found')) {
+          throw new Error(`[${label}] Failed to render ${suite.name}${route} (title: "${title}")`)
+        }
+
+        await page.screenshot({ path: outPath, fullPage: true })
+        const fileSize = (await stat(outPath)).size
+        if (fileSize < config.capture.minScreenshotBytes) {
+          throw new Error(
+            `[${label}] Screenshot for ${suite.name}${route} (${viewport.name}) is only ${fileSize} bytes. Page likely did not render.`,
+          )
+        }
+
+        const capture = {
+          suite: suite.name,
+          route,
+          viewport: viewport.name,
+          file: fileName,
+          bytes: fileSize,
+        }
+        captures.push(capture)
+        console.log(`[${label}] ${suite.name}${route} (${viewport.name}) -> ${path.relative(ROOT, outPath)} (${fileSize} bytes)`)
+      }
+
+      await page.close()
+    }
+  } finally {
+    await browser.close()
+    await new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())))
+  }
+
+  return captures
+}
+
+async function capture(label, config, args) {
+  const outputDir = path.join(ROOT, config.outputDir, label)
+  await rm(outputDir, { recursive: true, force: true })
+  await ensureDir(outputDir)
+
+  const suites = resolveSuites(config, args)
+  const manifest = {
+    label,
+    capturedAt: new Date().toISOString(),
+    configPath: path.relative(ROOT, args.configPath),
+    suites: [],
+  }
+
+  for (const suite of suites) {
+    const captures = await captureSuite({ label, suite, config, outputDir })
+    manifest.suites.push({ name: suite.name, distDir: suite.distDir, routes: suite.routes, captures })
+  }
+
+  const manifestPath = path.join(outputDir, 'manifest.json')
+  await Bun.write(manifestPath, JSON.stringify(manifest, null, 2))
+  console.log(`\nCaptured ${manifest.suites.reduce((n, s) => n + s.captures.length, 0)} screenshots -> ${path.relative(ROOT, outputDir)}`)
+}
+
+function compareImages(beforePath, afterPath, fuzzPercent) {
+  const args = ['-metric', 'AE']
+  if (fuzzPercent > 0) args.push('-fuzz', `${fuzzPercent}%`)
+  args.push(beforePath, afterPath, 'null:')
+
+  const proc = spawnSync('compare', args, { encoding: 'utf8' })
+  const stderr = (proc.stderr || '').trim()
+  const diffPixels = Number.parseFloat(stderr)
+  return Number.isFinite(diffPixels) ? diffPixels : null
+}
+
+function classifyDiff(diffPixels, compareConfig) {
+  if (diffPixels === null) return 'unknown'
+  if (diffPixels <= compareConfig.identicalMaxPixels) return 'identical'
+  if (diffPixels <= compareConfig.minorMaxPixels) return 'minor'
+  return 'changed'
+}
+
+async function compare(config, args) {
+  const beforeDir = path.join(ROOT, config.outputDir, 'before')
+  const afterDir = path.join(ROOT, config.outputDir, 'after')
+  const diffDir = path.join(ROOT, config.outputDir, 'diff')
+
+  if (!(await pathExists(beforeDir))) {
+    throw new Error('Missing before captures. Run: bun run visual-diff:capture:before')
+  }
+  if (!(await pathExists(afterDir))) {
+    throw new Error('Missing after captures. Run: bun run visual-diff:capture:after')
+  }
+
+  await ensureDir(diffDir)
+  const files = (await readdir(beforeDir)).filter((file) => file.endsWith('.png')).sort()
+  const results = []
+
+  for (const file of files) {
+    const beforePath = path.join(beforeDir, file)
+    const afterPath = path.join(afterDir, file)
+
+    if (!(await pathExists(afterPath))) {
+      results.push({ file, diffPixels: null, status: 'missing-after' })
+      continue
+    }
+
+    try {
+      const diffPixels = compareImages(beforePath, afterPath, config.compare.fuzzPercent)
+      const status = classifyDiff(diffPixels, config.compare)
+      results.push({ file, diffPixels, status })
+
+      if (status === 'changed' || status === 'minor') {
+        const diffPath = path.join(diffDir, file.replace('.png', '-diff.png'))
+        spawnSync('compare', [beforePath, afterPath, diffPath])
+      }
+    } catch (error) {
+      results.push({ file, diffPixels: null, status: 'error', error: String(error) })
+    }
+  }
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    fuzzPercent: config.compare.fuzzPercent,
+    summary: {
+      total: results.length,
+      identical: results.filter((r) => r.status === 'identical').length,
+      minor: results.filter((r) => r.status === 'minor').length,
+      changed: results.filter((r) => r.status === 'changed').length,
+      missingAfter: results.filter((r) => r.status === 'missing-after').length,
+      unknown: results.filter((r) => r.status === 'unknown' || r.status === 'error').length,
+    },
+    results,
+  }
+
+  const reportPath = path.join(ROOT, config.outputDir, 'report.json')
+  await Bun.write(reportPath, JSON.stringify(report, null, 2))
+
+  console.log(`\nVisual diff summary (${report.summary.total} screenshots, fuzz ${config.compare.fuzzPercent}%):`)
+  console.log(`  identical: ${report.summary.identical}`)
+  console.log(`  minor:     ${report.summary.minor}`)
+  console.log(`  changed:   ${report.summary.changed}`)
+  if (report.summary.missingAfter > 0) console.log(`  missing:   ${report.summary.missingAfter}`)
+  console.log(`Report: ${path.relative(ROOT, reportPath)}`)
+  console.log(`Diff images: ${path.relative(ROOT, diffDir)}/`)
+
+  for (const row of results.filter((r) => r.status !== 'identical')) {
+    console.log(`  ${row.status}: ${row.file}${row.diffPixels != null ? ` (${row.diffPixels} px)` : ''}`)
+  }
+
+  if (args.strict && (report.summary.changed > 0 || report.summary.missingAfter > 0 || report.summary.unknown > 0)) {
+    return false
+  }
+
+  return true
+}
+
+function parseScreenshotName(file) {
+  const match = /^(.+?)__(.+?)__(desktop|mobile)\.png$/.exec(file)
+  if (!match) return { suite: 'unknown', route: file, viewport: 'unknown' }
+  const [, suite, slug, viewport] = match
+  const route = slug === 'home' ? '/' : `/${slug.replaceAll('_', '/')}/`
+  return { suite, route, viewport }
+}
+
+function renderMarkdownReport(report) {
+  const lines = [
+    '## Visual diff',
+    '',
+    `Generated with \`bun run visual-diff:compare\` (${report.summary.total} screenshots, fuzz ${report.fuzzPercent}%).`,
+    '',
+    '| Status | Suite | Route | Viewport | Diff (px) |',
+    '| --- | --- | --- | --- | ---: |',
+  ]
+
+  for (const row of report.results) {
+    const { suite, route, viewport } = parseScreenshotName(row.file)
+    const statusLabel =
+      row.status === 'identical'
+        ? 'identical'
+        : row.status === 'minor'
+          ? 'minor'
+          : row.status === 'changed'
+            ? 'changed'
+            : row.status
+    const diff = row.diffPixels == null ? '—' : String(Math.round(row.diffPixels))
+    lines.push(`| ${statusLabel} | ${suite} | ${route} | ${viewport} | ${diff} |`)
+  }
+
+  lines.push(
+    '',
+    '**Summary:**',
+    `- identical: ${report.summary.identical}`,
+    `- minor: ${report.summary.minor}`,
+    `- changed: ${report.summary.changed}`,
+  )
+
+  if (report.summary.changed > 0 || report.summary.minor > 0) {
+    lines.push('', 'Diff images are in `.visual-diff/diff/` (local only, gitignored).')
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+async function report(config) {
+  const reportPath = path.join(ROOT, config.outputDir, 'report.json')
+  if (!(await pathExists(reportPath))) {
+    throw new Error('Missing report.json. Run: bun run visual-diff:compare')
+  }
+
+  const reportData = JSON.parse(await readFile(reportPath, 'utf8'))
+  const markdown = renderMarkdownReport(reportData)
+  const markdownPath = path.join(ROOT, config.outputDir, 'report.md')
+  await Bun.write(markdownPath, markdown)
+
+  console.log(markdown)
+  console.log(`Saved markdown report -> ${path.relative(ROOT, markdownPath)}`)
+}
+
+async function installBrowsers() {
+  const proc = spawnSync('bunx', ['playwright', 'install', 'chromium'], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  })
+  if (proc.status !== 0) process.exit(proc.status ?? 1)
+}
+
+function printHelp() {
+  console.log(`Visual diff helper
+
+Commands:
+  capture <before|after>   Capture screenshots from built dist folders
+  compare                  Compare before/after screenshots
+  report                   Print PR-ready markdown from report.json
+  install                  Install Playwright Chromium browser
+
+Options:
+  --config <path>          Config file (default: visual-diff.config.json)
+  --suite <name>           Limit to one suite (web|docs)
+  --routes <a,b,c>         Override routes for selected suite(s)
+  --strict                 Exit 1 when compare finds changed/missing screenshots
+
+Examples:
+  bun run build && bun run visual-diff:capture:before
+  bun run build && bun run visual-diff:capture:after
+  bun run visual-diff:compare
+  bun run visual-diff:report
+  bun run visual-diff:capture:before -- --suite web --routes /,/pricing/
+`)
+}
+
+const args = parseArgs(process.argv.slice(2))
+
+if (!args.command || args.command === 'help' || args.command === '--help') {
+  printHelp()
+  process.exit(args.command ? 0 : 1)
+}
+
+const config = await loadConfig(args.configPath)
+
+try {
+  if (args.command === 'capture') {
+    if (!args.label || !['before', 'after'].includes(args.label)) {
+      console.error('Usage: bun run visual-diff:capture:before|after')
+      process.exit(1)
+    }
+    await capture(args.label, config, args)
+  } else if (args.command === 'compare') {
+    const ok = await compare(config, args)
+    process.exit(ok ? 0 : 1)
+  } else if (args.command === 'report') {
+    await report(config)
+  } else if (args.command === 'install') {
+    await installBrowsers()
+  } else {
+    printHelp()
+    process.exit(1)
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+}

--- a/visual-diff.config.json
+++ b/visual-diff.config.json
@@ -1,0 +1,42 @@
+{
+  "outputDir": ".visual-diff",
+  "viewports": [
+    { "name": "desktop", "width": 1440, "height": 900 },
+    { "name": "mobile", "width": 390, "height": 844 }
+  ],
+  "suites": [
+    {
+      "name": "web",
+      "distDir": "apps/web/dist",
+      "port": 4173,
+      "routes": [
+        "/",
+        "/pricing/",
+        "/plugins/",
+        "/blog/",
+        "/about/"
+      ]
+    },
+    {
+      "name": "docs",
+      "distDir": "apps/docs/dist",
+      "port": 4174,
+      "routes": [
+        "/docs/",
+        "/docs/getting-started/quickstart/",
+        "/docs/plugins/updater/"
+      ]
+    }
+  ],
+  "capture": {
+    "waitUntil": "load",
+    "settleMs": 1000,
+    "navigationTimeoutMs": 120000,
+    "minScreenshotBytes": 10000
+  },
+  "compare": {
+    "fuzzPercent": 1,
+    "identicalMaxPixels": 0,
+    "minorMaxPixels": 5000
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a generic visual regression workflow (`scripts/visual-diff.mjs` + `visual-diff.config.json`) for before/after screenshot capture and comparison.
- Exposes `bun run visual-diff:*` scripts for setup, capture, compare, and PR-ready markdown reports.
- Documents the required agent/PR workflow in `AGENTS.md` (baseline before changes, report in PR description, re-run after each visual push).

## Usage

```bash
bun run visual-diff:setup
bun run build && bun run visual-diff:capture:before
# make visual changes
bun run build && bun run visual-diff:capture:after
bun run visual-diff:compare
bun run visual-diff:report   # paste into PR description
```

Focused PR captures:

```bash
bun run visual-diff:capture:before -- --suite web --routes /,/pricing/
```

## Test plan

- [x] `bun run visual-diff` prints help
- [x] `bun install` resolves `playwright` dev dependency
- [ ] Full capture/compare cycle on a visual PR (requires `bun run build` + ImageMagick + Playwright Chromium)


Made with [Cursor](https://cursor.com)