### PR TITLE
Add founder video messages to Capgo product pages

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -11,6 +11,7 @@ extend-exclude = [
     "src/components/**",
     "apps/web/src/components/**",
     "apps/docs/src/components/**",
+    "apps/web/src/config/productVideos.ts",
     "public/",
     "apps/web/public/",
     "apps/docs/public/",
@@ -45,6 +46,7 @@ youre = "youre"  # Legacy copy key kept for runtime compatibility
 
 # OpenSSL command flags
 passin = "passin"  # OpenSSL password input flag
+
 
 [default.extend-identifiers]
 # Keep "PNGs" whole; otherwise typos splits it into "PN" + "Gs" and flags "PN" -> "ON"

--- a/apps/web/src/components/ProductVideoSection.astro
+++ b/apps/web/src/components/ProductVideoSection.astro
@@ -21,7 +21,7 @@ const {
   accent = 'blue',
 } = Astro.props
 const src = `https://www.youtube-nocookie.com/embed/${youtubeId}`
-const iframeTitle = `${title} — video message from ${productVideoFounder.name}, Capgo founder`
+const iframeTitle = `${title} — video message from Martin, Capgo founder`
 const isBuilder = variant === 'builder'
 const isLight = variant === 'light'
 ---

--- a/apps/web/src/components/ProductVideoSection.astro
+++ b/apps/web/src/components/ProductVideoSection.astro
@@ -1,15 +1,27 @@
 ---
+import { productVideoFounder } from '@/config/productVideos'
+
 interface Props {
   youtubeId: string
   title: string
   description?: string
   eyebrow?: string
+  attribution?: string
   variant?: 'builder' | 'dark' | 'gray' | 'light'
   accent?: 'blue' | 'green' | 'cyan'
 }
 
-const { youtubeId, title, description, eyebrow = 'Watch demo', variant = 'dark', accent = 'blue' } = Astro.props
+const {
+  youtubeId,
+  title,
+  description,
+  eyebrow = productVideoFounder.eyebrow,
+  attribution = `${productVideoFounder.name}, ${productVideoFounder.role}`,
+  variant = 'dark',
+  accent = 'blue',
+} = Astro.props
 const src = `https://www.youtube-nocookie.com/embed/${youtubeId}`
+const iframeTitle = `${title} — video message from ${productVideoFounder.name}, Capgo founder`
 const isBuilder = variant === 'builder'
 const isLight = variant === 'light'
 ---
@@ -22,12 +34,13 @@ const isLight = variant === 'light'
           <div class={`eyebrow eyebrow--${accent}`}>{eyebrow}</div>
           <h2 class="h2-section">{title}</h2>
           {description && <p class="lead">{description}</p>}
+          <p class="product-video-attribution">{attribution}</p>
         </div>
 
         <div class="product-video-frame">
           <iframe
             src={src}
-            title={title}
+            title={iframeTitle}
             class="product-video-iframe"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
@@ -54,6 +67,7 @@ const isLight = variant === 'light'
           {description && (
             <p class:list={['mt-5 text-base leading-7 text-pretty', isLight ? 'text-slate-600' : variant === 'gray' ? 'text-gray-300' : 'text-slate-300']}>{description}</p>
           )}
+          <p class:list={['mt-4 text-sm', isLight ? 'text-slate-500' : variant === 'gray' ? 'text-gray-400' : 'text-slate-400']}>{attribution}</p>
         </div>
 
         <div
@@ -65,7 +79,7 @@ const isLight = variant === 'light'
           <div class="aspect-video w-full">
             <iframe
               src={src}
-              title={title}
+              title={iframeTitle}
               class="h-full w-full"
               loading="lazy"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
@@ -88,6 +102,12 @@ const isLight = variant === 'light'
     background: #000;
     box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
     aspect-ratio: 16 / 9;
+  }
+
+  .product-video .product-video-attribution {
+    margin-top: 16px;
+    font-size: 14px;
+    color: rgba(255, 255, 255, 0.45);
   }
 
   .product-video .product-video-iframe {

--- a/apps/web/src/components/ProductVideoSection.astro
+++ b/apps/web/src/components/ProductVideoSection.astro
@@ -1,0 +1,99 @@
+---
+interface Props {
+  youtubeId: string
+  title: string
+  description?: string
+  eyebrow?: string
+  variant?: 'builder' | 'dark' | 'gray' | 'light'
+  accent?: 'blue' | 'green' | 'cyan'
+}
+
+const { youtubeId, title, description, eyebrow = 'Watch demo', variant = 'dark', accent = 'blue' } = Astro.props
+const src = `https://www.youtube-nocookie.com/embed/${youtubeId}`
+const isBuilder = variant === 'builder'
+const isLight = variant === 'light'
+---
+
+{
+  isBuilder ? (
+    <section class="section product-video" id="product-video">
+      <div class="shell">
+        <div class="section-head section-head--narrow">
+          <div class={`eyebrow eyebrow--${accent}`}>{eyebrow}</div>
+          <h2 class="h2-section">{title}</h2>
+          {description && <p class="lead">{description}</p>}
+        </div>
+
+        <div class="product-video-frame">
+          <iframe
+            src={src}
+            title={title}
+            class="product-video-iframe"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            referrerpolicy="strict-origin-when-cross-origin"
+            allowfullscreen
+          />
+        </div>
+      </div>
+    </section>
+  ) : (
+    <section
+      id="product-video"
+      class:list={[
+        'scroll-mt-20 py-16 sm:py-20',
+        isLight ? 'border-y border-slate-200 bg-white text-slate-950' : variant === 'gray' ? 'bg-gray-900 text-white' : 'border-y border-white/10 bg-slate-900 text-white',
+      ]}
+    >
+      <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div class="mx-auto max-w-3xl text-center lg:mx-0 lg:text-left">
+          <p class:list={['font-mono text-sm font-semibold tracking-wide uppercase', isLight ? 'text-blue-700' : variant === 'gray' ? 'text-emerald-300' : 'text-cyan-300']}>
+            {eyebrow}
+          </p>
+          <h2 class:list={['mt-3 text-3xl font-semibold tracking-tight text-balance sm:text-4xl', isLight ? 'text-slate-950' : 'text-white']}>{title}</h2>
+          {description && (
+            <p class:list={['mt-5 text-base leading-7 text-pretty', isLight ? 'text-slate-600' : variant === 'gray' ? 'text-gray-300' : 'text-slate-300']}>{description}</p>
+          )}
+        </div>
+
+        <div
+          class:list={[
+            'mx-auto mt-10 max-w-5xl overflow-hidden rounded-xl border bg-black shadow-2xl lg:mx-0',
+            isLight ? 'border-slate-200 shadow-slate-200/40' : variant === 'gray' ? 'border-gray-700 shadow-black/30' : 'border-white/10 shadow-black/40',
+          ]}
+        >
+          <div class="aspect-video w-full">
+            <iframe
+              src={src}
+              title={title}
+              class="h-full w-full"
+              loading="lazy"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin"
+              allowfullscreen
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+<style is:global>
+  .product-video .product-video-frame {
+    margin-top: 40px;
+    overflow: hidden;
+    border-radius: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: #000;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+    aspect-ratio: 16 / 9;
+  }
+
+  .product-video .product-video-iframe {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+</style>

--- a/apps/web/src/config/productVideos.ts
+++ b/apps/web/src/config/productVideos.ts
@@ -4,40 +4,49 @@ export type ProductVideo = {
   description: string
 }
 
+export const productVideoFounder = {
+  eyebrow: 'From Martin',
+  name: 'Martin Donadieu',
+  role: 'Founder, Capgo',
+} as const
+
 export const productVideos = {
   mobileApp: {
     youtubeId: 'rrd61l70G5A',
-    title: 'Test Capgo updates on a real device',
-    description: 'Watch how the Capgo mobile app applies bundle previews, shares QR tests with your team, and keeps native build status visible while you validate a release.',
+    title: 'Why we built the Capgo mobile app',
+    description:
+      'Capgo founder Martin Donadieu on testing bundle previews on real devices, sharing QR tests with your team, and keeping release decisions close when you are away from your laptop.',
   },
   cli: {
     youtubeId: 'LCwaZrCOIGI',
-    title: 'Ship from the Capgo CLI',
-    description: 'See compatibility checks, guarded live-update uploads, native build requests, and MCP automation from the same terminal workflow.',
+    title: 'Why the Capgo CLI matters',
+    description:
+      'Capgo founder Martin Donadieu on shipping Capacitor releases from the terminal, checking compatibility before you push, and keeping native builds in the same workflow.',
   },
   skills: {
     youtubeId: 'M4iWu144Szw',
-    title: 'Use Capgo skills with your AI agent',
-    description: 'See how Capacitor and Capgo skills install in agent tools and guide live updates, plugins, builds, and migrations from natural-language requests.',
+    title: 'Why we open-sourced Capgo skills',
+    description: 'Capgo founder Martin Donadieu on giving AI agents practical Capacitor and Capgo knowledge for live updates, plugins, builds, and migrations.',
   },
   plugins: {
     youtubeId: 'p2hc5pzsHAY',
-    title: 'Explore the Capgo plugin catalog',
-    description: 'See how maintained Capgo plugins cover native capabilities, docs, and production workflows for Capacitor apps.',
+    title: 'Why Capgo maintains production plugins',
+    description:
+      'Capgo founder Martin Donadieu on the native gaps teams hit in production Capacitor apps, and why we keep a maintained plugin catalog instead of leaving you to guess.',
   },
   appflowMigration: {
     youtubeId: '1o2qbkyvlIY',
-    title: 'Migrate from Ionic Appflow to Capgo',
-    description: 'Walk through moving live updates, channels, and release automation off Appflow while keeping your Capacitor app and store credentials under your control.',
+    title: 'Why teams move from Appflow to Capgo',
+    description: 'Capgo founder Martin Donadieu on migrating live updates and release automation while keeping your repo, credentials, and release control in your hands.',
   },
   nativeBuild: {
     youtubeId: 'M_gXaLB-Muc',
-    title: 'Request native iOS and Android builds',
-    description: 'See how Capgo Builder turns a Capacitor project into signed native builds with logs, artifacts, and release records your team can trust.',
+    title: 'Why we built Capgo native builds',
+    description: 'Capgo founder Martin Donadieu on turning Capacitor projects into signed iOS and Android releases without asking you to hand over your App Store credentials.',
   },
   liveUpdate: {
     youtubeId: '7AdzMDR4dKk',
-    title: 'Ship Capgo live updates safely',
-    description: 'See channels, compatibility gates, rollback, and encrypted bundle delivery in a production Capacitor release flow.',
+    title: 'Why Capgo live updates work the way they do',
+    description: 'Capgo founder Martin Donadieu on channels, compatibility checks, rollback, and shipping web bundle changes safely after store approval.',
   },
 } as const satisfies Record<string, ProductVideo>

--- a/apps/web/src/config/productVideos.ts
+++ b/apps/web/src/config/productVideos.ts
@@ -1,0 +1,43 @@
+export type ProductVideo = {
+  youtubeId: string
+  title: string
+  description: string
+}
+
+export const productVideos = {
+  mobileApp: {
+    youtubeId: 'rrd61l70G5A',
+    title: 'Test Capgo updates on a real device',
+    description: 'Watch how the Capgo mobile app applies bundle previews, shares QR tests with your team, and keeps native build status visible while you validate a release.',
+  },
+  cli: {
+    youtubeId: 'LCwaZrCOIGI',
+    title: 'Ship from the Capgo CLI',
+    description: 'See compatibility checks, guarded live-update uploads, native build requests, and MCP automation from the same terminal workflow.',
+  },
+  skills: {
+    youtubeId: 'M4iWu144Szw',
+    title: 'Use Capgo skills with your AI agent',
+    description: 'See how Capacitor and Capgo skills install in agent tools and guide live updates, plugins, builds, and migrations from natural-language requests.',
+  },
+  plugins: {
+    youtubeId: 'p2hc5pzsHAY',
+    title: 'Explore the Capgo plugin catalog',
+    description: 'See how maintained Capgo plugins cover native capabilities, docs, and production workflows for Capacitor apps.',
+  },
+  appflowMigration: {
+    youtubeId: '1o2qbkyvlIY',
+    title: 'Migrate from Ionic Appflow to Capgo',
+    description: 'Walk through moving live updates, channels, and release automation off Appflow while keeping your Capacitor app and store credentials under your control.',
+  },
+  nativeBuild: {
+    youtubeId: 'M_gXaLB-Muc',
+    title: 'Request native iOS and Android builds',
+    description: 'See how Capgo Builder turns a Capacitor project into signed native builds with logs, artifacts, and release records your team can trust.',
+  },
+  liveUpdate: {
+    youtubeId: '7AdzMDR4dKk',
+    title: 'Ship Capgo live updates safely',
+    description: 'See channels, compatibility gates, rollback, and encrypted bundle delivery in a production Capacitor release flow.',
+  },
+} as const satisfies Record<string, ProductVideo>

--- a/apps/web/src/config/productVideos.ts
+++ b/apps/web/src/config/productVideos.ts
@@ -6,7 +6,7 @@ export type ProductVideo = {
 
 export const productVideoFounder = {
   eyebrow: 'From Martin',
-  name: 'Martin Donadieu',
+  name: 'Martin',
   role: 'Founder, Capgo',
 } as const
 
@@ -15,38 +15,36 @@ export const productVideos = {
     youtubeId: 'rrd61l70G5A',
     title: 'Why we built the Capgo mobile app',
     description:
-      'Capgo founder Martin Donadieu on testing bundle previews on real devices, sharing QR tests with your team, and keeping release decisions close when you are away from your laptop.',
+      'Capgo founder Martin on testing bundle previews on real devices, sharing QR tests with your team, and keeping release decisions close when you are away from your laptop.',
   },
   cli: {
     youtubeId: 'LCwaZrCOIGI',
     title: 'Why the Capgo CLI matters',
-    description:
-      'Capgo founder Martin Donadieu on shipping Capacitor releases from the terminal, checking compatibility before you push, and keeping native builds in the same workflow.',
+    description: 'Capgo founder Martin on shipping Capacitor releases from the terminal, checking compatibility before you push, and keeping native builds in the same workflow.',
   },
   skills: {
     youtubeId: 'M4iWu144Szw',
     title: 'Why we open-sourced Capgo skills',
-    description: 'Capgo founder Martin Donadieu on giving AI agents practical Capacitor and Capgo knowledge for live updates, plugins, builds, and migrations.',
+    description: 'Capgo founder Martin on giving AI agents practical Capacitor and Capgo knowledge for live updates, plugins, builds, and migrations.',
   },
   plugins: {
     youtubeId: 'p2hc5pzsHAY',
     title: 'Why Capgo maintains production plugins',
-    description:
-      'Capgo founder Martin Donadieu on the native gaps teams hit in production Capacitor apps, and why we keep a maintained plugin catalog instead of leaving you to guess.',
+    description: 'Capgo founder Martin on the native gaps teams hit in production Capacitor apps, and why we keep a maintained plugin catalog instead of leaving you to guess.',
   },
   appflowMigration: {
     youtubeId: '1o2qbkyvlIY',
     title: 'Why teams move from Appflow to Capgo',
-    description: 'Capgo founder Martin Donadieu on migrating live updates and release automation while keeping your repo, credentials, and release control in your hands.',
+    description: 'Capgo founder Martin on migrating live updates and release automation while keeping your repo, credentials, and release control in your hands.',
   },
   nativeBuild: {
     youtubeId: 'M_gXaLB-Muc',
     title: 'Why we built Capgo native builds',
-    description: 'Capgo founder Martin Donadieu on turning Capacitor projects into signed iOS and Android releases without asking you to hand over your App Store credentials.',
+    description: 'Capgo founder Martin on turning Capacitor projects into signed iOS and Android releases without asking you to hand over your App Store credentials.',
   },
   liveUpdate: {
     youtubeId: '7AdzMDR4dKk',
     title: 'Why Capgo live updates work the way they do',
-    description: 'Capgo founder Martin Donadieu on channels, compatibility checks, rollback, and shipping web bundle changes safely after store approval.',
+    description: 'Capgo founder Martin on channels, compatibility checks, rollback, and shipping web bundle changes safely after store approval.',
   },
 } as const satisfies Record<string, ProductVideo>

--- a/apps/web/src/pages/app_mobile.astro
+++ b/apps/web/src/pages/app_mobile.astro
@@ -1,6 +1,8 @@
 ---
 import '@/styles/mobile-app-product.css'
 import ProductAppExamples from '@/components/ProductAppExamples.astro'
+import ProductVideoSection from '@/components/ProductVideoSection.astro'
+import { productVideos } from '@/config/productVideos'
 import ProductTestimonials from '@/components/ProductTestimonials.astro'
 import { productTestimonials } from '@/config/productTestimonials'
 import type { SolutionStoreAppId } from '@/config/solutionStoreApps'
@@ -225,6 +227,8 @@ const appExampleIds: SolutionStoreAppId[] = ['com.windyty.android', 'com.studysm
       </div>
     </div>
   </section>
+
+  <ProductVideoSection youtubeId={productVideos.mobileApp.youtubeId} title={productVideos.mobileApp.title} description={productVideos.mobileApp.description} />
 
   <section class="bg-white py-16 text-slate-950 sm:py-20">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">

--- a/apps/web/src/pages/capgo-cli.astro
+++ b/apps/web/src/pages/capgo-cli.astro
@@ -2,6 +2,8 @@
 import '@/styles/cli-product.css'
 import CommandCode from '@/components/CommandCode.astro'
 import ProductAppExamples from '@/components/ProductAppExamples.astro'
+import ProductVideoSection from '@/components/ProductVideoSection.astro'
+import { productVideos } from '@/config/productVideos'
 import ProductTestimonials from '@/components/ProductTestimonials.astro'
 import { productTestimonials } from '@/config/productTestimonials'
 import type { SolutionStoreAppId } from '@/config/solutionStoreApps'
@@ -291,6 +293,8 @@ const comparisonRows = [
       </div>
     </div>
   </section>
+
+  <ProductVideoSection youtubeId={productVideos.cli.youtubeId} title={productVideos.cli.title} description={productVideos.cli.description} />
 
   <section class="bg-white py-16 text-slate-950 sm:py-20">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">

--- a/apps/web/src/pages/ionic-appflow.astro
+++ b/apps/web/src/pages/ionic-appflow.astro
@@ -1,5 +1,7 @@
 ---
 import Layout from '@/layouts/Layout.astro'
+import ProductVideoSection from '@/components/ProductVideoSection.astro'
+import { productVideos } from '@/config/productVideos'
 import { getRelativeLocaleUrl } from '@/services/links'
 import m from '@/copy/messages'
 import { pluginCountLabel } from '@/config/plugins'
@@ -223,6 +225,13 @@ const nativeBuildUrl = getRelativeLocaleUrl(locale, 'native-build')
           <p class="text-sm text-gray-400" set:html={m.appflow_migration_stuck({}, { locale })} />
         </div>
       </div>
+
+      <ProductVideoSection
+        variant="gray"
+        youtubeId={productVideos.appflowMigration.youtubeId}
+        title={productVideos.appflowMigration.title}
+        description={productVideos.appflowMigration.description}
+      />
 
       <!-- Enterprise Plugins -->
       <div class="mb-16">

--- a/apps/web/src/pages/live-update.astro
+++ b/apps/web/src/pages/live-update.astro
@@ -1,6 +1,8 @@
 ---
 import '@/styles/lu-product.css'
 import ProductTestimonials from '@/components/ProductTestimonials.astro'
+import ProductVideoSection from '@/components/ProductVideoSection.astro'
+import { productVideos } from '@/config/productVideos'
 import { productTestimonials } from '@/config/productTestimonials'
 import Layout from '@/layouts/Layout.astro'
 import m, { type MessageValues } from '@/copy/messages'
@@ -263,6 +265,14 @@ const featureTiles = [
         </div>
       </div>
     </section>
+
+    <ProductVideoSection
+      variant="builder"
+      accent="blue"
+      youtubeId={productVideos.liveUpdate.youtubeId}
+      title={productVideos.liveUpdate.title}
+      description={productVideos.liveUpdate.description}
+    />
 
     <!-- PROOF -->
     <ProductTestimonials

--- a/apps/web/src/pages/native-build.astro
+++ b/apps/web/src/pages/native-build.astro
@@ -1,6 +1,8 @@
 ---
 import CommandCode from '@/components/CommandCode.astro'
 import ProductTestimonials from '@/components/ProductTestimonials.astro'
+import ProductVideoSection from '@/components/ProductVideoSection.astro'
+import { productVideos } from '@/config/productVideos'
 import { productTestimonials } from '@/config/productTestimonials'
 import Layout from '@/layouts/Layout.astro'
 import { Icon } from 'astro-icon/components'
@@ -323,6 +325,14 @@ function buildTimeDisplay(buildTimeSeconds: number, name?: string) {
         </div>
       </div>
     </section>
+
+    <ProductVideoSection
+      variant="builder"
+      accent="green"
+      youtubeId={productVideos.nativeBuild.youtubeId}
+      title={productVideos.nativeBuild.title}
+      description={productVideos.nativeBuild.description}
+    />
 
     <!-- ============================================ PROOF ============================================ -->
     <ProductTestimonials

--- a/apps/web/src/pages/plugins.astro
+++ b/apps/web/src/pages/plugins.astro
@@ -1,5 +1,7 @@
 ---
 import ProductTestimonials from '@/components/ProductTestimonials.astro'
+import ProductVideoSection from '@/components/ProductVideoSection.astro'
+import { productVideos } from '@/config/productVideos'
 import PluginIcon from '@/components/PluginIcon.astro'
 import { actions, pluginCategories } from '@/config/plugins'
 import { productTestimonials } from '@/config/productTestimonials'
@@ -502,6 +504,9 @@ const content = {
         </div>
       </div>
     </section>
+
+    <ProductVideoSection variant="gray" youtubeId={productVideos.plugins.youtubeId} title={productVideos.plugins.title} description={productVideos.plugins.description} />
+
     <section class="px-6 py-12 lg:px-8">
       <div class="mx-auto max-w-7xl">
         <!-- More Options Section -->

--- a/apps/web/src/pages/skills.astro
+++ b/apps/web/src/pages/skills.astro
@@ -2,6 +2,8 @@
 import '@/styles/skills-product.css'
 import Layout from '@/layouts/Layout.astro'
 import CommandCode from '@/components/CommandCode.astro'
+import ProductVideoSection from '@/components/ProductVideoSection.astro'
+import { productVideos } from '@/config/productVideos'
 import { getRelativeLocaleUrl } from '@/services/links'
 
 const locale = Astro.locals.locale
@@ -483,6 +485,8 @@ const skillCount = skills.length
         </div>
       </div>
     </section>
+
+    <ProductVideoSection variant="gray" youtubeId={productVideos.skills.youtubeId} title={productVideos.skills.title} description={productVideos.skills.description} />
 
     <!-- Plugin Groups -->
     <section class="py-16">


### PR DESCRIPTION
## Summary
- Add a reusable `ProductVideoSection` component with accessible YouTube embeds (`youtube-nocookie.com`, lazy-loaded, 16:9)
- Centralize video IDs and founder copy in `productVideos.ts`
- Place founder video messages below the hero on seven product pages: mobile app, CLI, skills, plugins, Appflow migration, native build, and live update
- Exclude `productVideos.ts` from typo checks so valid YouTube IDs do not fail CI

## Test plan
- [ ] Open `/app_mobile/`, `/capgo-cli/`, `/skills/`, `/plugins/`, `/ionic-appflow/`, `/native-build/`, and `/live-update/`
- [ ] Confirm each page shows a "From Martin" section below the hero (not inside it)
- [ ] Verify YouTube embeds load and play correctly
- [ ] Check builder pages (`/live-update/`, `/native-build/`) match existing section styling
- [ ] Confirm Spell Check with Typos CI passes