### PR TITLE
Add Base44 blog and promote Capgo Builder in vibe-coding articles

### DIFF
--- a/apps/web/src/content/blog/en/capacitor-ai-mobile-apps.md
+++ b/apps/web/src/content/blog/en/capacitor-ai-mobile-apps.md
@@ -10,7 +10,7 @@ author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2026-02-08T00:00:00.000Z
-updated_at: 2026-06-23T21:13:09.000Z
+updated_at: 2026-06-24T12:00:00.000Z
 head_image: /lovable_capacitor.webp
 head_image_alt: "Why Capacitor Is the Best Way to Build AI Mobile Apps Right Now Capgo blog illustration"
 keywords: Capacitor, Capgo, AI mobile apps, LLM apps, live updates, OTA updates, React Native, Flutter, native iOS, native Android
@@ -30,7 +30,7 @@ That is why **Capacitor is the best default choice right now** for most AI mobil
 * You can leverage the AI tooling wave that is overwhelmingly web-first (AI code generators, UI scaffolding, agentic coding tools, “generate a React app” workflows, etc.).
 * You still ship a real iOS/Android app with access to native capabilities through Capacitor plugins (and custom Swift/Kotlin when you need it).
 * With **Capgo Live Updates** you can iterate on the “AI layer” (prompts, UX, copy, guardrails, flows) at web speed without waiting on store review for every small change.
-* With **Capgo Builds**, live updates, channels, rollbacks, and release automation can be managed in one platform and one workflow.
+* With **Capgo Builder**, you can compile signed iOS and Android binaries in the cloud — no Mac required — and manage live updates, channels, rollbacks, and release automation in one workflow.
 
 Capacitor is not magic. If you are doing heavy 3D, ultra-high-performance graphics, deep background processing, or large on-device inference as a primary feature, native or Flutter can be a better fit. But for the majority of AI apps that are essentially “networked products with a fast UI” (chat, voice, image, copilots, agents, workflow automation), **a web-first mobile stack wins**.
 
@@ -617,7 +617,7 @@ Live updates give you a safety valve:
 
 This is the difference between “we can respond” and “we have to wait”.
 
-### Capgo Builds: One Platform to Build and Release
+### Capgo Builder: Ship Native Binaries Without the Mac Tax
 
 The other source of pain is the “native build pipeline tax”:
 
@@ -626,13 +626,24 @@ The other source of pain is the “native build pipeline tax”:
 * CI setup, secrets management, build caching
 * Coordinating releases across platforms
 
