### PR TITLE
docs(blog): update Next.js Capacitor guide with iOS layout fixes and Capgo UI

### DIFF
--- a/apps/web/src/content/blog/en/angular-mobile-app-capacitor.md
+++ b/apps/web/src/content/blog/en/angular-mobile-app-capacitor.md
@@ -3,12 +3,12 @@ slug: angular-mobile-app-capacitor
 title: Building Mobile Apps with Angular and Capacitor
 description: >-
   Learn how to create a mobile app with Angular, Capacitor, and enhance the
-  native UI with Konsta UI.
+  Capgo Native Navigation, Transitions, and iOS layout best practices.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2023-06-06T00:00:00.000Z
-updated_at: 2026-06-18T14:21:30.000Z
+updated_at: 2026-06-23T00:00:00.000Z
 head_image: /angular_capacitor.webp
 head_image_alt: "Building Mobile Apps with Angular and Capacitor Capgo blog illustration"
 keywords: Angular, mobile app development, live updates, OTA updates, continuous integration, mobile app updates
@@ -18,13 +18,13 @@ locale: en
 next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
 ---
 
-In this tutorial, we'll begin with a new [Angular](https://angular.io/) app and transition into the native mobile app realm using Capacitor. Optionally, you can also add [Konsta UI](https://konstaui.com/) for an improved mobile UI with Tailwind CSS.
+In this tutorial, we'll begin with a new [Angular](https://angular.io/) app and transition into the native mobile app realm using Capacitor. You can also add Capgo Native Navigation and Transitions for a native mobile feel, and use tailwind-capacitor for safe areas.
 
 Capacitor allows you to easily convert your Angular web application into a native mobile app without requiring significant modifications or learning a new skill like React Native.
 
 With just a few simple steps, most Angular applications can be transformed into mobile apps.
 
-This tutorial will guide you through the process, starting with a new Angular app and then incorporating Capacitor to move into the realm of native mobile apps. Additionally, you can optionally use [Konsta UI](https://konstaui.com/) to enhance your mobile UI with Tailwind CSS.
+This tutorial will guide you through the process, starting with a new Angular app and then incorporating Capacitor to move into the realm of native mobile apps. You can also use Capgo Native Navigation, Transitions, and tailwind-capacitor for safe areas.
 
 ## About Capacitor
 
@@ -237,86 +237,204 @@ npx cap sync
 
 After hitting the button, you can witness the beautiful native share dialog in action!
 
-## Adding Konsta UI
+Next, you can make the app feel more native on iOS and Android with Capgo navigation and transitions, and fix common iOS layout issues that cause horizontal overflow or cropped safe areas.
 
-To use Konsta UI in your Nuxt 3 app, you need to have [tailwind already install](https://tailwindcss.com/docs/guides/angular/) and to install the package:
+## Native-feeling UI with Capgo Native Navigation and Transitions
+
+I've worked for years with [Ionic](https://ionicframework.com/) to build cross-platform applications, but integrating it with Angular is hacky and rarely worth it when you already have [Tailwind CSS](https://tailwindcss.com/).
+
+For a native mobile feel in an Angular + Capacitor app, use Capgo plugins instead of web-only UI kits like Konsta UI:
+
+- **[@capgo/capacitor-native-navigation](https://github.com/Cap-go/capacitor-native-navigation)** — native navbar, Liquid Glass tab bar on iOS, and a blurred tab bar style on Android. Your Angular router keeps route state; the plugin owns the native chrome.
+- **[@capgo/capacitor-transitions](https://github.com/Cap-go/capacitor-transitions)** — Ionic-style page transitions and iOS edge swipe-back in the WebView layer, without adopting Ionic UI.
+
+Install both:
 
 ```shell
-npm i konsta
+bun add @capgo/capacitor-native-navigation @capgo/capacitor-transitions
+bunx cap sync
 ```
 
-Additionally, you need to modify your `tailwind.config.js` file:
+Configure native navigation with CSS inset mode so web content respects the native bars:
+
+```typescript
+import { NativeNavigation } from '@capgo/capacitor-native-navigation';
+
+await NativeNavigation.configure({
+  contentInsetMode: 'css',
+  animationDuration: 360,
+  glass: {
+    effect: 'liquidGlass',
+  },
+});
+```
+
+Render a Liquid Glass tab bar (iOS uses system-owned rendering; Android uses a blurred WebView backdrop):
+
+```typescript
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+
+const router = inject(Router);
+
+await NativeNavigation.setTabbar({
+  selectedId: 'home',
+  labelVisibilityMode: 'labeled',
+  icons: true,
+  colors: { dynamic: true },
+  tabs: [
+    { id: 'home', title: 'Home', icon: { svg: '...' } },
+    { id: 'settings', title: 'Settings', icon: { svg: '...' } },
+  ],
+});
+
+await NativeNavigation.addListener('tabSelect', ({ id }) => {
+  router.navigate([`/${id}`]);
+});
+```
+```
+
+Add native page transitions in your app shell:
+
+```typescript
+// app.component.ts
+import { Component, CUSTOM_ELEMENTS_SCHEMA, ElementRef, ViewChild, AfterViewInit } from '@angular/core';
+import { Router } from '@angular/router';
+import '@capgo/capacitor-transitions';
+import { initTransitions, setDirection, setupRouterOutlet } from '@capgo/capacitor-transitions';
+
+initTransitions({ platform: 'auto' });
+
+@Component({
+  selector: 'app-root',
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  template: `
+    <cap-router-outlet #outlet platform="auto" swipe-gesture="auto">
+      <router-outlet></router-outlet>
+    </cap-router-outlet>
+  `,
+})
+export class AppComponent implements AfterViewInit {
+  @ViewChild('outlet') outlet?: ElementRef<HTMLElement>;
+
+  constructor(private router: Router) {}
+
+  ngAfterViewInit() {
+    if (this.outlet?.nativeElement) {
+      setupRouterOutlet(this.outlet.nativeElement, { platform: 'auto', swipeGesture: 'auto' });
+    }
+  }
+
+  openSettings() {
+    setDirection('forward');
+    this.router.navigate(['/settings']);
+  }
+}
+```
+
+Wrap routed pages in `cap-router-outlet`, `cap-page`, and `cap-content`, and call `setDirection('forward')` or `setDirection('back')` before navigating. Do not duplicate web headers or footers when native navigation owns those surfaces.
+
+See the full guides: [Using @capgo/capacitor-native-navigation](/plugins/capacitor-native-navigation/) and [Using @capgo/capacitor-transitions](/plugins/capacitor-transitions/).
+
+### Safe areas with Tailwind
+
+For device safe areas in Tailwind CSS, use [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor) (published as `tailwind-capacitor` on npm). It provides `safe-areas` utilities and other Capacitor-friendly Tailwind plugins:
+
+```shell
+bun add -D tailwind-capacitor
+```
+
+In `src/styles.css`:
+
+```css
+@import 'tailwindcss';
+@plugin "@capgo/tailwind-capacitor/platform";
+@plugin "@capgo/tailwind-capacitor/safe-areas";
+```
+
+Use utilities such as `pt-safe`, `pb-safe`, and `px-safe` instead of sprinkling `env(safe-area-inset-*)` by hand. The project is actively developed — if something is missing for your Angular setup, [open a PR on GitHub](https://github.com/Cap-go/tailwind-capacitor/pulls).
+
+## Fixing iOS Layout Issues (Viewport, Safe Area, and Horizontal Overflow)
+
+If content looks cropped, shifted, or horizontally scrollable on iOS, adding more `overflow-x: hidden` or tweaking the viewport tag alone usually does not fix it. Work through these checks in order.
+
+### Make sure the viewport meta tag is applied correctly
+
+In `src/index.html`, set the viewport meta tag in `<head>`:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+```
+
+### Handle iOS safe area from one root wrapper only
+
+Create a single app shell and apply safe area padding there — not in multiple nested components:
+
+```css
+html,
+body,
+app-root {
+  width: 100%;
+  min-height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app-shell {
+  min-height: 100dvh;
+  width: 100%;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+}
+```
+
+Wrap all page content inside `.app-shell`. Duplicated safe-area padding in headers, modals, and layout wrappers often makes the UI look cropped or too large.
+
+With [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor), you can express the same padding with utilities like `pt-safe pb-safe px-safe` on that single shell.
+
+### Set Capacitor iOS `contentInset` to `never` first
+
+In `capacitor.config.ts`, prefer native inset disabled and let CSS (or Native Navigation's `contentInsetMode: 'css'`) own the safe area:
+
+```typescript
+const config: CapacitorConfig = {
+  appId: 'com.example.myapp',
+  appName: 'my-app',
+  webDir: 'www',
+  ios: {
+    contentInset: 'never',
+  },
+};
+```
+
+Mixing Capacitor's automatic content inset with CSS `env(safe-area-inset-*)` padding is a common cause of double spacing.
+
+### Find the real overflowing element
+
+The usual culprit is an element using `100vw`, Tailwind `w-screen`, a fixed pixel width, or a large `min-width`.
+
+In Safari Web Inspector, run:
 
 ```javascript
-// import konstaConfig config
-const konstaConfig = require('konsta/config')
-
-// wrap config with konstaConfig config
-module.exports = konstaConfig({
-  content: [
-    './src/**/*.{html,ts}',
-  ],
-  darkMode: 'media', // or 'class'
-  theme: {
-    extend: {},
-  },
-  variants: {
-    extend: {},
-  },
-  plugins: [],
-})
+[...document.querySelectorAll('*')]
+  .filter(el => el.scrollWidth > document.documentElement.clientWidth)
+  .map(el => ({
+    el,
+    tag: el.tagName,
+    class: el.className,
+    scrollWidth: el.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
 ```
 
-`konstaConfig` will extend the default (or your custom one) Tailwind CSS config with some extra variants and helper utilities required for Konsta UI.
-
-Now we need to set up the main [App](https://konstaui.com/vue/app/) component so we can set some global parameters (like `theme`).
-
-We need to wrap the whole app with `App` in the `src/app/app.component.html`:
-
-```html
-<app>
-  <h1>Welcome to Angular and Capacitor!</h1>
-  <button (click)="share()">Share now!</button>
-</app>
-```
-
-### Example Page
-
-Now when everything is set up, we can use Konsta UI Vue components in our Angular pages.
-
-For example, let's open `src/app/app.component.html` and change it to the following:
-
-```html
-<app>
-  <page>
-    <navbar title="My App" />
-
-    <block strong>
-      <p>
-        Here is your Angular & Konsta UI app. Let's see what we have here.
-      </p>
-    </block>
-    <block-title>Navigation</block-title>
-    <list>
-      <list-item href="/about/" title="About" />
-      <list-item href="/form/" title="Form" />
-    </list>
-
-    <block strong class="flex space-x-4">
-      <button>Button 1</button>
-      <button>Button 2</button>
-    </block>
-  </page>
-</app>
-```
-
-If the live reload is out of sync after installing all the necessary components, try restarting everything. Once you have done that, you should see a mobile app with a somewhat native look, built with Angular and Capacitor!
-
-You should see the following page as a result:
-
-<div class="mx-auto" style="width: 50%;">
-  <img src="/konsta-next.webp" alt="konsta-angular">
-</div>
+With Tailwind, replace `w-screen` with `w-full` when possible. Many horizontal overflow issues come from `100vw` / `w-screen`, duplicated safe-area padding, or a fixed-width container — not from the viewport meta tag itself.
 
 ## Conclusion
 

--- a/apps/web/src/content/blog/en/building-a-native-mobile-app-with-nextjs-and-capacitor.md
+++ b/apps/web/src/content/blog/en/building-a-native-mobile-app-with-nextjs-and-capacitor.md
@@ -9,7 +9,7 @@ author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2023-02-21T00:00:00.000Z
-updated_at: 2026-06-18T14:21:30.000Z
+updated_at: 2026-06-23T00:00:00.000Z
 head_image: /next_capgo.webp
 head_image_alt: "Convert Your Next.js App to iOS & Android with Capacitor 8 Capgo blog illustration"
 keywords: Next.js 15, Capacitor 8, convert web app to mobile, iOS, Android, mobile app development, static export, native plugins
@@ -30,7 +30,8 @@ Capacitor wraps your web app in a native container, giving you access to device 
 - Add Capacitor 8 with essential native plugins
 - Build and test on iOS and Android simulators
 - Enable live reload for faster development
-- Optionally add Konsta UI for native-looking components
+- Fix common iOS layout issues (viewport, safe area, horizontal overflow)
+- Add native-feeling UI with Capgo Native Navigation and Transitions
 
 > Looking to start a new project from scratch? Check out our guide on [Building a Next.js Mobile App from Scratch](/blog/nextjs-mobile-app-capacitor-from-scratch/).
 
@@ -336,122 +337,176 @@ Now, when you click the "Share now!" button, the native share dialog will appear
 <div class="mx-auto" style="width: 50%;">
   <img src="/next-capacitor-share.webp" alt="next-capacitor-share">
 </div>
+Next, you can make the app feel more native on iOS and Android with Capgo navigation and transitions, and fix common iOS layout issues that cause horizontal overflow or cropped safe areas.
+## Native-feeling UI with Capgo Native Navigation and Transitions
 
-To make the button look more mobile-friendly, we can add some styling using my favorite UI component library for web apps - Next.js (no pun intended). 
+I've worked for years with [Ionic](https://ionicframework.com/) to build cross-platform applications, but integrating it with Next.js is hacky and rarely worth it when you already have [Tailwind CSS 4](https://tailwindcss.com/).
 
-## Adding Konsta UI v5 with Tailwind CSS 4
+For a native mobile feel in a Next.js + Capacitor app, use Capgo plugins instead of web-only UI kits like Konsta UI:
 
-I've worked years with [Ionic](https://ionicframework.com/) to build awesome cross platform applications and it was one of the best choices for years.
-But now i don't recommend it anymore it's very hacky to integrate it with Next.js and it's not really worth it when you have already [Tailwind CSS 4](https://tailwindcss.com/).
+- **[@capgo/capacitor-native-navigation](https://github.com/Cap-go/capacitor-native-navigation)** — native navbar, Liquid Glass tab bar on iOS, and a blurred tab bar style on Android. Your Next.js router keeps route state; the plugin owns the native chrome.
+- **[@capgo/capacitor-transitions](https://github.com/Cap-go/capacitor-transitions)** — Ionic-style page transitions and iOS edge swipe-back in the WebView layer, without adopting Ionic UI.
 
-
-if you want a really great looking mobile UI that adapts to iOS and Android specific styling i recommend Konsta UI v5.
-
-You need to have [Tailwind CSS 4 already installed](https://tailwindcss.com/docs/guides/nextjs/) 
-To enhance the mobile UI of your Next.js app, you can use [Konsta UI v5](https://konstaui.com/), a mobile-friendly UI component library that adapts to iOS and Android styling. Follow these steps to integrate Konsta UI v5:
-
-1. Install the required packages (Konsta UI v5):
+Install both:
 
 ```shell
-bun add konsta
+bun add @capgo/capacitor-native-navigation @capgo/capacitor-transitions
+bunx cap sync
 ```
 
-2. Import Konsta UI theme in your main CSS file (e.g., `styles/globals.css`):
+Configure native navigation with CSS inset mode so web content respects the native bars:
+
+```typescript
+import { NativeNavigation } from '@capgo/capacitor-native-navigation';
+
+await NativeNavigation.configure({
+  contentInsetMode: 'css',
+  animationDuration: 360,
+  glass: {
+    effect: 'liquidGlass',
+  },
+});
+```
+
+Render a Liquid Glass tab bar (iOS uses system-owned rendering; Android uses a blurred WebView backdrop):
+
+```typescript
+await NativeNavigation.setTabbar({
+  selectedId: 'home',
+  labelVisibilityMode: 'labeled',
+  icons: true,
+  colors: { dynamic: true },
+  tabs: [
+    { id: 'home', title: 'Home', icon: { svg: '...' } },
+    { id: 'settings', title: 'Settings', icon: { svg: '...' } },
+  ],
+});
+
+await NativeNavigation.addListener('tabSelect', ({ id }) => {
+  router.push(`/${id}`);
+});
+```
+
+Add native page transitions in your app shell:
+
+```typescript
+import '@capgo/capacitor-transitions';
+import { initTransitions, setDirection, setupRouterOutlet } from '@capgo/capacitor-transitions/react';
+
+initTransitions({ platform: 'auto' });
+```
+
+Wrap routed pages in `cap-router-outlet`, `cap-page`, and `cap-content`, and call `setDirection('forward')` or `setDirection('back')` before `router.push()` or `router.back()`. Do not duplicate web headers or footers when native navigation owns those surfaces.
+
+See the full guides: [Using @capgo/capacitor-native-navigation](/plugins/capacitor-native-navigation/) and [Using @capgo/capacitor-transitions](/plugins/capacitor-transitions/).
+
+### Safe areas with Tailwind
+
+For device safe areas in Tailwind CSS, use [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor) (published as `tailwind-capacitor` on npm). It provides `safe-areas` utilities and other Capacitor-friendly Tailwind plugins:
+
+```shell
+bun add -D tailwind-capacitor
+```
+
+In `styles/globals.css`:
 
 ```css
 @import 'tailwindcss';
-/* import Konsta UI v5 theme */
-@import 'konsta/theme.css';
+@plugin "@capgo/tailwind-capacitor/platform";
+@plugin "@capgo/tailwind-capacitor/safe-areas";
 ```
 
-3. Configure Tailwind CSS 4 for Next.js (PostCSS):
+Use utilities such as `pt-safe`, `pb-safe`, and `px-safe` instead of sprinkling `env(safe-area-inset-*)` by hand. The project is actively developed — if something is missing for your Next.js setup, [open a PR on GitHub](https://github.com/Cap-go/tailwind-capacitor/pulls).
 
-Create `postcss.config.mjs` at the project root:
+## Fixing iOS Layout Issues (Viewport, Safe Area, and Horizontal Overflow)
 
-```js
-export default {
-  plugins: {
-    '@tailwindcss/postcss': {},
+If content looks cropped, shifted, or horizontally scrollable on iOS, adding more `overflow-x: hidden` or tweaking the viewport tag alone usually does not fix it. Work through these checks in order.
+
+### Make sure the viewport meta tag is applied correctly
+
+**App Router** (`app/`): export `viewport` from `app/layout.tsx`:
+
+```typescript
+import type { Viewport } from 'next';
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  viewportFit: 'cover',
+};
+```
+
+**Pages Router** (`pages/`): put the viewport meta tag in `pages/_app.tsx`, not `_document.tsx` (Next.js may not apply tags from `_document.tsx` the way you expect for viewport behavior).
+
+### Handle iOS safe area from one root wrapper only
+
+Create a single app shell and apply safe area padding there — not in multiple nested components:
+
+```css
+html,
+body,
+#__next {
+  width: 100%;
+  min-height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app-shell {
+  min-height: 100dvh;
+  width: 100%;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+}
+```
+
+Wrap all page content inside `.app-shell`. Duplicated safe-area padding in headers, modals, and layout wrappers often makes the UI look cropped or too large.
+
+With [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor), you can express the same padding with utilities like `pt-safe pb-safe px-safe` on that single shell.
+
+### Set Capacitor iOS `contentInset` to `never` first
+
+In `capacitor.config.ts`, prefer native inset disabled and let CSS (or Native Navigation's `contentInsetMode: 'css'`) own the safe area:
+
+```typescript
+const config: CapacitorConfig = {
+  appId: 'com.example.myapp',
+  appName: 'my-app',
+  webDir: 'out',
+  ios: {
+    contentInset: 'never',
   },
-}
+};
 ```
 
-Tailwind v4 uses PostCSS directly in Next.js. Keep your global imports in `styles/globals.css` (already added above).
+Mixing Capacitor's automatic content inset with CSS `env(safe-area-inset-*)` padding is a common cause of double spacing.
 
-4. Wrap your app with the Konsta UI v5 `App` component in `pages/_app.js`:
+### Find the real overflowing element
+
+The usual culprit is an element using `100vw`, Tailwind `w-screen`, a fixed pixel width, or a large `min-width`.
+
+In Safari Web Inspector, run:
 
 ```javascript
-import { App } from 'konsta/react';
-import '../styles/globals.css';
-
-function MyApp({ Component, pageProps }) {
-  return (
-    <App theme="ios">
-      <Component {...pageProps} />
-    </App>
-  );
-}
-
-export default MyApp;
-```
-### Example Page
-
-Now when everything is set up, we can use Konsta UI v5 React components in our Next.js pages.
-
-5. Update the `pages/index.js` file to use Konsta UI v5 components:
-
-```javascript
-import {
-  Page,
-  Navbar,
-  Block,
-  Button,
-  List,
-  ListItem,
-  BlockTitle,
-} from 'konsta/react';
-
-export default function Home() {
-  return (
-    <Page>
-      <Navbar title="My App" />
-
-      <Block strong>
-        <p>
-          Here is your Next.js & Konsta UI app. Let's see what we have here.
-        </p>
-      </Block>
-      <BlockTitle>Navigation</BlockTitle>
-      <List>
-        <ListItem href="/about/" title="About" />
-        <ListItem href="/form/" title="Form" />
-      </List>
-
-      <Block strong className="flex space-x-4">
-        <Button>Button 1</Button>
-        <Button>Button 2</Button>
-      </Block>
-    </Page>
-  );
-}
+[...document.querySelectorAll('*')]
+  .filter(el => el.scrollWidth > document.documentElement.clientWidth)
+  .map(el => ({
+    el,
+    tag: el.tagName,
+    class: el.className,
+    scrollWidth: el.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
 ```
 
-6. Add Roboto font for Material Design theme (required for Konsta UI v5):
-
-In your `pages/_document.js` or main HTML file, add:
-
-```html
-<link rel="preconnect" href="https://fonts.googleapis.com" />
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link
-  href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap"
-  rel="stylesheet"
-/>
-```
-
-7. Restart the development server and rebuild the app.
-
-Your Next.js app should now have a native-looking mobile UI powered by Konsta UI v5 and styled with Tailwind CSS 4.
+With Tailwind, replace `w-screen` with `w-full` when possible. Many horizontal overflow issues come from `100vw` / `w-screen`, duplicated safe-area padding, or a fixed-width container — not from the viewport meta tag itself.
 
 ## Performance Optimization
 
@@ -472,7 +527,8 @@ You've successfully converted your existing Next.js web application into native 
 - Added Capacitor 8 with essential plugins
 - Built and deployed to iOS and Android simulators
 - Enabled live reload for development
-- Optionally added Konsta UI for native-looking components
+- Fixed common iOS layout issues (viewport, safe area, overflow)
+- Added native-feeling UI with Capgo Native Navigation and Transitions
 
 **Next steps:**
 - Set up [Capgo](https://capgo.app/) for over-the-air updates without app store resubmission
@@ -485,8 +541,10 @@ You've successfully converted your existing Next.js web application into native 
 ## Resources
 
 - [Next.js Documentation](https://nextjs.org/docs)
+- [@capgo/capacitor-native-navigation](https://github.com/Cap-go/capacitor-native-navigation/) — Liquid Glass tab bar and native chrome
 - [Capacitor 8 Documentation](https://capacitorjs.com/docs)
-- [Konsta UI v5 Documentation](https://konstaui.com/docs)
+- [@capgo/capacitor-transitions](https://github.com/Cap-go/capacitor-transitions/) — native-feeling page transitions
+- [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor) — Tailwind safe-area utilities for Capacitor
 - [Capgo - Live Updates for Capacitor Apps](https://capgo.app/)
 
 Learn how Capgo can help you build better apps faster, [sign up for a free account](/register/) today.

--- a/apps/web/src/content/blog/en/building-a-native-mobile-app-with-nuxt-and-capacitor.md
+++ b/apps/web/src/content/blog/en/building-a-native-mobile-app-with-nuxt-and-capacitor.md
@@ -9,7 +9,7 @@ author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2023-06-03T00:00:00.000Z
-updated_at: 2026-06-18T14:21:30.000Z
+updated_at: 2026-06-23T00:00:00.000Z
 head_image: /nuxt_capgo.webp
 head_image_alt: "Convert Your Nuxt App to iOS & Android with Capacitor 8 Capgo blog illustration"
 keywords: Nuxt 4, Capacitor 8, convert web app to mobile, iOS, Android, mobile app development, static generation, native plugins, Vue
@@ -30,7 +30,8 @@ Capacitor wraps your web app in a native container, giving you access to device 
 - Add Capacitor 8 with essential native plugins
 - Build and test on iOS and Android simulators
 - Enable live reload for faster development
-- Optionally add Konsta UI for native-looking components
+- Fix common iOS layout issues (viewport, safe area, horizontal overflow)
+- Add native-feeling UI with Capgo Native Navigation and Transitions
 
 > Looking to start a new project from scratch? Check out our guide on [Building a Nuxt Mobile App from Scratch](/blog/nuxt-mobile-app-capacitor-from-scratch/).
 
@@ -321,119 +322,206 @@ bunx cap sync
 
 Now, when you click the "Share now!" button, the native share dialog will appear.
 
-## Adding Konsta UI v5 with Tailwind CSS 4
+Next, you can make the app feel more native on iOS and Android with Capgo navigation and transitions, and fix common iOS layout issues that cause horizontal overflow or cropped safe areas.
 
-To make the button look more mobile-friendly, you can add Konsta UI for native-looking iOS and Android components.
+## Native-feeling UI with Capgo Native Navigation and Transitions
 
-You need to have [Tailwind CSS 4 already installed](https://tailwindcss.com/docs/installation/framework-guides/nuxt).
+I've worked for years with [Ionic](https://ionicframework.com/) to build cross-platform applications, but integrating it with Nuxt is hacky and rarely worth it when you already have [Tailwind CSS](https://tailwindcss.com/).
 
-1. Install the required packages:
+For a native mobile feel in a Nuxt + Capacitor app, use Capgo plugins instead of web-only UI kits like Konsta UI:
+
+- **[@capgo/capacitor-native-navigation](https://github.com/Cap-go/capacitor-native-navigation)** — native navbar, Liquid Glass tab bar on iOS, and a blurred tab bar style on Android. Your Nuxt router keeps route state; the plugin owns the native chrome.
+- **[@capgo/capacitor-transitions](https://github.com/Cap-go/capacitor-transitions)** — Ionic-style page transitions and iOS edge swipe-back in the WebView layer, without adopting Ionic UI.
+
+Install both:
 
 ```shell
-bun add konsta
-bun add tailwindcss @tailwindcss/vite
+bun add @capgo/capacitor-native-navigation @capgo/capacitor-transitions
+bunx cap sync
 ```
 
-2. Configure the Vite plugin in `nuxt.config.ts`:
+Configure native navigation with CSS inset mode so web content respects the native bars:
 
 ```typescript
-import tailwindcss from '@tailwindcss/vite';
+import { NativeNavigation } from '@capgo/capacitor-native-navigation';
 
-export default defineNuxtConfig({
-  compatibilityDate: '2025-01-15',
-  devtools: { enabled: true },
-  css: ['~/assets/css/main.css'],
-  vite: {
-    plugins: [tailwindcss()],
+await NativeNavigation.configure({
+  contentInsetMode: 'css',
+  animationDuration: 360,
+  glass: {
+    effect: 'liquidGlass',
   },
 });
 ```
 
-3. Create `app/assets/css/main.css`:
+Render a Liquid Glass tab bar (iOS uses system-owned rendering; Android uses a blurred WebView backdrop):
+
+```typescript
+await NativeNavigation.setTabbar({
+  selectedId: 'home',
+  labelVisibilityMode: 'labeled',
+  icons: true,
+  colors: { dynamic: true },
+  tabs: [
+    { id: 'home', title: 'Home', icon: { svg: '...' } },
+    { id: 'settings', title: 'Settings', icon: { svg: '...' } },
+  ],
+});
+
+await NativeNavigation.addListener('tabSelect', ({ id }) => {
+  router.push(`/${id}`);
+});
+```
+
+Add native page transitions in your app shell:
+
+```vue
+<script setup>
+import { ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import '@capgo/capacitor-transitions';
+import { initTransitions, setDirection, setupRouterOutlet } from '@capgo/capacitor-transitions/vue';
+
+initTransitions({ platform: 'auto' });
+
+const router = useRouter();
+const outletRef = ref(null);
+
+onMounted(() => {
+  if (outletRef.value) {
+    setupRouterOutlet(outletRef.value, { platform: 'auto', swipeGesture: 'auto' });
+  }
+});
+
+const openSettings = () => {
+  setDirection('forward');
+  router.push('/settings');
+};
+</script>
+
+<template>
+  <cap-router-outlet ref="outletRef">
+    <router-view />
+  </cap-router-outlet>
+</template>
+```
+
+Wrap routed pages in `cap-router-outlet`, `cap-page`, and `cap-content`, and call `setDirection('forward')` or `setDirection('back')` before navigating. Do not duplicate web headers or footers when native navigation owns those surfaces.
+
+See the full guides: [Using @capgo/capacitor-native-navigation](/plugins/capacitor-native-navigation/) and [Using @capgo/capacitor-transitions](/plugins/capacitor-transitions/).
+
+### Safe areas with Tailwind
+
+For device safe areas in Tailwind CSS, use [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor) (published as `tailwind-capacitor` on npm). It provides `safe-areas` utilities and other Capacitor-friendly Tailwind plugins:
+
+```shell
+bun add -D tailwind-capacitor
+```
+
+In `app/assets/css/main.css`:
 
 ```css
 @import 'tailwindcss';
-@import 'konsta/theme.css';
+@plugin "@capgo/tailwind-capacitor/platform";
+@plugin "@capgo/tailwind-capacitor/safe-areas";
 ```
 
-4. Wrap your app with the Konsta UI `App` component in `app/app.vue`:
+For Nuxt 4 with Tailwind CSS 4, keep this import in the CSS file referenced from `nuxt.config.ts`.
 
-```vue
-<template>
-  <App theme="ios">
-    <NuxtPage />
-  </App>
-</template>
+Use utilities such as `pt-safe`, `pb-safe`, and `px-safe` instead of sprinkling `env(safe-area-inset-*)` by hand. The project is actively developed — if something is missing for your Nuxt setup, [open a PR on GitHub](https://github.com/Cap-go/tailwind-capacitor/pulls).
 
-<script setup>
-import { App } from 'konsta/vue';
-</script>
-```
+## Fixing iOS Layout Issues (Viewport, Safe Area, and Horizontal Overflow)
 
-5. Update your page to use Konsta UI components:
+If content looks cropped, shifted, or horizontally scrollable on iOS, adding more `overflow-x: hidden` or tweaking the viewport tag alone usually does not fix it. Work through these checks in order.
 
-```vue
-<template>
-  <Page>
-    <Navbar title="My App" />
+### Make sure the viewport meta tag is applied correctly
 
-    <Block strong>
-      <p>
-        Here is your Nuxt & Konsta UI app. Let's see what we have here.
-      </p>
-    </Block>
-
-    <BlockTitle>Navigation</BlockTitle>
-    <List>
-      <ListItem href="/about/" title="About" />
-      <ListItem href="/form/" title="Form" />
-    </List>
-
-    <Block strong class="flex space-x-4">
-      <Button>Button 1</Button>
-      <Button>Button 2</Button>
-    </Block>
-  </Page>
-</template>
-
-<script setup>
-import {
-  Page,
-  Navbar,
-  Block,
-  Button,
-  List,
-  ListItem,
-  BlockTitle,
-} from 'konsta/vue';
-</script>
-```
-
-6. Add Roboto font for Material Design theme in `nuxt.config.ts`:
+In `nuxt.config.ts`, set the viewport through `app.head`:
 
 ```typescript
 export default defineNuxtConfig({
   app: {
     head: {
-      link: [
-        { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
-        { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' },
+      meta: [
         {
-          rel: 'stylesheet',
-          href: 'https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap',
+          name: 'viewport',
+          content: 'width=device-width, initial-scale=1, viewport-fit=cover',
         },
       ],
     },
   },
-  // ... rest of config
 });
 ```
 
-Your Nuxt app should now have a native-looking mobile UI:
+### Handle iOS safe area from one root wrapper only
 
-<div class="mx-auto" style="width: 50%;">
-  <img src="/konsta-nuxt.webp" alt="konsta-nuxt">
-</div>
+Create a single app shell and apply safe area padding there — not in multiple nested components:
+
+```css
+html,
+body,
+#__nuxt {
+  width: 100%;
+  min-height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app-shell {
+  min-height: 100dvh;
+  width: 100%;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+}
+```
+
+Wrap all page content inside `.app-shell`. Duplicated safe-area padding in headers, modals, and layout wrappers often makes the UI look cropped or too large.
+
+With [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor), you can express the same padding with utilities like `pt-safe pb-safe px-safe` on that single shell.
+
+### Set Capacitor iOS `contentInset` to `never` first
+
+In `capacitor.config.ts`, prefer native inset disabled and let CSS (or Native Navigation's `contentInsetMode: 'css'`) own the safe area:
+
+```typescript
+const config: CapacitorConfig = {
+  appId: 'com.example.myapp',
+  appName: 'my-app',
+  webDir: 'out',
+  ios: {
+    contentInset: 'never',
+  },
+};
+```
+
+Mixing Capacitor's automatic content inset with CSS `env(safe-area-inset-*)` padding is a common cause of double spacing.
+
+### Find the real overflowing element
+
+The usual culprit is an element using `100vw`, Tailwind `w-screen`, a fixed pixel width, or a large `min-width`.
+
+In Safari Web Inspector, run:
+
+```javascript
+[...document.querySelectorAll('*')]
+  .filter(el => el.scrollWidth > document.documentElement.clientWidth)
+  .map(el => ({
+    el,
+    tag: el.tagName,
+    class: el.className,
+    scrollWidth: el.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+```
+
+With Tailwind, replace `w-screen` with `w-full` when possible. Many horizontal overflow issues come from `100vw` / `w-screen`, duplicated safe-area padding, or a fixed-width container — not from the viewport meta tag itself.
 
 ## Conclusion
 
@@ -444,7 +532,8 @@ You've successfully converted your existing Nuxt web application into native iOS
 - Added Capacitor 8 with essential plugins
 - Built and deployed to iOS and Android simulators
 - Enabled live reload for development
-- Optionally added Konsta UI for native-looking components
+- Fixed common iOS layout issues (viewport, safe area, overflow)
+- Added native-feeling UI with Capgo Native Navigation and Transitions
 
 **Next steps:**
 - Set up [Capgo](https://capgo.app/) for over-the-air updates without app store resubmission
@@ -458,7 +547,9 @@ You've successfully converted your existing Nuxt web application into native iOS
 
 - [Nuxt Documentation](https://nuxt.com/docs)
 - [Capacitor 8 Documentation](https://capacitorjs.com/docs)
-- [Konsta UI Vue Documentation](https://konstaui.com/vue)
+- [@capgo/capacitor-native-navigation](https://github.com/Cap-go/capacitor-native-navigation/) — Liquid Glass tab bar and native chrome
+- [@capgo/capacitor-transitions](https://github.com/Cap-go/capacitor-transitions/) — native-feeling page transitions
+- [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor) — Tailwind safe-area utilities for Capacitor
 - [Capgo - Live Updates for Capacitor Apps](https://capgo.app/)
 
 Learn how Capgo can help you build better apps faster, [sign up for a free account](/register/) today.

--- a/apps/web/src/content/blog/en/create-react-mobile-apps-with-capacitor.md
+++ b/apps/web/src/content/blog/en/create-react-mobile-apps-with-capacitor.md
@@ -2,13 +2,12 @@
 slug: create-react-mobile-apps-with-capacitor
 title: Building Mobile Apps with React and Capacitor
 description: >-
-  Learn how to build a mobile app using React, Capacitor, and enhance the native
-  UI with Konsta UI.
+  Learn how to build a mobile app using React, Capacitor, and add Capgo Native Navigation, Transitions, and iOS layout best practices.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2023-02-21T00:00:00.000Z
-updated_at: 2026-06-18T14:21:30.000Z
+updated_at: 2026-06-23T00:00:00.000Z
 head_image: /react_capacitor.webp
 head_image_alt: "Building Mobile Apps with React and Capacitor Capgo blog illustration"
 keywords: React, Capacitor, mobile app development, live updates, OTA updates, continuous integration, mobile app updates
@@ -18,13 +17,13 @@ locale: en
 next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
 ---
 
-In this tutorial, we'll begin with a new [React](https://reactjs.org/) app and transition to native mobile development using Capacitor. Optionally, you can also add [Konsta UI](https://konstaui.com/) for an improved mobile UI with Tailwind CSS.
+In this tutorial, we'll begin with a new [React](https://reactjs.org/) app and transition to native mobile development using Capacitor. You can also add Capgo Native Navigation and Transitions for a native mobile feel, and use tailwind-capacitor for safe areas.
 
 Capacitor allows you to easily convert your React web application into a native mobile app without significant modifications or learning a new skill like React Native.
 
 With just a few simple steps, most React applications can be transformed into mobile apps.
 
-This tutorial will guide you through the process, starting with a new React app and then incorporating Capacitor to move into the realm of native mobile apps. Additionally, you can optionally use [Konsta UI](https://konstaui.com/) to enhance your mobile UI with Tailwind CSS.
+This tutorial will guide you through the process, starting with a new React app and then incorporating Capacitor to move into the realm of native mobile apps. You can also use Capgo Native Navigation, Transitions, and tailwind-capacitor for safe areas.
 
 ## About Capacitor
 
@@ -248,119 +247,189 @@ After hitting the button, you can witness the beautiful native share dialog in a
   <img src="/next-capacitor-share.webp" alt="react-capacitor-share">
 </div>
 
-To make the button look more mobile-friendly, we can add some styling using my favorite UI component library for web apps - React (no pun intended).
+Next, you can make the app feel more native on iOS and Android with Capgo navigation and transitions, and fix common iOS layout issues that cause horizontal overflow or cropped safe areas.
 
-## Adding Konsta UI
+## Native-feeling UI with Capgo Native Navigation and Transitions
 
-I’ve worked years with [Ionic](https://ionicframework.com/) to build awesome cross-platform applications, and it was one of the best choices for years. But now I don't recommend it anymore; it's very hacky to integrate it with React, and it's not really worth it when you have already [tailwindcss](https://tailwindcss.com/).
+I've worked for years with [Ionic](https://ionicframework.com/) to build cross-platform applications, but integrating it with React is hacky and rarely worth it when you already have [Tailwind CSS](https://tailwindcss.com/).
 
-If you want a great-looking mobile UI that adapts to iOS and Android specific styling, I recommend Konsta UI.
+For a native mobile feel in a React + Capacitor app, use Capgo plugins instead of web-only UI kits like Konsta UI:
 
-You need to have [tailwind already install](https://tailwindcss.com/docs/guides/vite/#react) 
+- **[@capgo/capacitor-native-navigation](https://github.com/Cap-go/capacitor-native-navigation)** — native navbar, Liquid Glass tab bar on iOS, and a blurred tab bar style on Android. Your React router keeps route state; the plugin owns the native chrome.
+- **[@capgo/capacitor-transitions](https://github.com/Cap-go/capacitor-transitions)** — Ionic-style page transitions and iOS edge swipe-back in the WebView layer, without adopting Ionic UI.
 
-To use it, we only need to install the package react package:
+Install both:
 
 ```shell
-npm i konsta
+bun add @capgo/capacitor-native-navigation @capgo/capacitor-transitions
+bunx cap sync
 ```
 
-Additionally, you need to modify your `tailwind.config.js` file:
+Configure native navigation with CSS inset mode so web content respects the native bars:
 
-```javascript
-// import konstaConfig config
-const konstaConfig = require('konsta/config')
+```typescript
+import { NativeNavigation } from '@capgo/capacitor-native-navigation';
 
-// wrap config with konstaConfig config
-module.exports = konstaConfig({
-  content: [
-    './src/**/*.{js,ts,javascript,tsx}',
+await NativeNavigation.configure({
+  contentInsetMode: 'css',
+  animationDuration: 360,
+  glass: {
+    effect: 'liquidGlass',
+  },
+});
+```
+
+Render a Liquid Glass tab bar (iOS uses system-owned rendering; Android uses a blurred WebView backdrop):
+
+```typescript
+await NativeNavigation.setTabbar({
+  selectedId: 'home',
+  labelVisibilityMode: 'labeled',
+  icons: true,
+  colors: { dynamic: true },
+  tabs: [
+    { id: 'home', title: 'Home', icon: { svg: '...' } },
+    { id: 'settings', title: 'Settings', icon: { svg: '...' } },
   ],
-  darkMode: 'media', // or 'class'
-  theme: {
-    extend: {},
-  },
-  variants: {
-    extend: {},
-  },
-  plugins: [],
-})
+});
+
+await NativeNavigation.addListener('tabSelect', ({ id }) => {
+  navigate(`/${id}`);
+});
 ```
 
-`konstaConfig` will extend the default (or your custom one) Tailwind CSS config with some extra variants and helper utilities required for Konsta UI.
+Add native page transitions in your app shell:
 
-Now we need to set up the main [App](https://konstaui.com/react/app/) component so we can set some global parameters (like `theme`).
+```tsx
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import '@capgo/capacitor-transitions';
+import { initTransitions, setDirection, setupRouterOutlet } from '@capgo/capacitor-transitions/react';
 
-We need to wrap the whole app with `App` in the `src/App.js`:
+initTransitions({ platform: 'auto' });
 
-```javascript
-import { App } from 'konsta/react';
-import './App.css';
+export function AppShell() {
+  const navigate = useNavigate();
+  const outletRef = useRef<HTMLElement>(null);
 
-function MyApp({ Component, pageProps }) {
-  return (
-    // Wrap our app with App component
-    <App theme="ios">
-      <Component {...pageProps} />
-    </App>
-  );
+  useEffect(() => {
+    if (outletRef.current) {
+      setupRouterOutlet(outletRef.current, { platform: 'auto', swipeGesture: 'auto' });
+    }
+  }, []);
+
+  const openSettings = () => {
+    setDirection('forward');
+    navigate('/settings');
+  };
+
+  return <cap-router-outlet ref={outletRef}>{/* routes */}</cap-router-outlet>;
+}
+```
+
+Wrap routed pages in `cap-router-outlet`, `cap-page`, and `cap-content`, and call `setDirection('forward')` or `setDirection('back')` before navigating. Do not duplicate web headers or footers when native navigation owns those surfaces.
+
+See the full guides: [Using @capgo/capacitor-native-navigation](/plugins/capacitor-native-navigation/) and [Using @capgo/capacitor-transitions](/plugins/capacitor-transitions/).
+
+### Safe areas with Tailwind
+
+For device safe areas in Tailwind CSS, use [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor) (published as `tailwind-capacitor` on npm). It provides `safe-areas` utilities and other Capacitor-friendly Tailwind plugins:
+
+```shell
+bun add -D tailwind-capacitor
+```
+
+In `src/index.css`:
+
+```css
+@import 'tailwindcss';
+@plugin "@capgo/tailwind-capacitor/platform";
+@plugin "@capgo/tailwind-capacitor/safe-areas";
+```
+
+Use utilities such as `pt-safe`, `pb-safe`, and `px-safe` instead of sprinkling `env(safe-area-inset-*)` by hand. The project is actively developed — if something is missing for your React setup, [open a PR on GitHub](https://github.com/Cap-go/tailwind-capacitor/pulls).
+
+## Fixing iOS Layout Issues (Viewport, Safe Area, and Horizontal Overflow)
+
+If content looks cropped, shifted, or horizontally scrollable on iOS, adding more `overflow-x: hidden` or tweaking the viewport tag alone usually does not fix it. Work through these checks in order.
+
+### Make sure the viewport meta tag is applied correctly
+
+Add the viewport meta tag in `index.html` inside `<head>`:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+```
+
+### Handle iOS safe area from one root wrapper only
+
+Create a single app shell and apply safe area padding there — not in multiple nested components:
+
+```css
+html,
+body,
+#root {
+  width: 100%;
+  min-height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
 }
 
-export default MyApp;
-```
-
-### Example Page
-
-Now when everything is set up, we can use Konsta UI React components in our React app.
-
-For example, let's open `src/App.js` and change it to the following:
-
-```javascript
-// Konsta UI components
-import {
-  Page,
-  Navbar,
-  Block,
-  Button,
-  List,
-  ListItem,
-  Link,
-  BlockTitle,
-} from 'konsta/react';
-
-function App() {
-  return (
-    <Page>
-      <Navbar title="My App" />
-
-      <Block strong>
-        <p>
-          Here is your React & Konsta UI app. Let's see what we have here.
-        </p>
-      </Block>
-      <BlockTitle>Navigation</BlockTitle>
-      <List>
-        <ListItem href="/about/" title="About" />
-        <ListItem href="/form/" title="Form" />
-      </List>
-
-      <Block strong className="flex space-x-4">
-        <Button>Button 1</Button>
-        <Button>Button 2</Button>
-      </Block>
-    </Page>
-  );
+* {
+  box-sizing: border-box;
 }
 
-export default App;
+.app-shell {
+  min-height: 100dvh;
+  width: 100%;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+}
 ```
 
-If the live reload is out of sync after installing all the necessary components, try restarting everything. Once you have done that, you should see a mobile app with a somewhat native look, built with React and Capacitor!
+Wrap all page content inside `.app-shell`. Duplicated safe-area padding in headers, modals, and layout wrappers often makes the UI look cropped or too large.
 
-You should see the following page as a result:
+With [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor), you can express the same padding with utilities like `pt-safe pb-safe px-safe` on that single shell.
 
-<div class="mx-auto" style="width: 50%;">
-  <img src="/konsta-next.webp" alt="konsta-react">
-</div>
+### Set Capacitor iOS `contentInset` to `never` first
+
+In `capacitor.config.ts`, prefer native inset disabled and let CSS (or Native Navigation's `contentInsetMode: 'css'`) own the safe area:
+
+```typescript
+const config: CapacitorConfig = {
+  appId: 'com.example.myapp',
+  appName: 'my-app',
+  webDir: 'dist',
+  ios: {
+    contentInset: 'never',
+  },
+};
+```
+
+Mixing Capacitor's automatic content inset with CSS `env(safe-area-inset-*)` padding is a common cause of double spacing.
+
+### Find the real overflowing element
+
+The usual culprit is an element using `100vw`, Tailwind `w-screen`, a fixed pixel width, or a large `min-width`.
+
+In Safari Web Inspector, run:
+
+```javascript
+[...document.querySelectorAll('*')]
+  .filter(el => el.scrollWidth > document.documentElement.clientWidth)
+  .map(el => ({
+    el,
+    tag: el.tagName,
+    class: el.className,
+    scrollWidth: el.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+```
+
+With Tailwind, replace `w-screen` with `w-full` when possible. Many horizontal overflow issues come from `100vw` / `w-screen`, duplicated safe-area padding, or a fixed-width container — not from the viewport meta tag itself.
 
 ## Conclusion
 

--- a/apps/web/src/content/blog/en/creating-mobile-apps-with-react-and-capacitor.md
+++ b/apps/web/src/content/blog/en/creating-mobile-apps-with-react-and-capacitor.md
@@ -3,12 +3,12 @@ slug: creating-mobile-apps-with-react-and-capacitor
 title: Building Mobile Apps with Pure React.js and Capacitor
 description: >-
   A guide on how to transform a React.js web application into a native mobile
-  app utilizing Capacitor, and enhancing the native UI with Konsta UI.
+  app utilizing Capacitor, and adding Capgo Native Navigation, Transitions, and iOS layout best practices.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2023-06-29T00:00:00.000Z
-updated_at: 2026-06-18T14:21:30.000Z
+updated_at: 2026-06-23T00:00:00.000Z
 head_image: /react_capacitor.webp
 head_image_alt: "Building Mobile Apps with Pure React.js and Capacitor Capgo blog illustration"
 keywords: React, Capacitor, mobile app development, live updates, OTA updates, continuous integration, mobile app updates
@@ -18,7 +18,7 @@ locale: en
 next_blog: implementing-live-updates-in-your-react-capacitor-app
 ---
 
-This tutorial will walk you through crafting a mobile application using React, Capacitor, and Konsta UI. By the end, you’ll know how to morph a React.js web app into a native mobile application with Capacitor, and implement a native UI using Konsta UI.
+This tutorial will walk you through crafting a mobile application using React and Capacitor. By the end, you’ll know how to morph a React.js web app into a native mobile application with Capacitor, and add a native feel with Capgo Native Navigation and Transitions.
 
 Capacitor enables the easy transformation of your React.js web app into a native mobile application, requiring no substantial alterations or learning of new strategies such as React Native.
 
@@ -180,96 +180,189 @@ export default ShareButton;
 
 After installing a new plugin, remember to sync your React project again using `npx cap sync`.
 
-## Implementing Konsta UI: Better-looking Mobile UI
+Next, you can make the app feel more native on iOS and Android with Capgo navigation and transitions, and fix common iOS layout issues that cause horizontal overflow or cropped safe areas.
 
-For a better-looking mobile UI experience, we'll use Konsta UI. It provides iOS and Android-specific styling, and it's easy to work with.
+## Native-feeling UI with Capgo Native Navigation and Transitions
 
-To use Konsta UI, install the React package:
+I've worked for years with [Ionic](https://ionicframework.com/) to build cross-platform applications, but integrating it with React is hacky and rarely worth it when you already have [Tailwind CSS](https://tailwindcss.com/).
+
+For a native mobile feel in a React + Capacitor app, use Capgo plugins instead of web-only UI kits like Konsta UI:
+
+- **[@capgo/capacitor-native-navigation](https://github.com/Cap-go/capacitor-native-navigation)** — native navbar, Liquid Glass tab bar on iOS, and a blurred tab bar style on Android. Your React router keeps route state; the plugin owns the native chrome.
+- **[@capgo/capacitor-transitions](https://github.com/Cap-go/capacitor-transitions)** — Ionic-style page transitions and iOS edge swipe-back in the WebView layer, without adopting Ionic UI.
+
+Install both:
 
 ```shell
-npm i konsta
+bun add @capgo/capacitor-native-navigation @capgo/capacitor-transitions
+bunx cap sync
 ```
 
-Modify your `tailwind.config.js` file like so:
+Configure native navigation with CSS inset mode so web content respects the native bars:
 
-```javascript
-// import konstaConfig config
-const konstaConfig = require('konsta/config')
+```typescript
+import { NativeNavigation } from '@capgo/capacitor-native-navigation';
 
-// wrap config with konstaConfig config
-module.exports = konstaConfig({
-  content: [
-    './src/**/*.{js,ts,javascript,tsx}',
+await NativeNavigation.configure({
+  contentInsetMode: 'css',
+  animationDuration: 360,
+  glass: {
+    effect: 'liquidGlass',
+  },
+});
+```
+
+Render a Liquid Glass tab bar (iOS uses system-owned rendering; Android uses a blurred WebView backdrop):
+
+```typescript
+await NativeNavigation.setTabbar({
+  selectedId: 'home',
+  labelVisibilityMode: 'labeled',
+  icons: true,
+  colors: { dynamic: true },
+  tabs: [
+    { id: 'home', title: 'Home', icon: { svg: '...' } },
+    { id: 'settings', title: 'Settings', icon: { svg: '...' } },
   ],
-  darkMode: 'media', // or 'class'
-  theme: {
-    extend: {},
-  },
-  variants: {
-    extend: {},
-  },
-  plugins: [],
-})
+});
+
+await NativeNavigation.addListener('tabSelect', ({ id }) => {
+  navigate(`/${id}`);
+});
 ```
 
-`konstaConfig` will supplement your current Tailwind CSS config with additional variants and utilities necessary for Konsta UI.
+Add native page transitions in your app shell:
 
-Now, set up the primary App component to set global parameters like `theme`. Wrap the main app with App in the `src/index.js`:
+```tsx
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import '@capgo/capacitor-transitions';
+import { initTransitions, setDirection, setupRouterOutlet } from '@capgo/capacitor-transitions/react';
 
-```javascript
-import React from 'react';
-import ReactDOM from 'react-dom';
-import {App} from 'konsta/react';
-import './index.css';
-import MyApp from './App';
+initTransitions({ platform: 'auto' });
 
-ReactDOM.render(
-  <React.StrictMode>
-    <App theme="ios">
-      <MyApp />
-    </App>
-  </React.StrictMode>,
-  document.getElementById('root')
-);
-```
+export function AppShell() {
+  const navigate = useNavigate();
+  const outletRef = useRef<HTMLElement>(null);
 
-Let's use Konsta UI React components in our React.js pages. Open `src/App.js` and modify it to:
+  useEffect(() => {
+    if (outletRef.current) {
+      setupRouterOutlet(outletRef.current, { platform: 'auto', swipeGesture: 'auto' });
+    }
+  }, []);
 
-```javascript
-// Konsta UI components
-import {
-  Page,
-  Navbar,
-  Block,
-  Button,
-  List,
-  ListItem,
-} from 'konsta/react';
+  const openSettings = () => {
+    setDirection('forward');
+    navigate('/settings');
+  };
 
-export default function MyApp() {
-  return (
-    <Page>
-      <Navbar title="My App" />
-
-      <Block strong>
-        <p>
-          Welcome to your React & Konsta UI app.
-        </p>
-      </Block>
-      
-      <List>
-        <ListItem href="/about" title="About" />
-      </List>
-
-      <Block strong>
-        <Button>Click Me</Button>
-      </Block>
-    </Page>
-  );
+  return <cap-router-outlet ref={outletRef}>{/* routes */}</cap-router-outlet>;
 }
 ```
 
-If everything has been done right, you should see effortless integration between React and Konsta UI to give your mobile app a native look.
+Wrap routed pages in `cap-router-outlet`, `cap-page`, and `cap-content`, and call `setDirection('forward')` or `setDirection('back')` before navigating. Do not duplicate web headers or footers when native navigation owns those surfaces.
+
+See the full guides: [Using @capgo/capacitor-native-navigation](/plugins/capacitor-native-navigation/) and [Using @capgo/capacitor-transitions](/plugins/capacitor-transitions/).
+
+### Safe areas with Tailwind
+
+For device safe areas in Tailwind CSS, use [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor) (published as `tailwind-capacitor` on npm). It provides `safe-areas` utilities and other Capacitor-friendly Tailwind plugins:
+
+```shell
+bun add -D tailwind-capacitor
+```
+
+In `src/index.css`:
+
+```css
+@import 'tailwindcss';
+@plugin "@capgo/tailwind-capacitor/platform";
+@plugin "@capgo/tailwind-capacitor/safe-areas";
+```
+
+Use utilities such as `pt-safe`, `pb-safe`, and `px-safe` instead of sprinkling `env(safe-area-inset-*)` by hand. The project is actively developed — if something is missing for your React setup, [open a PR on GitHub](https://github.com/Cap-go/tailwind-capacitor/pulls).
+
+## Fixing iOS Layout Issues (Viewport, Safe Area, and Horizontal Overflow)
+
+If content looks cropped, shifted, or horizontally scrollable on iOS, adding more `overflow-x: hidden` or tweaking the viewport tag alone usually does not fix it. Work through these checks in order.
+
+### Make sure the viewport meta tag is applied correctly
+
+Add the viewport meta tag in `index.html` inside `<head>`:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+```
+
+### Handle iOS safe area from one root wrapper only
+
+Create a single app shell and apply safe area padding there — not in multiple nested components:
+
+```css
+html,
+body,
+#root {
+  width: 100%;
+  min-height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app-shell {
+  min-height: 100dvh;
+  width: 100%;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+}
+```
+
+Wrap all page content inside `.app-shell`. Duplicated safe-area padding in headers, modals, and layout wrappers often makes the UI look cropped or too large.
+
+With [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor), you can express the same padding with utilities like `pt-safe pb-safe px-safe` on that single shell.
+
+### Set Capacitor iOS `contentInset` to `never` first
+
+In `capacitor.config.ts`, prefer native inset disabled and let CSS (or Native Navigation's `contentInsetMode: 'css'`) own the safe area:
+
+```typescript
+const config: CapacitorConfig = {
+  appId: 'com.example.myapp',
+  appName: 'my-app',
+  webDir: 'build',
+  ios: {
+    contentInset: 'never',
+  },
+};
+```
+
+Mixing Capacitor's automatic content inset with CSS `env(safe-area-inset-*)` padding is a common cause of double spacing.
+
+### Find the real overflowing element
+
+The usual culprit is an element using `100vw`, Tailwind `w-screen`, a fixed pixel width, or a large `min-width`.
+
+In Safari Web Inspector, run:
+
+```javascript
+[...document.querySelectorAll('*')]
+  .filter(el => el.scrollWidth > document.documentElement.clientWidth)
+  .map(el => ({
+    el,
+    tag: el.tagName,
+    class: el.className,
+    scrollWidth: el.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+```
+
+With Tailwind, replace `w-screen` with `w-full` when possible. Many horizontal overflow issues come from `100vw` / `w-screen`, duplicated safe-area padding, or a fixed-width container — not from the viewport meta tag itself.
 
 ## Conclusion
 

--- a/apps/web/src/content/blog/en/creating-mobile-apps-with-sveltekit-and-capacitor.md
+++ b/apps/web/src/content/blog/en/creating-mobile-apps-with-sveltekit-and-capacitor.md
@@ -3,12 +3,12 @@ slug: creating-mobile-apps-with-sveltekit-and-capacitor
 title: Building Mobile Apps with SvelteKit and Capacitor
 description: >-
   Learn how to build a mobile app using SvelteKit, Capacitor, and enhance the
-  native UI with Konsta UI.
+  Capgo Native Navigation, Transitions, and iOS layout best practices.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2023-06-04T00:00:00.000Z
-updated_at: 2026-06-18T14:21:30.000Z
+updated_at: 2026-06-23T00:00:00.000Z
 head_image: /sveltekit_capacitor.webp
 head_image_alt: "Building Mobile Apps with SvelteKit and Capacitor Capgo blog illustration"
 keywords: SvelteKit, Capacitor, mobile app development, live updates, OTA updates, continuous integration, mobile app updates
@@ -18,11 +18,11 @@ locale: en
 next_blog: updating-your-capacitor-apps-seamlessly-with-capacitor-updater
 ---
 
-In this tutorial, we'll begin with a new [SvelteKit](https://kit.svelte.dev/) app and transition to native mobile development using Capacitor. Optionally, you can also integrate [Konsta UI](https://konstaui.com/) for an enhanced Tailwind CSS mobile UI.
+In this tutorial, we'll begin with a new [SvelteKit](https://kit.svelte.dev/) app and transition to native mobile development using Capacitor. You can also add Capgo Native Navigation and Transitions for a native mobile feel, and use tailwind-capacitor for safe areas.
 
 Capacitor allows you to easily convert your SvelteKit web application into a native mobile app without the need for significant modifications or learning a new skill like React Native.
 
-Follow this step-by-step guide to transform your SvelteKit app into a mobile app using Capacitor and, if desired, enhance your mobile UI with Konsta UI.
+Follow this step-by-step guide to transform your SvelteKit app into a mobile app using Capacitor, with optional Capgo Native Navigation, Transitions, and iOS layout guidance.
 
 ## About Capacitor
 
@@ -267,101 +267,183 @@ npx cap sync
 
 After hitting the button, you can witness the beautiful native share dialog in action!
 
-## Adding Konsta UI
+Next, you can make the app feel more native on iOS and Android with Capgo navigation and transitions, and fix common iOS layout issues that cause horizontal overflow or cropped safe areas.
 
-To use Konsta UI in your Nuxt 3 app, you need to have [tailwind already install](https://tailwindcss.com/docs/guides/sveltekit/) and to install the package:
+## Native-feeling UI with Capgo Native Navigation and Transitions
+
+I've worked for years with [Ionic](https://ionicframework.com/) to build cross-platform applications, but integrating it with SvelteKit is hacky and rarely worth it when you already have [Tailwind CSS](https://tailwindcss.com/).
+
+For a native mobile feel in a SvelteKit + Capacitor app, use Capgo plugins instead of web-only UI kits like Konsta UI:
+
+- **[@capgo/capacitor-native-navigation](https://github.com/Cap-go/capacitor-native-navigation)** — native navbar, Liquid Glass tab bar on iOS, and a blurred tab bar style on Android. Your SvelteKit router keeps route state; the plugin owns the native chrome.
+- **[@capgo/capacitor-transitions](https://github.com/Cap-go/capacitor-transitions)** — Ionic-style page transitions and iOS edge swipe-back in the WebView layer, without adopting Ionic UI.
+
+Install both:
 
 ```shell
-npm i konsta
+bun add @capgo/capacitor-native-navigation @capgo/capacitor-transitions
+bunx cap sync
 ```
 
-Additionally, you need to modify your `tailwind.config.js` file:
+Configure native navigation with CSS inset mode so web content respects the native bars:
+
+```typescript
+import { NativeNavigation } from '@capgo/capacitor-native-navigation';
+
+await NativeNavigation.configure({
+  contentInsetMode: 'css',
+  animationDuration: 360,
+  glass: {
+    effect: 'liquidGlass',
+  },
+});
+```
+
+Render a Liquid Glass tab bar (iOS uses system-owned rendering; Android uses a blurred WebView backdrop):
+
+```typescript
+await NativeNavigation.setTabbar({
+  selectedId: 'home',
+  labelVisibilityMode: 'labeled',
+  icons: true,
+  colors: { dynamic: true },
+  tabs: [
+    { id: 'home', title: 'Home', icon: { svg: '...' } },
+    { id: 'settings', title: 'Settings', icon: { svg: '...' } },
+  ],
+});
+
+await NativeNavigation.addListener('tabSelect', ({ id }) => {
+  goto(`/${id}`);
+});
+```
+
+Add native page transitions in your app shell:
+
+```svelte
+<script>
+  import { goto } from '$app/navigation';
+  import { routerOutlet, page, setDirection } from '@capgo/capacitor-transitions/svelte';
+  import '@capgo/capacitor-transitions';
+
+  function openSettings() {
+    setDirection('forward');
+    goto('/settings');
+  }
+</script>
+
+<cap-router-outlet use:routerOutlet>
+  <cap-page use:page>
+    <cap-content slot="content">
+      <slot />
+    </cap-content>
+  </cap-page>
+</cap-router-outlet>
+```
+
+Wrap routed pages in `cap-router-outlet`, `cap-page`, and `cap-content`, and call `setDirection('forward')` or `setDirection('back')` before navigating. Do not duplicate web headers or footers when native navigation owns those surfaces.
+
+See the full guides: [Using @capgo/capacitor-native-navigation](/plugins/capacitor-native-navigation/) and [Using @capgo/capacitor-transitions](/plugins/capacitor-transitions/).
+
+### Safe areas with Tailwind
+
+For device safe areas in Tailwind CSS, use [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor) (published as `tailwind-capacitor` on npm). It provides `safe-areas` utilities and other Capacitor-friendly Tailwind plugins:
+
+```shell
+bun add -D tailwind-capacitor
+```
+
+In `src/app.css`:
+
+```css
+@import 'tailwindcss';
+@plugin "@capgo/tailwind-capacitor/platform";
+@plugin "@capgo/tailwind-capacitor/safe-areas";
+```
+
+Use utilities such as `pt-safe`, `pb-safe`, and `px-safe` instead of sprinkling `env(safe-area-inset-*)` by hand. The project is actively developed — if something is missing for your SvelteKit setup, [open a PR on GitHub](https://github.com/Cap-go/tailwind-capacitor/pulls).
+
+## Fixing iOS Layout Issues (Viewport, Safe Area, and Horizontal Overflow)
+
+If content looks cropped, shifted, or horizontally scrollable on iOS, adding more `overflow-x: hidden` or tweaking the viewport tag alone usually does not fix it. Work through these checks in order.
+
+### Make sure the viewport meta tag is applied correctly
+
+In `src/app.html`, set the viewport meta tag in `<head>`:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+```
+
+### Handle iOS safe area from one root wrapper only
+
+Create a single app shell and apply safe area padding there — not in multiple nested components:
+
+```css
+html,
+body,
+body {
+  width: 100%;
+  min-height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app-shell {
+  min-height: 100dvh;
+  width: 100%;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+}
+```
+
+Wrap all page content inside `.app-shell`. Duplicated safe-area padding in headers, modals, and layout wrappers often makes the UI look cropped or too large.
+
+With [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor), you can express the same padding with utilities like `pt-safe pb-safe px-safe` on that single shell.
+
+### Set Capacitor iOS `contentInset` to `never` first
+
+In `capacitor.config.ts`, prefer native inset disabled and let CSS (or Native Navigation's `contentInsetMode: 'css'`) own the safe area:
+
+```typescript
+const config: CapacitorConfig = {
+  appId: 'com.example.myapp',
+  appName: 'my-app',
+  webDir: 'build',
+  ios: {
+    contentInset: 'never',
+  },
+};
+```
+
+Mixing Capacitor's automatic content inset with CSS `env(safe-area-inset-*)` padding is a common cause of double spacing.
+
+### Find the real overflowing element
+
+The usual culprit is an element using `100vw`, Tailwind `w-screen`, a fixed pixel width, or a large `min-width`.
+
+In Safari Web Inspector, run:
 
 ```javascript
-// import konstaConfig config
-const konstaConfig = require('konsta/config')
-
-// wrap config with konstaConfig config
-module.exports = konstaConfig({
-  content: [
-    './src/routes/**/*.{svelte}',
-    './src/components/**/*.{svelte}',
-  ],
-  darkMode: 'media', // or 'class'
-  theme: {
-    extend: {},
-  },
-  variants: {
-    extend: {},
-  },
-  plugins: [],
-})
+[...document.querySelectorAll('*')]
+  .filter(el => el.scrollWidth > document.documentElement.clientWidth)
+  .map(el => ({
+    el,
+    tag: el.tagName,
+    class: el.className,
+    scrollWidth: el.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
 ```
 
-`konstaConfig` will extend the default (or your custom one) Tailwind CSS config with some extra variants and helper utilities required for Konsta UI.
-
-Now we need to set up the main [App](https://konstaui.com/vue/app/) component so we can set some global parameters (like `theme`).
-
-We need to wrap the whole app with `App` in the `src/routes/+layout.svelte`:
-
-```html
-<script>
-  import { App } from 'konsta/svelte';
-</script>
-
-<App theme="ios">
-  <slot />
-</App>
-```
-
-### Example Page
-
-Now when everything is set up, we can use Konsta UI Svelte components in our SvelteKit pages.
-
-For example, let's open `src/routes/index.svelte` and change it to the following:
-
-```html
-<script>
-  import {
-    Page,
-    Navbar,
-    Block,
-    Button,
-    List,
-    ListItem,
-    Link,
-    BlockTitle,
-  } from 'konsta/svelte';
-</script>
-
-<Page>
-  <Navbar title="My App" />
-
-  <Block strong>
-    <p>
-      Here is your SvelteKit & Konsta UI app. Let's see what we have here.
-    </p>
-  </Block>
-  <BlockTitle>Navigation</BlockTitle>
-  <List>
-    <ListItem href="/about/" title="About" />
-    <ListItem href="/form/" title="Form" />
-  </List>
-
-  <Block strong class="flex space-x-4">
-    <Button>Button 1</Button>
-    <Button>Button 2</Button>
-  </Block>
-</Page>
-```
-
-If the live reload is out of sync after installing all the necessary components, try restarting everything. Once you have done that, you should see a mobile app with a somewhat native look, built with SvelteKit and Capacitor!
-
-You should see the following page as a result:
-
-<div class="mx-auto" style="width: 50%;">
-  <img src="/konsta-sveltekit.webp" alt="konsta-sveltekit">
-</div>
+With Tailwind, replace `w-screen` with `w-full` when possible. Many horizontal overflow issues come from `100vw` / `w-screen`, duplicated safe-area padding, or a fixed-width container — not from the viewport meta tag itself.
 
 ## Conclusion
 

--- a/apps/web/src/content/blog/en/nextjs-mobile-app-capacitor-from-scratch.md
+++ b/apps/web/src/content/blog/en/nextjs-mobile-app-capacitor-from-scratch.md
@@ -9,7 +9,7 @@ author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2026-01-15T00:00:00.000Z
-updated_at: 2026-06-18T14:21:30.000Z
+updated_at: 2026-06-23T00:00:00.000Z
 head_image: /next_capgo.webp
 head_image_alt: "Build a Next.js Mobile App from Scratch with Capacitor 8 Capgo blog illustration"
 keywords: Next.js 15, Capacitor 8, mobile app from scratch, iOS development, Android development, React mobile app, native plugins, Tailwind CSS
@@ -430,12 +430,115 @@ You now have a working Next.js mobile app. Here's what to do next:
 - **Push Notifications:** `bun add @capacitor/push-notifications`
 - **File System:** `bun add @capacitor/filesystem`
 
-### UI Enhancement
-Consider adding [Konsta UI](https://konstaui.com/) for native-looking iOS/Android components:
+### Native UI and transitions
+
+Use Capgo plugins instead of Konsta UI for a native mobile feel:
+
+- **[@capgo/capacitor-native-navigation](https://github.com/Cap-go/capacitor-native-navigation)** — Liquid Glass tab bar and native navbar
+- **[@capgo/capacitor-transitions](https://github.com/Cap-go/capacitor-transitions)** — native-feeling page transitions
 
 ```shell
-bun add konsta
+bun add @capgo/capacitor-native-navigation @capgo/capacitor-transitions
+bunx cap sync
 ```
+
+For Tailwind safe areas, add [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor):
+
+```shell
+bun add -D tailwind-capacitor
+```
+
+See [Using @capgo/capacitor-native-navigation](/plugins/capacitor-native-navigation/), [Using @capgo/capacitor-transitions](/plugins/capacitor-transitions/), and the [tailwind-capacitor repo](https://github.com/Cap-go/tailwind-capacitor) for Next.js-specific setup.
+
+## Fixing iOS Layout Issues (Viewport, Safe Area, and Horizontal Overflow)
+
+If content looks cropped, shifted, or horizontally scrollable on iOS, adding more `overflow-x: hidden` or tweaking the viewport tag alone usually does not fix it. Work through these checks in order.
+
+### Make sure the viewport meta tag is applied correctly
+
+**App Router** (`app/`): export `viewport` from `app/layout.tsx`:
+
+```typescript
+import type { Viewport } from 'next';
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  viewportFit: 'cover',
+};
+```
+
+**Pages Router** (`pages/`): put the viewport meta tag in `pages/_app.tsx`, not `_document.tsx`.
+
+### Handle iOS safe area from one root wrapper only
+
+Create a single app shell and apply safe area padding there — not in multiple nested components:
+
+```css
+html,
+body,
+#__next {
+  width: 100%;
+  min-height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app-shell {
+  min-height: 100dvh;
+  width: 100%;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+}
+```
+
+Wrap all page content inside `.app-shell`. Duplicated safe-area padding in headers, modals, and layout wrappers often makes the UI look cropped or too large.
+
+With [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor), you can express the same padding with utilities like `pt-safe pb-safe px-safe` on that single shell.
+
+### Set Capacitor iOS `contentInset` to `never` first
+
+In `capacitor.config.ts`, prefer native inset disabled and let CSS (or Native Navigation's `contentInsetMode: 'css'`) own the safe area:
+
+```typescript
+const config: CapacitorConfig = {
+  appId: 'com.example.myapp',
+  appName: 'my-app',
+  webDir: 'out',
+  ios: {
+    contentInset: 'never',
+  },
+};
+```
+
+Mixing Capacitor's automatic content inset with CSS `env(safe-area-inset-*)` padding is a common cause of double spacing.
+
+### Find the real overflowing element
+
+The usual culprit is an element using `100vw`, Tailwind `w-screen`, a fixed pixel width, or a large `min-width`.
+
+In Safari Web Inspector, run:
+
+```javascript
+[...document.querySelectorAll('*')]
+  .filter(el => el.scrollWidth > document.documentElement.clientWidth)
+  .map(el => ({
+    el,
+    tag: el.tagName,
+    class: el.className,
+    scrollWidth: el.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+```
+
+With Tailwind, replace `w-screen` with `w-full` when possible. Many horizontal overflow issues come from `100vw` / `w-screen`, duplicated safe-area padding, or a fixed-width container — not from the viewport meta tag itself.
 
 ### Over-the-Air Updates
 Set up [Capgo](https://capgo.app/) to push updates without app store resubmission:
@@ -463,7 +566,9 @@ Make sure you ran `bun run mobile` after making changes. For live reload, verify
 - [Capacitor 8 Documentation](https://capacitorjs.com/docs)
 - [Next.js 15 Documentation](https://nextjs.org/docs)
 - [Capgo - Live Updates](https://capgo.app/)
-- [Konsta UI - Mobile UI Components](https://konstaui.com/)
+- [@capgo/capacitor-native-navigation](https://github.com/Cap-go/capacitor-native-navigation/)
+- [@capgo/capacitor-transitions](https://github.com/Cap-go/capacitor-transitions/)
+- [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor)
 
 Ready to ship your app? Learn how Capgo can help you deliver updates faster — [sign up for a free account](/register/) today.
 

--- a/apps/web/src/content/blog/en/nuxt-mobile-app-capacitor-from-scratch.md
+++ b/apps/web/src/content/blog/en/nuxt-mobile-app-capacitor-from-scratch.md
@@ -9,7 +9,7 @@ author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2026-01-15T00:00:00.000Z
-updated_at: 2026-06-18T14:21:30.000Z
+updated_at: 2026-06-23T00:00:00.000Z
 head_image: /nuxt_capgo.webp
 head_image_alt: "Build a Nuxt Mobile App from Scratch with Capacitor 8 Capgo blog illustration"
 keywords: Nuxt 4, Capacitor 8, mobile app from scratch, iOS development, Android development, Vue mobile app, native plugins, Tailwind CSS
@@ -518,19 +518,117 @@ You now have a working Nuxt mobile app. Here's what to do next:
 - **Push Notifications:** `bun add @capacitor/push-notifications`
 - **File System:** `bun add @capacitor/filesystem`
 
-### UI Enhancement
-Consider adding [Konsta UI](https://konstaui.com/) for native-looking iOS/Android components:
+### Native UI and transitions
+
+Use Capgo plugins instead of Konsta UI for a native mobile feel:
+
+- **[@capgo/capacitor-native-navigation](https://github.com/Cap-go/capacitor-native-navigation)** — Liquid Glass tab bar and native navbar
+- **[@capgo/capacitor-transitions](https://github.com/Cap-go/capacitor-transitions)** — native-feeling page transitions
 
 ```shell
-bun add konsta
+bun add @capgo/capacitor-native-navigation @capgo/capacitor-transitions
+bunx cap sync
 ```
 
-Then update your CSS to import the theme:
+For Tailwind safe areas, add [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor):
+
+```shell
+bun add -D tailwind-capacitor
+```
+
+See [Using @capgo/capacitor-native-navigation](/plugins/capacitor-native-navigation/), [Using @capgo/capacitor-transitions](/plugins/capacitor-transitions/), and the [tailwind-capacitor repo](https://github.com/Cap-go/tailwind-capacitor) for Nuxt-specific setup.
+## Fixing iOS Layout Issues (Viewport, Safe Area, and Horizontal Overflow)
+
+If content looks cropped, shifted, or horizontally scrollable on iOS, adding more `overflow-x: hidden` or tweaking the viewport tag alone usually does not fix it. Work through these checks in order.
+
+### Make sure the viewport meta tag is applied correctly
+
+In `nuxt.config.ts`, set the viewport through `app.head`:
+
+```typescript
+export default defineNuxtConfig({
+  app: {
+    head: {
+      meta: [
+        {
+          name: 'viewport',
+          content: 'width=device-width, initial-scale=1, viewport-fit=cover',
+        },
+      ],
+    },
+  },
+});
+```
+
+### Handle iOS safe area from one root wrapper only
+
+Create a single app shell and apply safe area padding there — not in multiple nested components:
 
 ```css
-@import 'tailwindcss';
-@import 'konsta/theme.css';
+html,
+body,
+#__nuxt {
+  width: 100%;
+  min-height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app-shell {
+  min-height: 100dvh;
+  width: 100%;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+}
 ```
+
+Wrap all page content inside `.app-shell`. Duplicated safe-area padding in headers, modals, and layout wrappers often makes the UI look cropped or too large.
+
+With [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor), you can express the same padding with utilities like `pt-safe pb-safe px-safe` on that single shell.
+
+### Set Capacitor iOS `contentInset` to `never` first
+
+In `capacitor.config.ts`, prefer native inset disabled and let CSS (or Native Navigation's `contentInsetMode: 'css'`) own the safe area:
+
+```typescript
+const config: CapacitorConfig = {
+  appId: 'com.example.myapp',
+  appName: 'my-app',
+  webDir: '.output/public',
+  ios: {
+    contentInset: 'never',
+  },
+};
+```
+
+Mixing Capacitor's automatic content inset with CSS `env(safe-area-inset-*)` padding is a common cause of double spacing.
+
+### Find the real overflowing element
+
+The usual culprit is an element using `100vw`, Tailwind `w-screen`, a fixed pixel width, or a large `min-width`.
+
+In Safari Web Inspector, run:
+
+```javascript
+[...document.querySelectorAll('*')]
+  .filter(el => el.scrollWidth > document.documentElement.clientWidth)
+  .map(el => ({
+    el,
+    tag: el.tagName,
+    class: el.className,
+    scrollWidth: el.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+```
+
+With Tailwind, replace `w-screen` with `w-full` when possible. Many horizontal overflow issues come from `100vw` / `w-screen`, duplicated safe-area padding, or a fixed-width container — not from the viewport meta tag itself.
 
 ### Over-the-Air Updates
 Set up [Capgo](https://capgo.app/) to push updates without app store resubmission:
@@ -561,7 +659,9 @@ Make sure you configured `nitro: { preset: 'static' }` in `nuxt.config.ts` and r
 - [Capacitor 8 Documentation](https://capacitorjs.com/docs)
 - [Nuxt 4 Documentation](https://nuxt.com/docs)
 - [Capgo - Live Updates](https://capgo.app/)
-- [Konsta UI - Mobile UI Components](https://konstaui.com/)
+- [@capgo/capacitor-native-navigation](https://github.com/Cap-go/capacitor-native-navigation/)
+- [@capgo/capacitor-transitions](https://github.com/Cap-go/capacitor-transitions/)
+- [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor)
 
 Ready to ship your app? Learn how Capgo can help you deliver updates faster — [sign up for a free account](/register/) today.
 

--- a/apps/web/src/content/blog/en/quasar-mobile-app-capacitor.md
+++ b/apps/web/src/content/blog/en/quasar-mobile-app-capacitor.md
@@ -6,7 +6,7 @@ author: Anik Dhabal Babu
 author_image_url: 'https://avatars.githubusercontent.com/u/81948346?v=4'
 author_url: 'https://x.com/anikDhabal'
 created_at: 2023-09-14T00:00:00.000Z
-updated_at: 2026-06-18T14:21:30.000Z
+updated_at: 2026-06-23T00:00:00.000Z
 head_image: /quasar_capgo.webp
 head_image_alt: "'Creating Mobile Apps with live updates, Quasar and Capacitor.' Capgo blog illustration"
 keywords: Quasar, Capacitor, mobile app development, live updates, OTA updates, continuous integration, mobile app updates
@@ -262,100 +262,193 @@ npx cap sync
 
 After hitting the button, you can witness the beautiful native share dialog in action!
 
-## Optionally Adding Konsta UI
+Next, you can make the app feel more native on iOS and Android with Capgo navigation and transitions, and fix common iOS layout issues that cause horizontal overflow or cropped safe areas.
 
-To use Konsta UI in your Quasar app, you need to have [tailwind already install](https://tailwindcss.com/docs/installation/) and to install the package:
+## Native-feeling UI with Capgo Native Navigation and Transitions
+
+I've worked for years with [Ionic](https://ionicframework.com/) to build cross-platform applications, but integrating it with Quasar is hacky and rarely worth it when you already have [Tailwind CSS](https://tailwindcss.com/).
+
+For a native mobile feel in a Quasar + Capacitor app, use Capgo plugins instead of web-only UI kits like Konsta UI:
+
+- **[@capgo/capacitor-native-navigation](https://github.com/Cap-go/capacitor-native-navigation)** — native navbar, Liquid Glass tab bar on iOS, and a blurred tab bar style on Android. Your Quasar router keeps route state; the plugin owns the native chrome.
+- **[@capgo/capacitor-transitions](https://github.com/Cap-go/capacitor-transitions)** — Ionic-style page transitions and iOS edge swipe-back in the WebView layer, without adopting Ionic UI.
+
+Install both:
 
 ```shell
-npm i konsta
+npm add @capgo/capacitor-native-navigation @capgo/capacitor-transitions
+npmx cap sync
 ```
 
-Additionally, you need to modify your `tailwind.config.js` file:
+Configure native navigation with CSS inset mode so web content respects the native bars:
+
+```typescript
+import { NativeNavigation } from '@capgo/capacitor-native-navigation';
+
+await NativeNavigation.configure({
+  contentInsetMode: 'css',
+  animationDuration: 360,
+  glass: {
+    effect: 'liquidGlass',
+  },
+});
+```
+
+Render a Liquid Glass tab bar (iOS uses system-owned rendering; Android uses a blurred WebView backdrop):
+
+```typescript
+await NativeNavigation.setTabbar({
+  selectedId: 'home',
+  labelVisibilityMode: 'labeled',
+  icons: true,
+  colors: { dynamic: true },
+  tabs: [
+    { id: 'home', title: 'Home', icon: { svg: '...' } },
+    { id: 'settings', title: 'Settings', icon: { svg: '...' } },
+  ],
+});
+
+await NativeNavigation.addListener('tabSelect', ({ id }) => {
+  router.push(`/${id}`);
+});
+```
+
+Add native page transitions in your app shell:
+
+```vue
+<script setup>
+import { ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import '@capgo/capacitor-transitions';
+import { initTransitions, setDirection, setupRouterOutlet } from '@capgo/capacitor-transitions/vue';
+
+initTransitions({ platform: 'auto' });
+
+const router = useRouter();
+const outletRef = ref(null);
+
+onMounted(() => {
+  if (outletRef.value) {
+    setupRouterOutlet(outletRef.value, { platform: 'auto', swipeGesture: 'auto' });
+  }
+});
+
+const openSettings = () => {
+  setDirection('forward');
+  router.push('/settings');
+};
+</script>
+
+<template>
+  <cap-router-outlet ref="outletRef">
+    <router-view />
+  </cap-router-outlet>
+</template>
+```
+
+Wrap routed pages in `cap-router-outlet`, `cap-page`, and `cap-content`, and call `setDirection('forward')` or `setDirection('back')` before navigating. Do not duplicate web headers or footers when native navigation owns those surfaces.
+
+See the full guides: [Using @capgo/capacitor-native-navigation](/plugins/capacitor-native-navigation/) and [Using @capgo/capacitor-transitions](/plugins/capacitor-transitions/).
+
+### Safe areas with Tailwind
+
+For device safe areas in Tailwind CSS, use [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor) (published as `tailwind-capacitor` on npm). It provides `safe-areas` utilities and other Capacitor-friendly Tailwind plugins:
+
+```shell
+npm add -D tailwind-capacitor
+```
+
+In `src/css/app.scss`:
+
+```css
+@import 'tailwindcss';
+@plugin "@capgo/tailwind-capacitor/platform";
+@plugin "@capgo/tailwind-capacitor/safe-areas";
+```
+
+Use utilities such as `pt-safe`, `pb-safe`, and `px-safe` instead of sprinkling `env(safe-area-inset-*)` by hand. The project is actively developed — if something is missing for your Quasar setup, [open a PR on GitHub](https://github.com/Cap-go/tailwind-capacitor/pulls).
+
+## Fixing iOS Layout Issues (Viewport, Safe Area, and Horizontal Overflow)
+
+If content looks cropped, shifted, or horizontally scrollable on iOS, adding more `overflow-x: hidden` or tweaking the viewport tag alone usually does not fix it. Work through these checks in order.
+
+### Make sure the viewport meta tag is applied correctly
+
+In `index.html` (or your Quasar HTML template), set the viewport meta tag in `<head>`:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+```
+
+### Handle iOS safe area from one root wrapper only
+
+Create a single app shell and apply safe area padding there — not in multiple nested components:
+
+```css
+html,
+body,
+#q-app {
+  width: 100%;
+  min-height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app-shell {
+  min-height: 100dvh;
+  width: 100%;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+}
+```
+
+Wrap all page content inside `.app-shell`. Duplicated safe-area padding in headers, modals, and layout wrappers often makes the UI look cropped or too large.
+
+With [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor), you can express the same padding with utilities like `pt-safe pb-safe px-safe` on that single shell.
+
+### Set Capacitor iOS `contentInset` to `never` first
+
+In `capacitor.config.ts`, prefer native inset disabled and let CSS (or Native Navigation's `contentInsetMode: 'css'`) own the safe area:
+
+```typescript
+const config: CapacitorConfig = {
+  appId: 'com.example.myapp',
+  appName: 'my-app',
+  webDir: 'dist/spa',
+  ios: {
+    contentInset: 'never',
+  },
+};
+```
+
+Mixing Capacitor's automatic content inset with CSS `env(safe-area-inset-*)` padding is a common cause of double spacing.
+
+### Find the real overflowing element
+
+The usual culprit is an element using `100vw`, Tailwind `w-screen`, a fixed pixel width, or a large `min-width`.
+
+In Safari Web Inspector, run:
 
 ```javascript
-// import konstaConfig config
-const konstaConfig = require('konsta/config')
-
-// wrap config with konstaConfig config
-module.exports = konstaConfig({
-  content: [
-    './pages/**/*.{vue}',
-    './components/**/*.{vue}',
-  ],
-  darkMode: 'media', // or 'class'
-  theme: {
-    extend: {},
-  },
-  variants: {
-    extend: {},
-  },
-  plugins: [],
-})
+[...document.querySelectorAll('*')]
+  .filter(el => el.scrollWidth > document.documentElement.clientWidth)
+  .map(el => ({
+    el,
+    tag: el.tagName,
+    class: el.className,
+    scrollWidth: el.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
 ```
 
-`konstaConfig` will extend the default (or your custom one) Tailwind CSS config with some extra variants and helper utilities required for Konsta UI.
-
-Now we need to set up the main [App](https://konstaui.com/vue/app/) component so we can set some global parameters (like `theme`).
-
-We need to wrap the whole app with `App` in the `pages/_app.vue`:
-
-```html
-<template>
-  <App theme="ios">
-    <Quasar />
-  </App>
-</template>
-
-<script setup>
-import { App } from 'konsta/vue';
-</script>
-```
-
-### Example Page
-
-Now when everything is set up, we can use Konsta UI Vue components in our Quasar pages.
-
-For example, let's open `pages/index.vue` and change it to the following:
-
-```html
-<template>
-  <Page>
-    <Navbar title="My App" />
-
-    <Block strong>
-      <p>
-        Here is your Quasar & Konsta UI app. Let's see what we have here.
-      </p>
-    </Block>
-    <BlockTitle>Navigation</BlockTitle>
-    <List>
-      <ListItem href="/about/" title="About" />
-      <ListItem href="/form/" title="Form" />
-    </List>
-
-    <Block strong class="flex space-x-4">
-      <Button>Button 1</Button>
-      <Button>Button 2</Button>
-    </Block>
-  </Page>
-</template>
-
-<script setup>
-import {
-  Page,
-  Navbar,
-  Block,
-  Button,
-  List,
-  ListItem,
-  Link,
-  BlockTitle,
-} from 'konsta/vue';
-</script>
-```
-
-If the live reload is out of sync after installing all the necessary components, try restarting everything. Once you have done that, you should see a mobile app with a somewhat native look, built with Quasar and Capacitor!
-
+With Tailwind, replace `w-screen` with `w-full` when possible. Many horizontal overflow issues come from `100vw` / `w-screen`, duplicated safe-area padding, or a fixed-width container — not from the viewport meta tag itself.
 
 ## Conclusion
 

--- a/apps/web/src/content/blog/en/vue-mobile-app-capacitor.md
+++ b/apps/web/src/content/blog/en/vue-mobile-app-capacitor.md
@@ -3,12 +3,12 @@ slug: vue-mobile-app-capacitor
 title: Building Mobile Apps with Vue and Capacitor
 description: >-
   Learn how to create a mobile app using Vue, Capacitor, and optionally enhance
-  the UI with Konsta UI.
+  Capgo Native Navigation, Transitions, and iOS layout best practices.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2023-06-08T00:00:00.000Z
-updated_at: 2026-06-18T14:21:30.000Z
+updated_at: 2026-06-23T00:00:00.000Z
 head_image: /vue_capacitor.webp
 head_image_alt: "Building Mobile Apps with Vue and Capacitor Capgo blog illustration"
 keywords: Vue, Capacitor, mobile app development, live updates, OTA updates, continuous integration, mobile app updates
@@ -18,7 +18,7 @@ locale: en
 next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
 ---
 
-In this tutorial, we'll guide you through the process of converting a Vue web application into a native mobile app using Capacitor. Optionally, you can also enhance your mobile UI with Konsta UI, a Tailwind CSS-based mobile UI library.
+In this tutorial, we'll guide you through the process of converting a Vue web application into a native mobile app using Capacitor. You can also add Capgo Native Navigation and Transitions for a native mobile feel, and use tailwind-capacitor for safe areas.
 
 ## About Capacitor
 
@@ -173,16 +173,193 @@ After installing new plugins, run the `sync` command and redeploy the app to you
 npx cap sync
 ```
 
-## Adding Konsta UI
+Next, you can make the app feel more native on iOS and Android with Capgo navigation and transitions, and fix common iOS layout issues that cause horizontal overflow or cropped safe areas.
 
-To use Konsta UI in your Vue app, you need to have [tailwind already install](https://tailwindcss.com/docs/guides/vite/#vue) and to install the package:
-To use Konsta UI in your Vue app, install the package and modify your `tailwind.config.js` file:
+## Native-feeling UI with Capgo Native Navigation and Transitions
+
+I've worked for years with [Ionic](https://ionicframework.com/) to build cross-platform applications, but integrating it with Vue is hacky and rarely worth it when you already have [Tailwind CSS](https://tailwindcss.com/).
+
+For a native mobile feel in a Vue + Capacitor app, use Capgo plugins instead of web-only UI kits like Konsta UI:
+
+- **[@capgo/capacitor-native-navigation](https://github.com/Cap-go/capacitor-native-navigation)** — native navbar, Liquid Glass tab bar on iOS, and a blurred tab bar style on Android. Your Vue router keeps route state; the plugin owns the native chrome.
+- **[@capgo/capacitor-transitions](https://github.com/Cap-go/capacitor-transitions)** — Ionic-style page transitions and iOS edge swipe-back in the WebView layer, without adopting Ionic UI.
+
+Install both:
 
 ```shell
-npm i konsta
+bun add @capgo/capacitor-native-navigation @capgo/capacitor-transitions
+bunx cap sync
 ```
 
-Wrap your app with the `App` component in the `pages/_app.vue` file, and use Konsta UI Vue components in your Vue pages.
+Configure native navigation with CSS inset mode so web content respects the native bars:
+
+```typescript
+import { NativeNavigation } from '@capgo/capacitor-native-navigation';
+
+await NativeNavigation.configure({
+  contentInsetMode: 'css',
+  animationDuration: 360,
+  glass: {
+    effect: 'liquidGlass',
+  },
+});
+```
+
+Render a Liquid Glass tab bar (iOS uses system-owned rendering; Android uses a blurred WebView backdrop):
+
+```typescript
+await NativeNavigation.setTabbar({
+  selectedId: 'home',
+  labelVisibilityMode: 'labeled',
+  icons: true,
+  colors: { dynamic: true },
+  tabs: [
+    { id: 'home', title: 'Home', icon: { svg: '...' } },
+    { id: 'settings', title: 'Settings', icon: { svg: '...' } },
+  ],
+});
+
+await NativeNavigation.addListener('tabSelect', ({ id }) => {
+  router.push(`/${id}`);
+});
+```
+
+Add native page transitions in your app shell:
+
+```vue
+<script setup>
+import { ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import '@capgo/capacitor-transitions';
+import { initTransitions, setDirection, setupRouterOutlet } from '@capgo/capacitor-transitions/vue';
+
+initTransitions({ platform: 'auto' });
+
+const router = useRouter();
+const outletRef = ref(null);
+
+onMounted(() => {
+  if (outletRef.value) {
+    setupRouterOutlet(outletRef.value, { platform: 'auto', swipeGesture: 'auto' });
+  }
+});
+
+const openSettings = () => {
+  setDirection('forward');
+  router.push('/settings');
+};
+</script>
+
+<template>
+  <cap-router-outlet ref="outletRef">
+    <router-view />
+  </cap-router-outlet>
+</template>
+```
+
+Wrap routed pages in `cap-router-outlet`, `cap-page`, and `cap-content`, and call `setDirection('forward')` or `setDirection('back')` before navigating. Do not duplicate web headers or footers when native navigation owns those surfaces.
+
+See the full guides: [Using @capgo/capacitor-native-navigation](/plugins/capacitor-native-navigation/) and [Using @capgo/capacitor-transitions](/plugins/capacitor-transitions/).
+
+### Safe areas with Tailwind
+
+For device safe areas in Tailwind CSS, use [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor) (published as `tailwind-capacitor` on npm). It provides `safe-areas` utilities and other Capacitor-friendly Tailwind plugins:
+
+```shell
+bun add -D tailwind-capacitor
+```
+
+In `src/assets/main.css`:
+
+```css
+@import 'tailwindcss';
+@plugin "@capgo/tailwind-capacitor/platform";
+@plugin "@capgo/tailwind-capacitor/safe-areas";
+```
+
+Use utilities such as `pt-safe`, `pb-safe`, and `px-safe` instead of sprinkling `env(safe-area-inset-*)` by hand. The project is actively developed — if something is missing for your Vue setup, [open a PR on GitHub](https://github.com/Cap-go/tailwind-capacitor/pulls).
+
+## Fixing iOS Layout Issues (Viewport, Safe Area, and Horizontal Overflow)
+
+If content looks cropped, shifted, or horizontally scrollable on iOS, adding more `overflow-x: hidden` or tweaking the viewport tag alone usually does not fix it. Work through these checks in order.
+
+### Make sure the viewport meta tag is applied correctly
+
+Add the viewport meta tag in `index.html` inside `<head>`:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+```
+
+### Handle iOS safe area from one root wrapper only
+
+Create a single app shell and apply safe area padding there — not in multiple nested components:
+
+```css
+html,
+body,
+#app {
+  width: 100%;
+  min-height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.app-shell {
+  min-height: 100dvh;
+  width: 100%;
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+}
+```
+
+Wrap all page content inside `.app-shell`. Duplicated safe-area padding in headers, modals, and layout wrappers often makes the UI look cropped or too large.
+
+With [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor), you can express the same padding with utilities like `pt-safe pb-safe px-safe` on that single shell.
+
+### Set Capacitor iOS `contentInset` to `never` first
+
+In `capacitor.config.ts`, prefer native inset disabled and let CSS (or Native Navigation's `contentInsetMode: 'css'`) own the safe area:
+
+```typescript
+const config: CapacitorConfig = {
+  appId: 'com.example.myapp',
+  appName: 'my-app',
+  webDir: 'dist',
+  ios: {
+    contentInset: 'never',
+  },
+};
+```
+
+Mixing Capacitor's automatic content inset with CSS `env(safe-area-inset-*)` padding is a common cause of double spacing.
+
+### Find the real overflowing element
+
+The usual culprit is an element using `100vw`, Tailwind `w-screen`, a fixed pixel width, or a large `min-width`.
+
+In Safari Web Inspector, run:
+
+```javascript
+[...document.querySelectorAll('*')]
+  .filter(el => el.scrollWidth > document.documentElement.clientWidth)
+  .map(el => ({
+    el,
+    tag: el.tagName,
+    class: el.className,
+    scrollWidth: el.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+```
+
+With Tailwind, replace `w-screen` with `w-full` when possible. Many horizontal overflow issues come from `100vw` / `w-screen`, duplicated safe-area padding, or a fixed-width container — not from the viewport meta tag itself.
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary
- Replace Konsta UI recommendations in the Next.js + Capacitor article with Capgo Native Navigation (Liquid Glass tab bar), Capacitor Transitions, and tailwind-capacitor for safe areas
- Add a troubleshooting section for common iOS layout issues: viewport setup (App Router vs Pages Router), single app-shell safe-area wrapper, `ios.contentInset: 'never'`, and finding overflowing elements (`100vw` / `w-screen`)

## Test plan
- [ ] Review rendered blog post at `/blog/building-a-native-mobile-app-with-nextjs-and-capacitor/`
- [ ] Verify internal links to plugin tutorials and tailwind-capacitor GitHub resolve correctly
- [ ] Confirm Konsta UI references are removed except as a contrast ("instead of Konsta UI")


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed the mobile app blog posts (Next.js, Angular, Nuxt, React, SvelteKit, Quasar, Vue) to align with the Capacitor 8 + Capgo workflow.
  * Replaced Konsta UI guidance with setup instructions for Capgo native navigation and transitions, including tab bar/page transition wiring and safe-area handling via `tailwind-capacitor`.
  * Added/expanded step-by-step troubleshooting for iOS layout issues (viewport, safe areas, and horizontal overflow).
  * Updated learning objectives, metadata timestamps, and resource links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->