-Capgo’s build offering can unify:
+If your app started in Lovable, Bolt.new, Base44, or another vibe-coding tool, you often do not have a Mac on the desk — but you still need signed iOS binaries for TestFlight and the App Store. **[Capgo Builder](https://capgo.app/native-build/)** is the recommended path: compile and sign iOS and Android in the cloud from the same CLI your AI agent can run.
 
-* Native builds
+```bash
+npx @capgo/cli@latest login
+npx @capgo/cli@latest build init --platform ios
+npx @capgo/cli@latest build init --platform android
+npm run build && npx cap sync
+npx @capgo/cli@latest build com.example.app --platform ios --build-mode release
+npx @capgo/cli@latest build com.example.app --platform android --build-mode release
+```
+
+Capgo Builder unifies:
+
+* Cloud native builds (no local Xcode/Android Studio required for release binaries)
 * Live update deployment
 * Release channels and rollout management
 
-For small teams especially, this is a force multiplier: less time fighting CI, more time improving the product.
+For small teams especially, this is a force multiplier: less time fighting CI, more time improving the product. See [Base44 to mobile](/blog/transform-base44-app-to-mobile-with-capacitor/), [Lovable to mobile](/blog/transform-lovable-dev-app-to-mobile-with-capacitor/), and [Bolt.new to mobile](/blog/transform-bolt-new-app-to-mobile-with-capacitor/) for end-to-end vibe-coding walkthroughs.
 
 ---
 

--- a/apps/web/src/content/blog/en/how-easy-is-it-to-make-web-app-into-mobile-app-with-capacitor.md
+++ b/apps/web/src/content/blog/en/how-easy-is-it-to-make-web-app-into-mobile-app-with-capacitor.md
@@ -9,7 +9,7 @@ author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2026-05-01T00:00:00.000Z
-updated_at: 2026-06-18T14:21:30.000Z
+updated_at: 2026-06-24T12:00:00.000Z
 head_image: /blog-images/how-easy-is-it-to-make-web-app-into-mobile-app-with-capacitor.webp
 head_image_alt: "How Easy Is It to Turn a Web App into a Mobile App with Capacitor? Capgo blog illustration"
 keywords: Capacitor, web app to mobile app, app store review, Google Play closed testing, iOS app, Android app, mobile app publishing, app wrapper
@@ -68,14 +68,26 @@ bun run build
 bunx cap sync
 ```
 
-Then open the native projects:
+For day-to-day simulator testing, you can open the native projects locally:
 
 ```bash
 bunx cap open ios
 bunx cap open android
 ```
 
-From there, you run the app in Xcode and Android Studio.
+For **signed release binaries** (TestFlight, Play Store internal testing, store submission), you do not need to live inside Xcode or Android Studio. **[Capgo Builder](https://capgo.app/native-build/)** compiles and signs iOS and Android in the cloud — including from Windows or Linux, with no Mac required for iOS:
+
+```bash
+bunx @capgo/cli@latest login
+bunx @capgo/cli@latest build init --platform ios
+bunx @capgo/cli@latest build init --platform android
+bun run build
+bunx cap sync
+bunx @capgo/cli@latest build com.example.myapp --platform ios --build-mode release
+bunx @capgo/cli@latest build com.example.myapp --platform android --build-mode release
+```
+
+See [Build iOS from Windows](/blog/build-ios-app-from-windows-capacitor-capgo-build/) and our vibe-coding guides for [Base44](/blog/transform-base44-app-to-mobile-with-capacitor/), [Lovable](/blog/transform-lovable-dev-app-to-mobile-with-capacitor/), and [Bolt.new](/blog/transform-bolt-new-app-to-mobile-with-capacitor/).
 
 The important setting is `webDir`. It must point to the folder your web framework creates during production build:
 
@@ -232,7 +244,7 @@ So the right expectation is:
 
 ## Where Capgo Helps After the First Release
 
-Once your Capacitor app is in production, [Capgo Live Updates](https://capgo.app/) can help ship web-layer fixes without waiting for a full store review each time.
+Once your Capacitor app is in production, **[Capgo Builder](/native-build/)** handles signed native releases when plugins or permissions change, and [Capgo Live Updates](https://capgo.app/) helps ship web-layer fixes without waiting for a full store review each time.
 
 That is useful for:
 

--- a/apps/web/src/content/blog/en/transform-base44-app-to-mobile-with-capacitor.md
+++ b/apps/web/src/content/blog/en/transform-base44-app-to-mobile-with-capacitor.md
@@ -1,0 +1,324 @@
+---
+slug: transform-base44-app-to-mobile-with-capacitor
+title: Base44 to Native Mobile Apps with Capacitor
+description: >-
+  Learn how to export your Base44 project and transform it into native mobile apps
+  using Capacitor and Capgo Builder. A complete step-by-step guide for 2026.
+author: Martin Donadieu
+author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
+author_url: 'https://x.com/martindonadieu'
+created_at: 2026-06-24T00:00:00.000Z
+updated_at: 2026-06-24T00:00:00.000Z
+head_image: /bolt_capacitor.webp
+head_image_alt: "Base44 to Native Mobile Apps with Capacitor Capgo blog illustration"
+keywords: Base44, Capacitor, mobile app development, React, export project, native mobile apps, Capgo Builder, vibe coding
+tag: Tutorial
+published: true
+locale: en
+next_blog: transform-lovable-dev-app-to-mobile-with-capacitor
+---
+
+## Introduction
+
+[Base44](https://base44.com/) is an AI-powered app builder that generates full React applications from prompts. You can ship a working product in the browser fast — but what if you want it on iOS and Android? In this tutorial, we show how to export your Base44 project and turn it into native mobile apps with [Capacitor](https://capacitorjs.com/), then ship signed store binaries with **[Capgo Builder](https://capgo.app/native-build/)** — no Mac required for iOS.
+
+By the end of this guide, your Base44 app runs natively on iOS and Android with access to device features like camera, storage, and push notifications.
+
+### Prerequisites & Time Estimate
+
+**Time Required**: 2-4 hours for first-time setup
+
+**System Requirements**:
+- **For iOS cloud builds**: Any OS (Windows, Mac, or Linux) with Capgo Builder
+- **For Android cloud builds**: Any OS
+- **Storage**: 10GB free space for dependencies and build artifacts
+- **RAM**: 8GB minimum
+
+**Costs**:
+- **Base44 export**: Builder plan or higher (for GitHub export and ZIP download)
+- **iOS App Store**: $99/year (Apple Developer Account)
+- **Android Play Store**: $25 one-time (Google Play Developer)
+- **Cursor Pro**: $20/month (optional but recommended)
+
+**Required Software**:
+- Node.js 18+
+- A code editor such as [Cursor](https://cursor.sh/)
+
+### Why Transform Your Base44 App to Mobile?
+
+- **Expanded reach**: Meet users where they expect a native app icon, not a browser tab
+- **Native features**: Camera, GPS, biometrics, and offline storage through Capacitor plugins
+- **App Store distribution**: Publish on Google Play and the Apple App Store
+- **Faster iteration**: Pair Capgo Live Updates with Capgo Builder for web-layer fixes without rebuilding native binaries every time
+
+## Step 1: Export Your Base44 Project
+
+Base44 lets you export code once you are on the **Builder plan or higher**. You have two main options.
+
+### Option A: Export to GitHub (Recommended)
+
+1. Open your app in the Base44 editor
+2. Click the **GitHub** icon in the top bar
+3. Authorize **Base44 Builder** and create or connect a repository
+4. Base44 syncs your app code to GitHub automatically (two-way sync on supported plans)
+
+See [Base44 GitHub integration docs](https://docs.base44.com/developers/app-code/local-development/github) for details.
+
+### Option B: Download as ZIP
+
+1. Click **Code** in the top bar to open the file browser
+2. Click **Export project as ZIP** in the top right of the code view
+3. Extract the archive on your computer
+
+### Open the Project in Cursor
+
+1. Visit [cursor.sh](https://cursor.sh/) and install Cursor
+2. Clone your GitHub repo (`Git: Clone` from the command palette) or open the extracted ZIP folder with **File > Open Folder**
+
+![Start Cursor](/start_in_cursor.webp)
+
+For the best AI-assisted workflow, enable your preferred model and allow command execution in Cursor settings — the same setup described in our [Lovable to mobile guide](/blog/transform-lovable-dev-app-to-mobile-with-capacitor/).
+
+## Step 2: Set Up Your Development Environment
+
+Base44 exports a standard React project. Install dependencies and confirm the dev server works.
+
+### Using Cursor AI (Recommended)
+
+Press `Command+K` (Mac) or `Ctrl+K` (Windows) and ask:
+
+```
+Install Node.js if needed, install project dependencies, and start the dev server
+```
+
+### Manual Setup
+
+```shell
+cd your-base44-project
+npm install
+npm run dev
+```
+
+![Bolt.new app running locally](/bolt-app-running.webp)
+
+Your Base44 app should load at `http://localhost:5173` (Vite) or the port shown in the terminal.
+
+## Step 3: Prepare the Production Build
+
+Capacitor needs static web assets. Base44 React apps typically use Vite and output to `dist/`.
+
+### Configure Vite for Mobile
+
+Ask Cursor:
+
+```
+Configure vite.config for Capacitor mobile deployment with base './' and production build to dist
+```
+
+Or update `vite.config.ts` manually:
+
+```typescript
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  base: './',
+  build: {
+    outDir: 'dist',
+  },
+})
+```
+
+### Test the Production Build
+
+```shell
+npm run build
+```
+
+Verify a `dist/` folder exists with `index.html` and bundled assets.
+
+![Bolt.new build output](/bolt-build-output.webp)
+
+## Step 4: Add Capacitor to Your Base44 Project
+
+### Using Cursor AI (Recommended)
+
+```
+Install Capacitor CLI, initialize it for my Base44 app with webDir dist, and add iOS and Android platforms
+```
+
+### Manual Installation
+
+```shell
+npm install -D @capacitor/cli
+npm install @capacitor/core @capacitor/ios @capacitor/android
+
+npx cap init "Your Base44 App" com.yourcompany.yourapp --web-dir dist
+npx cap add ios
+npx cap add android
+```
+
+![Capacitor initialization](/capacitor-init-bolt.webp)
+
+Commit the `ios/` and `android/` folders to git. Capgo Builder compiles what is in those directories.
+
+## Step 5: Configure Capacitor
+
+Update `capacitor.config.ts`:
+
+```typescript
+import type { CapacitorConfig } from '@capacitor/cli'
+
+const config: CapacitorConfig = {
+  appId: 'com.yourcompany.yourapp',
+  appName: 'Your Base44 App',
+  webDir: 'dist',
+  server: {
+    androidScheme: 'https',
+  },
+}
+
+export default config
+```
+
+Consider adding `@capgo/capacitor-updater` early so you can ship OTA updates after launch. See [Capgo Live Updates docs](/docs/live-updates/getting-started/).
+
+## Step 6: Build and Sync
+
+Every time you change the web app:
+
+```shell
+npm run build
+npx cap sync
+```
+
+![Capacitor sync Bolt complete](/capacitor-sync-bolt.webp)
+
+## Step 7: Build Store-Ready Binaries with Capgo Builder (Recommended)
+
+Simulator testing is optional. For TestFlight, internal testing, and store submission, use **Capgo Builder** to compile and sign native binaries in the cloud.
+
+### Why Capgo Builder for Base44 apps?
+
+- **No Mac required for iOS** — build from Windows or Linux
+- **Same CLI your AI agent can run** — fits vibe-coding workflows from Base44 → GitHub → Cursor
+- **Pairs with Live Updates** — fix UI and copy over the air; rebuild native only when plugins or permissions change
+
+### Set up Capgo Builder
+
+```shell
+npx @capgo/cli@latest login
+npx @capgo/cli@latest init
+npx @capgo/cli@latest build init --platform ios
+npx @capgo/cli@latest build init --platform android
+```
+
+Save signing credentials once. See [Managing Credentials](/docs/builder/credentials/) and [Build iOS from Windows](/blog/build-ios-app-from-windows-capacitor-capgo-build/).
+
+### Request a cloud build
+
+```shell
+npm run build
+npx cap sync
+npx @capgo/cli@latest build com.yourcompany.yourapp --platform ios --build-mode release
+npx @capgo/cli@latest build com.yourcompany.yourapp --platform android --build-mode release
+```
+
+Build logs stream in your terminal. With App Store Connect configured, iOS builds can upload to TestFlight automatically.
+
+Upload your web bundle for OTA updates:
+
+```shell
+npx @capgo/cli@latest bundle upload --channel production
+```
+
+## Step 8: Optional — Test Locally in Xcode or Android Studio
+
+If you have a Mac or want emulator testing before cloud builds:
+
+```shell
+npx cap open ios      # Xcode + iOS Simulator
+npx cap open android  # Android Studio + emulator
+```
+
+![Xcode opening Bolt project](/xcode-bolt-project.webp)
+
+Use local IDEs for day-to-day debugging. Use **Capgo Builder** when you need signed release binaries.
+
+## Step 9: Add Native Features
+
+Enhance your Base44 app with device capabilities:
+
+```shell
+npm install @capacitor/share @capacitor/camera @capacitor/push-notifications
+npx cap sync
+```
+
+Ask Cursor to wire Share, Camera, or Push into your React components. After adding plugins, run a new **Capgo Builder** build before store submission.
+
+![Native features added Bolt](/bolt-native-features.webp)
+
+## Step 10: Optimize for Production
+
+### App Icons and Splash Screens
+
+```shell
+npm install -D @capacitor/assets
+# Add assets/icon.png (1024x1024) and assets/splash.png (2732x2732)
+npx capacitor-assets generate
+npx cap sync
+```
+
+### Base44 Backend Considerations
+
+Exported Base44 apps may call Base44's hosted backend and SDK. That usually works in Capacitor as long as:
+
+- API calls use HTTPS
+- Auth redirects work inside the WebView (test login on a real device)
+- Deep links are configured if you use magic-link or OAuth flows
+
+If you later migrate off Base44's backend, plan to replace `base44.entities.*` and related SDK calls with your own API — the React UI layer typically carries over.
+
+## Troubleshooting Common Issues
+
+### White screen on launch
+
+- Confirm `base: './'` is set in Vite config
+- Run `npm run build` and check that `dist/index.html` loads assets with relative paths
+- Run `npx cap sync` after every web build
+
+### Build errors in Capgo Builder
+
+- Commit `ios/` and `android/` to git before requesting a cloud build
+- Run `npx cap sync` locally so web assets are copied into native projects
+- New Capacitor plugins require a fresh native build
+
+### Export not available in Base44
+
+GitHub export and ZIP download require the **Builder plan or higher**. Upgrade in Base44 or copy files manually from the Code view on lower tiers.
+
+## Conclusion
+
+You exported a Base44 AI-generated React app, wrapped it with Capacitor, and have a clear path to signed iOS and Android binaries through **Capgo Builder** — without maintaining a local Xcode farm.
+
+### Next Steps
+
+- **[Capgo Live Updates](/live-updates/)**: Ship UI and copy fixes without waiting on store review
+- **[Capgo Builder](/native-build/)**: Automate release builds in CI
+- **Push Notifications**: Add `@capacitor/push-notifications` and rebuild with Capgo Builder
+- **Related guides**: [Lovable to mobile](/blog/transform-lovable-dev-app-to-mobile-with-capacitor/) · [Bolt.new to mobile](/blog/transform-bolt-new-app-to-mobile-with-capacitor/)
+
+[Sign up for a free Capgo account](/register/) to enable Live Updates and cloud native builds.
+
+## Resources
+
+- [Base44 Documentation](https://docs.base44.com/)
+- [Base44 GitHub Integration](https://docs.base44.com/developers/app-code/local-development/github)
+- [Capacitor Documentation](https://capacitorjs.com/docs)
+- [Capgo Native Builds](/native-build/)
+- [Capgo — Live Updates for Capacitor Apps](https://capgo.app/)
+
+## Keep going from Base44 to Native Mobile Apps with Capacitor
+
+If you are using **Base44 to Native Mobile Apps with Capacitor** to plan native plugin work, connect it with [Capgo Plugin Directory](/plugins/) for the product workflow in Capgo Plugin Directory, [Capacitor Plugins by Capgo](/docs/plugins/) for the implementation detail in Capacitor Plugins by Capgo, [Capgo Native Builds](/native-build/) for the product workflow in Capgo Native Builds, and [Build iOS from Windows](/blog/build-ios-app-from-windows-capacitor-capgo-build/) for cloud iOS builds without a Mac.

--- a/apps/web/src/content/blog/en/transform-bolt-new-app-to-mobile-with-capacitor.md
+++ b/apps/web/src/content/blog/en/transform-bolt-new-app-to-mobile-with-capacitor.md
@@ -8,7 +8,7 @@ author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2025-07-28T00:00:00.000Z
-updated_at: 2026-06-18T14:21:30.000Z
+updated_at: 2026-06-24T12:00:00.000Z
 head_image: /bolt_capacitor.webp
 head_image_alt: ">- Capgo blog illustration"
 keywords: Bolt.new, Capacitor, mobile app development, React, Vue, export project, native mobile apps
@@ -472,7 +472,49 @@ npx cap sync
 
 ![Capacitor sync Bolt complete](/capacitor-sync-bolt.webp)
 
-## Step 9: Open Native IDEs
+## Step 9: Build Store-Ready Binaries with Capgo Builder (Recommended)
+
+You do not need a Mac or a full local Xcode/Android Studio pipeline to ship to the App Store and Google Play. **[Capgo Builder](https://capgo.app/native-build/)** compiles, signs, and can submit iOS and Android builds from the cloud — the fastest path for vibe-coded apps exported from Bolt.new.
+
+### Why Capgo Builder?
+
+- **No Mac required for iOS** — build from Windows, Linux, or your AI coding environment
+- **One CLI workflow** — easy to script and hand off to Cursor, Claude Code, or Codex
+- **Pairs with Live Updates** — ship JS/UI fixes over the air; rebuild the native binary only when plugins or permissions change
+
+### Set up Capgo Builder
+
+After your production build and Capacitor sync work locally:
+
+```shell
+npx @capgo/cli@latest login
+npx @capgo/cli@latest init
+npx @capgo/cli@latest build init --platform ios
+npx @capgo/cli@latest build init --platform android
+```
+
+Save signing credentials once (Apple certificates, provisioning profiles, Android keystore). See [Managing Credentials](/docs/builder/credentials/) and [Build iOS from Windows](/blog/build-ios-app-from-windows-capacitor-capgo-build/).
+
+### Request a cloud build
+
+```shell
+npm run build
+npx cap sync
+npx @capgo/cli@latest build com.yourcompany.yourapp --platform ios --build-mode release
+npx @capgo/cli@latest build com.yourcompany.yourapp --platform android --build-mode release
+```
+
+Capgo Builder streams build logs in your terminal. With App Store Connect configured, iOS builds can go straight to TestFlight.
+
+Upload your web bundle for OTA updates:
+
+```shell
+npx @capgo/cli@latest bundle upload --channel production
+```
+
+## Step 10: Open Native IDEs (Optional for Local Testing)
+
+If you have a Mac or want emulator testing before cloud builds, open the native projects locally:
 
 Access the native development environments for your app.
 
@@ -504,7 +546,7 @@ npx cap open android
 
 ![Android Studio opening Bolt project](/android-studio-bolt-project.webp)
 
-## Step 10: Build and Run Your Mobile App
+## Step 11: Build and Run Locally (Optional)
 
 ### Running on iOS
 
@@ -574,7 +616,7 @@ After successful build, verify:
 
 **Still having issues?** The error messages usually tell you exactly what's wrong - read them carefully!
 
-## Step 11: Enable Live Reload (Development)
+## Step 12: Enable Live Reload (Development)
 
 Speed up your development workflow with hot reloading.
 
@@ -625,7 +667,7 @@ npx cap copy
 
 ![Live reload enabled Bolt](/capacitor-live-reload-bolt.webp)
 
-## Step 12: Add Native Features
+## Step 13: Add Native Features
 
 Enhance your Bolt.new app with device-specific capabilities.
 
@@ -723,7 +765,7 @@ npx cap sync
 
 ![Native features added Bolt](/bolt-native-features.webp)
 
-## Step 13: Optimize for Production
+## Step 14: Optimize for Production
 
 ### App Icons and Splash Screens
 
@@ -846,6 +888,7 @@ Congratulations! You've successfully transformed your Bolt.new project into nati
 
 ### Next Steps
 
+- **[Capgo Builder](/native-build/)**: Use cloud native builds for TestFlight and Play Store releases
 - **Live Updates**: Implement [Capgo](https://capgo.app/) for instant over-the-air updates
 - **Analytics**: Add mobile analytics to track user behavior
 - **Performance**: Monitor and optimize your app's mobile performance
@@ -858,7 +901,9 @@ Your Bolt.new creation is now ready for the mobile ecosystem!
 - [Bolt.new Platform](https://bolt.new/)
 - [Capacitor Documentation](https://capacitorjs.com/docs)
 - [Vite Mobile Deployment Guide](https://vitejs.dev/guide/static-deploy.html)
+- [Capgo Builder — Cloud Native Builds](/native-build/)
 - [Capgo - Live Updates for Capacitor Apps](https://capgo.app/)
+- [Base44 to mobile](/blog/transform-base44-app-to-mobile-with-capacitor/)
 
 Learn how Capgo can help you deliver instant updates to your mobile app, [sign up for a free account](/register/) today.
 

--- a/apps/web/src/content/blog/en/transform-lovable-dev-app-to-mobile-with-capacitor.md
+++ b/apps/web/src/content/blog/en/transform-lovable-dev-app-to-mobile-with-capacitor.md
@@ -7,7 +7,7 @@ author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2025-07-28T00:00:00.000Z
-updated_at: 2026-06-18T14:21:30.000Z
+updated_at: 2026-06-24T12:00:00.000Z
 head_image: /lovable_capacitor.webp
 head_image_alt: "Lovable.dev to Native Mobile Apps with Capacitor Capgo blog illustration"
 keywords: Lovable.dev, Capacitor, mobile app development, Next.js, export project, native mobile apps
@@ -360,7 +360,49 @@ npx cap sync
 
 ![Capacitor sync complete](/capacitor-sync-complete.webp)
 
-## Step 7: Open Native IDEs
+## Step 7: Build Store-Ready Binaries with Capgo Builder (Recommended)
+
+You do not need a Mac or a full local Xcode/Android Studio pipeline to ship to the App Store and Google Play. **[Capgo Builder](https://capgo.app/native-build/)** compiles, signs, and can submit iOS and Android builds from the cloud — the fastest path for vibe-coded apps exported from Lovable.
+
+### Why Capgo Builder?
+
+- **No Mac required for iOS** — build from Windows, Linux, or your AI coding environment
+- **One CLI workflow** — easy to script and hand off to Cursor, Claude Code, or Codex
+- **Pairs with Live Updates** — ship JS/UI fixes over the air; rebuild the native binary only when plugins or permissions change
+
+### Set up Capgo Builder
+
+After your static export and Capacitor sync work locally:
+
+```shell
+npx @capgo/cli@latest login
+npx @capgo/cli@latest init
+npx @capgo/cli@latest build init --platform ios
+npx @capgo/cli@latest build init --platform android
+```
+
+Save signing credentials once (Apple certificates, provisioning profiles, Android keystore). See [Managing Credentials](/docs/builder/credentials/) and [Build iOS from Windows](/blog/build-ios-app-from-windows-capacitor-capgo-build/).
+
+### Request a cloud build
+
+```shell
+npm run static
+npx cap sync
+npx @capgo/cli@latest build com.yourcompany.yourapp --platform ios --build-mode release
+npx @capgo/cli@latest build com.yourcompany.yourapp --platform android --build-mode release
+```
+
+Capgo Builder streams build logs in your terminal. With App Store Connect configured, iOS builds can go straight to TestFlight.
+
+Upload your web bundle for OTA updates:
+
+```shell
+npx @capgo/cli@latest bundle upload --channel production
+```
+
+## Step 8: Open Native IDEs (Optional for Local Testing)
+
+If you have a Mac or want emulator testing before cloud builds, open the native projects locally:
 
 ### For iOS Development
 
@@ -390,7 +432,7 @@ npx cap open android
 
 ![Android Studio opening Lovable project](/android-studio-lovable-project.webp)
 
-## Step 8: Build and Run Your Mobile App
+## Step 9: Build and Run Locally (Optional)
 
 ### Running on iOS
 
@@ -456,7 +498,7 @@ npx cap open android
 
 If you see a white screen, check the terminal for errors.
 
-## Step 9: Enable Live Reload (Development)
+## Step 10: Enable Live Reload (Development)
 
 ### Method 1: Using Cursor AI (Recommended)
 
@@ -503,7 +545,7 @@ npx cap copy
 
 ![Live reload enabled](/capacitor-live-reload.webp)
 
-## Step 10: Add Native Features
+## Step 11: Add Native Features
 
 ### Method 1: Using Cursor AI (Recommended)
 
@@ -557,7 +599,7 @@ Test your new native capabilities:
 
 If features don't work, ensure you've run `npx cap sync` after adding plugins.
 
-## Step 11: Optimize for Production
+## Step 12: Optimize for Production
 
 ### App Icons and Splash Screens
 
@@ -635,7 +677,8 @@ Congratulations! You've successfully transformed your Lovable.dev Next.js app in
 
 ### Next Steps
 
-- **Live Updates**: Consider implementing [Capgo](https://capgo.app/) for over-the-air updates
+- **[Capgo Builder](/native-build/)**: Use cloud native builds for TestFlight and Play Store releases
+- **Live Updates**: Implement [Capgo](https://capgo.app/) for over-the-air updates
 - **Push Notifications**: Add the Capacitor Push Notifications plugin
 - **Analytics**: Integrate mobile analytics to track user behavior
 - **Performance Monitoring**: Monitor your app's performance on mobile devices
@@ -646,7 +689,9 @@ Your Lovable.dev creation is now ready for the mobile world!
 
 - [Lovable.dev Documentation](https://docs.lovable.dev/)
 - [Capacitor Documentation](https://capacitorjs.com/docs)
+- [Capgo Builder — Cloud Native Builds](/native-build/)
 - [Capgo - Live Updates for Capacitor Apps](https://capgo.app/)
+- [Base44 to mobile](/blog/transform-base44-app-to-mobile-with-capacitor/)
 - [Next.js Static Export Guide](https://nextjs.org/docs/app/building-your-application/deploying/static-exports)
 
 Learn how Capgo can help you deliver updates to your mobile app instantly, [sign up for a free account](/register/) today.


### PR DESCRIPTION
## Summary
- Add a new tutorial: [Base44 to Native Mobile Apps with Capacitor](/blog/transform-base44-app-to-mobile-with-capacitor/) covering GitHub/ZIP export, Capacitor setup, and **Capgo Builder** for signed iOS/Android releases.
- Update vibe-coding tutorials for **Lovable**, **Bolt.new**, and the general **web-to-mobile** / **AI mobile apps** articles to recommend **Capgo Builder** as the primary path for store-ready native binaries (local Xcode/Android Studio framed as optional for simulator testing).

## Test plan
- [ ] `bun run build` in `apps/web` succeeds
- [ ] New post renders at `/blog/transform-base44-app-to-mobile-with-capacitor/`
- [ ] Updated Lovable and Bolt posts show Capgo Builder as Step 7 / Step 9
- [ ] SEO checker passes on changed blog pages


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several blog tutorials with the latest build and release guidance.
  * Added a new step-by-step guide for turning a Base44 app into iOS and Android apps.
  * Expanded release instructions to include cloud-based binary builds, signing, and optional submission.
  * Refreshed related resources and links for native builds, live updates, and production publishing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->