### PR TITLE
Improve Lovable-to-mobile tutorial for 2026 cloud workflow

### DIFF
--- a/apps/web/src/content/blog/en/transform-base44-app-to-mobile-with-capacitor.md
+++ b/apps/web/src/content/blog/en/transform-base44-app-to-mobile-with-capacitor.md
@@ -77,7 +77,7 @@ See [Base44 GitHub integration docs](https://docs.base44.com/developers/app-code
 
 ![Start Cursor](/start_in_cursor.webp)
 
-For the best AI-assisted workflow, enable your preferred model and allow command execution in Cursor settings — the same setup described in our [Lovable to mobile guide](/blog/transform-lovable-dev-app-to-mobile-with-capacitor/).
+For the best AI-assisted workflow, enable your preferred model and allow command execution in Cursor settings — enable your preferred model and allow command execution in Cursor settings.
 
 ## Step 2: Set Up Your Development Environment
 

--- a/apps/web/src/content/blog/en/transform-base44-app-to-mobile-with-capacitor.md
+++ b/apps/web/src/content/blog/en/transform-base44-app-to-mobile-with-capacitor.md
@@ -77,7 +77,7 @@ See [Base44 GitHub integration docs](https://docs.base44.com/developers/app-code
 
 ![Start Cursor](/start_in_cursor.webp)
 
-For the best AI-assisted workflow, enable your preferred model and allow command execution in Cursor settings — enable your preferred model and allow command execution in Cursor settings.
+For the best AI-assisted workflow, enable your preferred model and allow command execution in Cursor settings — the same setup described in our [Lovable to mobile guide](/blog/transform-lovable-dev-app-to-mobile-with-capacitor/).
 
 ## Step 2: Set Up Your Development Environment
 

--- a/apps/web/src/content/blog/en/transform-lovable-dev-app-to-mobile-with-capacitor.md
+++ b/apps/web/src/content/blog/en/transform-lovable-dev-app-to-mobile-with-capacitor.md
@@ -41,7 +41,7 @@ We use [Cursor](https://cursor.sh/) throughout — its AI can run most of the te
 | --- | --- |
 | A computer | Mac, Windows, or Linux — cloud builds work from any OS |
 | A code editor | [Cursor](https://cursor.sh/) (recommended) or VS Code |
-| Node.js | Version 20 or newer (22 LTS recommended) |
+| Node.js | 24 LTS (latest — download from [nodejs.org](https://nodejs.org/)) |
 | Git | To clone your Lovable repo from GitHub |
 | Capgo account | [Free signup](/register/) — cloud builds and Live Updates |
 
@@ -175,7 +175,7 @@ npm run dev
 
 **For Windows:**
 
-1. Download Node.js from [nodejs.org](https://nodejs.org/)
+1. Download the **24 LTS** installer from [nodejs.org](https://nodejs.org/)
 2. Run the installer
 3. Open terminal and run:
 

--- a/apps/web/src/content/blog/en/transform-lovable-dev-app-to-mobile-with-capacitor.md
+++ b/apps/web/src/content/blog/en/transform-lovable-dev-app-to-mobile-with-capacitor.md
@@ -11,7 +11,7 @@ created_at: 2025-07-28T00:00:00.000Z
 updated_at: 2026-06-27T00:00:00.000Z
 head_image: /lovable_capacitor.webp
 head_image_alt: "Convert your Lovable app to iOS and Android with Capacitor Capgo blog illustration"
-keywords: Lovable, Lovable.dev, Capacitor, mobile app development, React, Vite, export project, native mobile apps, Capgo Builder, live updates, vibe coding
+keywords: Lovable, Lovable.dev, Capacitor, mobile app development, React, Vite, export project, native mobile apps, Capgo Builder, live updates, vibe coding, Cursor
 tag: Tutorial
 published: true
 locale: en
@@ -23,6 +23,8 @@ next_blog: building-a-native-mobile-app-with-nextjs-and-capacitor
 [Lovable](https://lovable.dev/) is an AI app builder that turns prompts into working React apps in minutes. You can ship in the browser fast — but what if you want your app on the App Store and Google Play, sitting on home screens like every other native app?
 
 This guide walks through the full path: export from Lovable, wrap the web app with [Capacitor](https://capacitorjs.com/), build signed iOS and Android binaries in the cloud with **[Capgo Builder](https://capgo.app/native-build/)** (no Mac required), add a real native feature, and push a layout fix over the air with **Capgo Live Updates**.
+
+We use [Cursor](https://cursor.sh/) throughout — its AI can run most of the terminal commands for you if you prefer not to type them manually.
 
 **Time required:** about 1–2 hours the first time, mostly account setup and waiting on cloud builds.
 
@@ -38,7 +40,7 @@ This guide walks through the full path: export from Lovable, wrap the web app wi
 | Requirement | Details |
 | --- | --- |
 | A computer | Mac, Windows, or Linux — cloud builds work from any OS |
-| A code editor | [Cursor](https://cursor.sh/) or VS Code |
+| A code editor | [Cursor](https://cursor.sh/) (recommended) or VS Code |
 | Node.js | Version 20 or newer (22 LTS recommended) |
 | Git | To clone your Lovable repo from GitHub |
 | Capgo account | [Free signup](/register/) — cloud builds and Live Updates |
@@ -49,6 +51,7 @@ This guide walks through the full path: export from Lovable, wrap the web app wi
 | --- | --- |
 | Apple Developer Program | $99/year |
 | Google Play Console | $25 one-time |
+| Cursor Pro | $20/month (optional but recommended for AI command execution) |
 | Capgo | Free tier available; paid plans for production scale |
 
 **Optional (local simulator only):**
@@ -95,12 +98,88 @@ Lovable keeps your code in its editor until you connect GitHub.
 
 ✅ **Success:** Visiting `github.com/YOUR-USERNAME/your-app` shows your app's code.
 
-## Step 2 — Clone and Run Your App Locally
+## Step 2 — Set Up Cursor and Clone Your Project
 
-Open a terminal in [Cursor](https://cursor.sh/) or VS Code and clone the repo (replace `YOUR-USERNAME`):
+Before we can work with your code locally, you'll need a code editor. We recommend [Cursor](https://cursor.sh/), an AI-powered editor that can run terminal commands for you.
+
+### Download and Install Cursor
+
+1. Visit [cursor.sh](https://cursor.sh/) and download the version for your operating system
+2. Install Cursor following the installation wizard
+3. Once installed, open Cursor
+
+![Start Cursor](/start_in_cursor.webp)
+
+### Configure Cursor for AI Development
+
+For the best experience, configure Cursor before you start:
+
+1. **Buy a Cursor Plan** — While Cursor offers a free tier, a Pro plan ($20/month) gives you unlimited AI completions, access to Claude and GPT-4, and command execution
+2. **Open Cursor Settings** by pressing `Command+,` (Mac) or `Ctrl+,` (Windows)
+
+![Cursor Settings](/cursor_settings.webp)
+
+3. **Enable AI Models** — Make sure AI features are enabled:
+
+![Allow Models](/allow_models.webp)
+
+4. **Select Your Preferred Model** — Choose Claude or GPT-4 for best results:
+
+![Select Cursor Model](/select_cursor_model.webp)
+
+5. **Allow Command Execution** — Enable Cursor to run commands for you:
+
+![Allow Run Commands](/allow_run_commands.webp)
+
+### Clone Your Repository in Cursor
+
+1. In Cursor, press `Shift+Command+P` (Mac) or `Shift+Ctrl+P` (Windows) to open the command palette
+2. Type "clone" and select **Git: Clone"**
+3. Paste your GitHub repository URL: `https://github.com/YOUR-USERNAME/your-lovable-app.git`
+4. Choose a folder where you want to save the project
+
+![Clone in Cursor](/clone_in_cursor.webp)
+
+5. Cursor will clone and open your project
+
+![Open in Cursor](/open_in_cursor.webp)
+
+## Step 3 — Install Dependencies and Run Locally
+
+### Method 1: Using Cursor AI (Recommended)
+
+1. Open Cursor's AI tab by pressing `Command+K` (Mac) or `Ctrl+K` (Windows)
+2. Type the following command:
+
+```
+Install Homebrew, Node.js and npm on my system, then install dependencies and run the dev server
+```
+
+The AI will automatically detect your OS, install Node.js, run `npm install`, and start the dev server with `npm run dev`.
+
+![Install Homebrew](/install_brew.webp)
+
+### Method 2: Manual Installation
+
+Open the terminal in Cursor by pressing `` Shift+Command+T `` (Mac) or `` Shift+Ctrl+T `` (Windows), then:
+
+**For macOS:**
 
 ```shell
-git clone https://github.com/YOUR-USERNAME/your-lovable-app.git
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew install node
+cd your-lovable-app
+npm install
+npm run dev
+```
+
+**For Windows:**
+
+1. Download Node.js from [nodejs.org](https://nodejs.org/)
+2. Run the installer
+3. Open terminal and run:
+
+```shell
 cd your-lovable-app
 npm install
 npm run dev
@@ -114,11 +193,21 @@ Press `Ctrl + C` to stop the dev server when you're ready to continue.
 
 ✅ **Success:** Your app opens in the browser with its UI working.
 
-## Step 3 — Prepare the Static Production Build
+## Step 4 — Prepare the Static Production Build
 
 Capacitor needs a production build before you add native platforms.
 
 ### React + Vite (most Lovable apps)
+
+#### Method 1: Using Cursor AI (Recommended)
+
+Press `Command+K` (Mac) or `Ctrl+K` (Windows) and ask:
+
+```
+Configure vite.config for Capacitor mobile deployment with base './' and production build to dist
+```
+
+#### Method 2: Manual Configuration
 
 Confirm `vite.config.ts` uses a relative base so assets load inside the native WebView:
 
@@ -147,13 +236,33 @@ You should see a `dist/` folder with `index.html` at its root.
 
 ### Legacy Next.js Lovable projects
 
-If your repo uses Next.js, configure static export and build to `out/`. See [Convert Your Next.js App to Mobile](/blog/building-a-native-mobile-app-with-nextjs-and-capacitor/) for the full `next.config` setup, then use `webDir: 'out'` in Capacitor instead of `dist`.
+If your repo uses Next.js, ask Cursor:
+
+```
+Add a static export script to package.json and configure next.config.js for mobile export with Capacitor
+```
+
+Or follow [Convert Your Next.js App to Mobile](/blog/building-a-native-mobile-app-with-nextjs-and-capacitor/) for the full `next.config` setup, then use `webDir: 'out'` in Capacitor instead of `dist`.
 
 ✅ **Success:** A static build folder exists (`dist/` or `out/`) with `index.html`.
 
-## Step 4 — Add Capacitor and Native Platforms
+## Step 5 — Add Capacitor and Native Platforms
 
 Capacitor wraps your web app in real iOS and Android shells — no rewrite needed.
+
+### Method 1: Using Cursor AI (Recommended)
+
+Press `Command+K` (Mac) or `Ctrl+K` (Windows) and ask:
+
+```
+Install Capacitor CLI, initialize it for my app with webDir dist, and add iOS and Android platforms
+```
+
+The AI will ask for your **app name** and **bundle ID** (e.g. `com.yourcompany.myapp`).
+
+![Capacitor initialization](/capacitor-init-lovable.webp)
+
+### Method 2: Manual Installation
 
 ```shell
 npm install @capacitor/core @capacitor/cli
@@ -168,7 +277,7 @@ When prompted:
 | App Package ID | com.yourcompany.myapp | Reverse-domain style — **cannot change after store publish** |
 | Web assets directory | `dist` | Use `out` for Next.js static export |
 
-**Pick a Package ID you actually own.** Bundle IDs are globally unique. Use a reverse-domain ID based on a domain you control (e.g. `com.yourcompany.myapp`) from the start — changing it later means find-and-replacing across `ios/` and `android/` and rebuilding.
+**Pick a Package ID you actually own.** Bundle IDs are globally unique. Use a reverse-domain ID based on a domain you control from the start — changing it later means find-and-replacing across `ios/` and `android/` and rebuilding.
 
 ```shell
 npm run build
@@ -178,9 +287,55 @@ npx cap add android
 npx cap sync
 ```
 
-![Capacitor initialization](/capacitor-init-lovable.webp)
-
 ![Capacitor platforms added](/capacitor-platforms-added.webp)
+
+### Configure Capacitor
+
+#### Method 1: Using Cursor AI (Recommended)
+
+Ask Cursor:
+
+```
+Update capacitor.config.ts to use dist as webDir and set up for HTTPS
+```
+
+For Next.js static export, ask it to use `out` instead.
+
+#### Method 2: Manual Configuration
+
+```typescript
+import type { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.yourcompany.myapp',
+  appName: 'My Lovable App',
+  webDir: 'dist',
+  server: {
+    androidScheme: 'https',
+  },
+};
+
+export default config;
+```
+
+### Build and Sync
+
+#### Method 1: Using Cursor AI (Recommended)
+
+Tell Cursor:
+
+```
+Build the production web app and sync it with Capacitor platforms
+```
+
+#### Method 2: Manual Commands
+
+```shell
+npm run build
+npx cap sync
+```
+
+![Capacitor sync complete](/capacitor-sync-complete.webp)
 
 Your project now looks like:
 
@@ -198,7 +353,7 @@ your-lovable-app/
 
 ✅ **Success:** `ios/` and `android/` folders appear and the terminal shows `Sync finished`.
 
-## Step 5 — Check Your `.gitignore`
+## Step 6 — Check Your `.gitignore`
 
 Capgo Builder compiles from your Git repository, so `ios/` and `android/` **must be committed**. A common mistake is ignoring them at the repo root.
 
@@ -207,11 +362,9 @@ Confirm:
 - Root `.gitignore` ignores `node_modules` and `dist` (the cloud rebuilds `dist` during web builds)
 - `ios/` and `android/` themselves are **not** ignored
 
-`npx cap add` already adds platform-level `.gitignore` files that ignore build artifacts but keep the project source.
-
 ✅ **Success:** `git status` shows `ios/` and `android/` ready to commit (not ignored).
 
-## Step 6 — Commit and Push
+## Step 7 — Commit and Push
 
 ```shell
 git add .
@@ -221,7 +374,7 @@ git push
 
 ✅ **Success:** Your GitHub repo shows the `ios/` and `android/` folders.
 
-## Step 7 — Build Store-Ready Binaries with Capgo Builder
+## Step 8 — Build Store-Ready Binaries with Capgo Builder
 
 You do not need a Mac or local Xcode/Android Studio pipeline to ship. **Capgo Builder** compiles, signs, and can submit iOS and Android builds from the cloud.
 
@@ -260,35 +413,134 @@ Build logs stream in your terminal. With App Store Connect configured, iOS build
 
 ✅ **Success:** A signed build completes and you can install it on a real device.
 
-## Step 8 — Optional: Test Locally in Xcode or Android Studio
+## Step 9 — Optional: Test Locally in Xcode or Android Studio
 
-If you have a Mac or want emulator testing:
+If you have a Mac or want emulator testing before cloud builds:
+
+### For iOS
+
+#### Method 1: Using Cursor AI (Recommended)
+
+```
+Open the iOS project in Xcode
+```
+
+#### Method 2: Manual Command
 
 ```shell
-npx cap open ios      # Xcode + iOS Simulator
-npx cap open android  # Android Studio + emulator
+npx cap open ios
 ```
 
 ![Xcode opening Lovable project](/xcode-lovable-project.webp)
 
-![Android Studio opening Lovable project](/android-studio-lovable-project.webp)
+**First-time Xcode setup:**
+
+1. Select a simulator from the device dropdown (e.g. iPhone 15)
+2. For real devices: enable **Automatically manage signing** and select your Apple Developer team
+3. Click the ▶️ Play button — first build takes 5–10 minutes
 
 ![Lovable app running on iOS](/lovable-ios-app.webp)
+
+### For Android
+
+#### Method 1: Using Cursor AI (Recommended)
+
+```
+Open the Android project in Android Studio
+```
+
+#### Method 2: Manual Command
+
+```shell
+npx cap open android
+```
+
+![Android Studio opening Lovable project](/android-studio-lovable-project.webp)
+
+**First-time Android Studio setup:**
+
+1. Install missing SDK packages if prompted
+2. Create an emulator in Device Manager (e.g. Pixel 6, API 33+)
+3. Click the green ▶️ Run button — first build takes 5–15 minutes
 
 ![Lovable app running on Android](/lovable-android-app.webp)
 
 Use local IDEs for day-to-day debugging. Use **Capgo Builder** when you need signed release binaries.
 
-## Step 9 — Add a Native Feature: The Camera
+✅ **Success:** App opens in simulator or emulator showing your Lovable content.
+
+## Step 10 — Enable Live Reload (Development)
+
+Speed up iteration by pointing the native shell at your local dev server.
+
+### Method 1: Using Cursor AI (Recommended)
+
+Tell Cursor:
+
+```
+Set up live reload for Capacitor development with my local IP address
+```
+
+### Method 2: Manual Setup
+
+1. Find your local IP address:
+
+```shell
+# macOS
+ipconfig getifaddr en0
+
+# Windows
+ipconfig
+```
+
+2. Update `capacitor.config.ts`:
+
+```typescript
+import type { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.yourcompany.myapp',
+  appName: 'My Lovable App',
+  webDir: 'dist',
+  server: {
+    url: 'http://YOUR_IP_ADDRESS:5173',
+    cleartext: true,
+  },
+};
+
+export default config;
+```
+
+Use port `8080` or `3000` if that is what `npm run dev` prints.
+
+3. Apply changes:
+
+```shell
+npx cap copy
+```
+
+![Live reload enabled](/capacitor-live-reload.webp)
+
+✅ **Success:** Edits to your web code hot-reload on the device or simulator.
+
+## Step 11 — Add a Native Feature: The Camera
 
 A Capacitor plugin lets JavaScript call real device features. We'll add the Camera plugin so users can snap a photo — something a browser tab cannot do reliably.
+
+### Method 1: Using Cursor AI (Recommended)
+
+Tell Cursor:
+
+```
+Add the Capacitor Camera plugin with iOS and Android permissions and a button to take a photo
+```
+
+### Method 2: Manual Installation
 
 ```shell
 npm install @capacitor/camera
 npx cap sync
 ```
-
-### Declare camera permissions
 
 **iOS** — add to `ios/App/App/Info.plist` inside the top-level `<dict>`:
 
@@ -303,8 +555,6 @@ npx cap sync
 <uses-permission android:name="android.permission.CAMERA" />
 ```
 
-### Use the camera in your app
-
 ```typescript
 import { Camera, CameraResultType } from '@capacitor/camera';
 
@@ -317,17 +567,15 @@ async function takePhoto() {
 }
 ```
 
-Capacitor shows the system permission dialog the first time — using the message you wrote in `Info.plist`.
-
 ![Native features added](/lovable-native-features.webp)
 
 Adding a plugin requires a **fresh native build** through Capgo Builder before it works on devices.
 
 ✅ **Success:** Camera code compiles and `npx cap sync` finishes without errors.
 
-## Step 10 — Add Capgo Live Updates
+## Step 12 — Add Capgo Live Updates
 
-Every native change — even a typo fix in native config — normally goes through app store review. **Capgo Live Updates** push changes to your app's web layer (HTML, CSS, JS, images) over the air in minutes.
+Every native change normally goes through app store review. **Capgo Live Updates** push changes to your app's web layer (HTML, CSS, JS, images) over the air in minutes.
 
 **Install the updater in your first release** so you're never stuck waiting on review when you need to ship a fix.
 
@@ -376,7 +624,7 @@ See [Capgo Live Updates docs](/docs/live-updates/getting-started/).
 
 ✅ **Success:** Updater plugin is installed and `notifyAppReady()` runs on startup.
 
-## Step 11 — Fix Status Bar Spacing with a Live Update
+## Step 13 — Fix Status Bar Spacing with a Live Update
 
 On a real iPhone, your header may sit **under** the status bar (clock and battery). Modern Capacitor draws edge-to-edge, so your app must respect **safe area insets**: `env(safe-area-inset-top)`, `-bottom`, `-left`, `-right`.
 
@@ -398,7 +646,7 @@ padding-top: 1.5rem;
 padding-top: max(1.5rem, env(safe-area-inset-top));
 ```
 
-In Tailwind, ask Lovable:
+In Cursor or Lovable, ask:
 
 > "The app content runs under the status bar at the top on mobile. Add `env(safe-area-inset-top)` to the top padding of each page header using `max()`, keeping the existing padding as the minimum."
 
@@ -418,7 +666,7 @@ Force-close the app on your device, reopen it, wait ~15–30 seconds, and open a
 
 For deeper layout work, see [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor) and [Capacitor edge-to-edge display](/blog/capacitor-edge-to-edge-display-native-config/).
 
-## Step 12 — Prepare Your Store Listing
+## Step 14 — Prepare Your Store Listing
 
 Your app is built, installable, and you can push instant updates. Going live on the public stores is mostly paperwork:
 
@@ -429,7 +677,13 @@ Your app is built, installable, and you can push instant updates. Going live on 
 - **Age rating** — questionnaire in each console
 - **Data collection disclosures** — Apple Privacy Nutrition Labels and Google Data Safety
 
-Generate icons and splash screens:
+### Method 1: Using Cursor AI (Recommended)
+
+```
+Set up app icons and splash screens for my Capacitor app
+```
+
+### Method 2: Manual Setup
 
 ```shell
 npm install -D @capacitor/assets
@@ -453,7 +707,7 @@ See our [first-time app review guide](/blog/first-time-app-review-guide/) for th
 - **"This App ID … is not available"** — Bundle IDs are globally unique. Pick a reverse-domain ID you control.
 - **iOS build fails after changing the bundle ID** — The ID in your native project must match Apple App Store Connect. Find-and-replace across `ios/` and `android/`, commit, rebuild.
 - **White screen on launch** — Set `base: './'` in Vite config, rebuild, and run `npx cap sync`.
-- **Content under the status bar** — Add `viewport-fit=cover` and `env(safe-area-inset-top)` padding (Step 11).
+- **Content under the status bar** — Add `viewport-fit=cover` and `env(safe-area-inset-top)` padding (Step 13).
 - **APK signed in debug mode** — Google Play rejects debug builds. Use a release build signed with your keystore.
 - **Deployment rejected — version already exists** — Bump version/build number in native projects and rebuild.
 

--- a/apps/web/src/content/blog/en/transform-lovable-dev-app-to-mobile-with-capacitor.md
+++ b/apps/web/src/content/blog/en/transform-lovable-dev-app-to-mobile-with-capacitor.md
@@ -1,16 +1,17 @@
 ---
 slug: transform-lovable-dev-app-to-mobile-with-capacitor
-title: Lovable.dev to Native Mobile Apps with Capacitor
+title: Convert Your Lovable App to iOS and Android with Capacitor
 description: >-
-  Learn how to export your Lovable.dev project and transform it into native mobile apps using Capacitor. A complete step-by-step guide for 2025.
+  Step-by-step guide to export your Lovable project, wrap it with Capacitor, build
+  signed iOS and Android apps in the cloud with Capgo Builder, and ship fixes over the air.
 author: Martin Donadieu
 author_image_url: 'https://avatars.githubusercontent.com/u/4084527?v=4'
 author_url: 'https://x.com/martindonadieu'
 created_at: 2025-07-28T00:00:00.000Z
-updated_at: 2026-06-24T21:41:36.000Z
+updated_at: 2026-06-27T00:00:00.000Z
 head_image: /lovable_capacitor.webp
-head_image_alt: "Lovable.dev to Native Mobile Apps with Capacitor Capgo blog illustration"
-keywords: Lovable.dev, Capacitor, mobile app development, Next.js, export project, native mobile apps
+head_image_alt: "Convert your Lovable app to iOS and Android with Capacitor Capgo blog illustration"
+keywords: Lovable, Lovable.dev, Capacitor, mobile app development, React, Vite, export project, native mobile apps, Capgo Builder, live updates, vibe coding
 tag: Tutorial
 published: true
 locale: en
@@ -19,360 +20,212 @@ next_blog: building-a-native-mobile-app-with-nextjs-and-capacitor
 
 ## Introduction
 
-[Lovable.dev](https://lovable.dev/) is a powerful AI-powered development platform that generates beautiful Next.js applications in minutes. But what if you want to take your Lovable.dev creation to mobile devices? In this tutorial, we'll show you how to export your Lovable.dev project and transform it into native mobile apps using [Capacitor](https://capacitorjs.com/).
+[Lovable](https://lovable.dev/) is an AI app builder that turns prompts into working React apps in minutes. You can ship in the browser fast — but what if you want your app on the App Store and Google Play, sitting on home screens like every other native app?
 
-By the end of this guide, you'll have your Lovable.dev web app running natively on both iOS and Android devices, with access to native device features like camera, storage, and push notifications.
+This guide walks through the full path: export from Lovable, wrap the web app with [Capacitor](https://capacitorjs.com/), build signed iOS and Android binaries in the cloud with **[Capgo Builder](https://capgo.app/native-build/)** (no Mac required), add a real native feature, and push a layout fix over the air with **Capgo Live Updates**.
 
-### Prerequisites & Time Estimate
+**Time required:** about 1–2 hours the first time, mostly account setup and waiting on cloud builds.
 
-**Time Required**: 2-4 hours for first-time setup
+**By the end, you'll have:**
 
-**System Requirements**:
-- **For iOS**: Mac computer running macOS 12.0+
-- **For Android**: Windows, Mac, or Linux
-- **Storage**: 20GB free space
-- **RAM**: 8GB minimum
+- A native iOS and Android app built from the cloud — no Xcode or Android Studio on the main path
+- The app running on a real device (TestFlight, direct install, or Play internal testing)
+- A working camera feature that only a native app can offer
+- Live Updates configured so UI and CSS fixes ship without store review
 
-**Costs**:
-- **iOS App Store**: $99/year (Apple Developer Account)
-- **Android Play Store**: $25 one-time (Google Play Developer)
-- **Cursor Pro**: $20/month (optional but recommended)
+## Prerequisites
 
-**Required Software** (we'll help you install):
-- Node.js 16+
-- Xcode (iOS only)
-- Android Studio (Android only)
+| Requirement | Details |
+| --- | --- |
+| A computer | Mac, Windows, or Linux — cloud builds work from any OS |
+| A code editor | [Cursor](https://cursor.sh/) or VS Code |
+| Node.js | Version 20 or newer (22 LTS recommended) |
+| Git | To clone your Lovable repo from GitHub |
+| Capgo account | [Free signup](/register/) — cloud builds and Live Updates |
 
-### Why Transform Your Lovable.dev App to Mobile?
+**Costs (only to publish publicly):**
 
-- **Expanded Reach**: Access mobile users who prefer native apps over web browsers
-- **Native Features**: Leverage device capabilities like camera, GPS, and offline storage
-- **App Store Distribution**: Publish your app on Google Play Store and Apple App Store
-- **Better Performance**: Native container provides improved performance and user experience
-- **Push Notifications**: Engage users with native push notifications
+| Item | Cost |
+| --- | --- |
+| Apple Developer Program | $99/year |
+| Google Play Console | $25 one-time |
+| Capgo | Free tier available; paid plans for production scale |
 
-## Step 1: Export Your Lovable.dev Project
+**Optional (local simulator only):**
 
-To export your project from Lovable.dev, you need to link it to GitHub first, as per Lovable's export system.
+| Tool | Why |
+| --- | --- |
+| Xcode (~15 GB, macOS only) | iOS Simulator on your Mac |
+| Android Studio (~1 GB + SDKs) | Android emulator |
 
-### Link Your Project to GitHub
+You can skip both. The main path in this guide builds in the cloud and installs on real devices without them.
 
-1. Open your Lovable.dev project in the browser
-2. Look for the **GitHub** or **Connect to GitHub** option in the Lovable interface
+## A Quick Note on Lovable and Frameworks
+
+Before touching code, know that **the kind of web app Lovable generates affects mobile wrapping**.
+
+For a long time, Lovable's default was a **React + Vite single-page app (SPA)**. As of May 2026, brand-new Lovable apps may use **TanStack Start with server-side rendering (SSR)** by default. SSR is great for the web, but Capacitor wraps a **static build** — a folder of HTML, CSS, and JavaScript with an `index.html` at its root — that ships inside the app on the device.
+
+An SSR app expects a server to render pages on each request. There is no server inside a phone, so for Capacitor you want **static, client-rendered output**.
+
+**What to do:**
+
+- **Starting fresh:** Ask Lovable for a **single-page app (SPA)** or to skip SSR so you get a static `dist/` folder.
+- **Already on TanStack Start (SSR):** Configure it to pre-render or output a static SPA. The only hard requirement is a static build folder containing `index.html`.
+- **Legacy Next.js Lovable projects:** Use [static export](/blog/building-a-native-mobile-app-with-nextjs-and-capacitor/) — output goes to `out/` instead of `dist/`.
+
+Whatever framework you use, point Capacitor's `webDir` at that folder. For a Vite SPA, that folder is `dist`.
+
+## Step 1 — Export Your Lovable App to GitHub
+
+Lovable keeps your code in its editor until you connect GitHub.
+
+1. Open your Lovable project in the browser
+2. Click **Upgrade** (top-right) if needed, then open **Git** in the left menu
+3. Choose **GitHub**, authorize Lovable, and link your account
+4. Lovable creates a repository and pushes your app automatically
 
 ![Lovable.dev GitHub connection](/lovable_github_step_1.webp)
 
-3. Authorize Lovable.dev to access your GitHub account
-
 ![Lovable.dev GitHub authorization](/lovable_github_step_2.webp)
-
-4. Create or select a repository for your project
 
 ![Lovable.dev repository setup](/lovable_github_step_3.webp)
 
-5. Once connected, your project is now backed up to GitHub
-
 ![Lovable.dev project exported](/lovable_github_done.webp)
 
-### Download and Install Cursor
+✅ **Success:** Visiting `github.com/YOUR-USERNAME/your-app` shows your app's code.
 
-Before we can work with your code, you'll need a code editor. We recommend [Cursor](https://cursor.sh/), an AI-powered code editor that makes development easier:
+## Step 2 — Clone and Run Your App Locally
 
-1. Visit [cursor.sh](https://cursor.sh/) and download the version for your operating system
-2. Install Cursor following the installation wizard
-3. Once installed, open Cursor
+Open a terminal in [Cursor](https://cursor.sh/) or VS Code and clone the repo (replace `YOUR-USERNAME`):
 
-![Start Cursor](/start_in_cursor.webp)
-
-### Configure Cursor for AI Development
-
-For the best experience, we recommend configuring Cursor properly:
-
-1. **Buy a Cursor Plan** - While Cursor offers a free tier, purchasing a Pro plan ($20/month) gives you:
-   - Unlimited AI completions
-   - Access to GPT-4 and Claude models
-   - Faster response times
-   - Priority support
-
-2. **Open Cursor Settings** by pressing `Command+,` (Mac) or `Ctrl+,` (Windows)
-
-![Cursor Settings](/cursor_settings.webp)
-
-3. **Enable AI Models** - Make sure AI features are enabled:
-
-![Allow Models](/allow_models.webp)
-
-4. **Select Your Preferred Model** - Choose Claude or GPT-4 for best results:
-
-![Select Cursor Model](/select_cursor_model.webp)
-
-5. **Allow Command Execution** - Enable Cursor to run commands for you:
-
-![Allow Run Commands](/allow_run_commands.webp)
-
-### Clone Your Repository in Cursor
-
-Now let's get your Lovable.dev project into Cursor:
-
-1. In Cursor, press `Shift+Command+P` (Mac) or `Shift+Ctrl+P` (Windows) to open the command palette
-2. Type "clone" and select **"Git: Clone"**
-3. Paste your GitHub repository URL: `https://github.com/yourusername/your-lovable-project.git`
-4. Choose a folder where you want to save the project
-
-![Clone in Cursor](/clone_in_cursor.webp)
-
-5. Cursor will clone and open your project
-
-![Open in Cursor](/open_in_cursor.webp)
-
-## Step 2: Set Up Your Development Environment
-
-### Install Required Tools
-
-#### Method 1: Using Cursor AI (Recommended)
-
-1. Open Cursor's AI tab by pressing `Command+K` (Mac) or `Ctrl+K` (Windows)
-2. Type the following command:
-   ```
-   Install Homebrew, Node.js and npm on my system, then install dependencies and run the dev server
-   ```
-
-The AI will automatically:
-- Detect your operating system
-- Install Homebrew (on macOS)
-- Install Node.js and npm
-- Navigate to your project directory
-- Run `npm install` to install dependencies
-- Start your development server with `npm run dev`
-
-![Install Homebrew](/install_brew.webp)
-
-#### Method 2: Manual Installation (If AI doesn't work)
-
-Open the terminal in Cursor by pressing `Shift+Command+T` (Mac) or `Shift+Ctrl+T` (Windows), then:
-
-**For macOS:**
 ```shell
-# Install Homebrew
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-# Install Node.js
-brew install node
-
-# Navigate to your project
-cd your-lovable-project
-
-# Install dependencies
-npm install
-
-# Run dev server
-npm run dev
-```
-
-**For Windows:**
-1. Download Node.js from [nodejs.org](https://nodejs.org/)
-2. Run the installer
-3. Open terminal and run:
-```shell
-cd your-lovable-project
+git clone https://github.com/YOUR-USERNAME/your-lovable-app.git
+cd your-lovable-app
 npm install
 npm run dev
 ```
 
 ![Lovable.dev app running locally](/lovable-app-running.webp)
 
-Your Lovable.dev app should now be running at `http://localhost:3000`.
+Lovable apps typically run on `http://localhost:8080` or `http://localhost:5173` — use whatever address your terminal prints.
 
-## Step 3: Prepare for Mobile Export
+Press `Ctrl + C` to stop the dev server when you're ready to continue.
 
-Lovable.dev projects are built with Next.js, so we need to configure static export for mobile deployment.
+✅ **Success:** Your app opens in the browser with its UI working.
 
-### Configure Your Project
+## Step 3 — Prepare the Static Production Build
 
-#### Method 1: Using Cursor AI (Recommended)
+Capacitor needs a production build before you add native platforms.
 
-1. Press `Command+K` (Mac) or `Ctrl+K` (Windows)
-2. Type this request:
-   ```
-   Add a static export script to package.json and configure next.config.js for mobile export with Capacitor
-   ```
+### React + Vite (most Lovable apps)
 
-The AI will automatically update your files.
+Confirm `vite.config.ts` uses a relative base so assets load inside the native WebView:
 
-#### Method 2: Manual Configuration
+```typescript
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
 
-1. Open `package.json` and add to scripts:
-```json
-{
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
-    "static": "NEXT_PUBLIC_IS_MOBILE=true next build"
-  }
-}
-```
-
-2. Update `next.config.js`:
-```javascript
-/** @type {import('next').NextConfig} */
-const isMobile = process.env.NEXT_PUBLIC_IS_MOBILE === 'true';
-const nextConfig = {
-  ...(isMobile ? {output: 'export'} : {}),
-  reactStrictMode: true,
-  images: {
-    unoptimized: true,
+export default defineConfig({
+  plugins: [react()],
+  base: './',
+  build: {
+    outDir: 'dist',
   },
-  trailingSlash: true,
-};
-
-module.exports = nextConfig;
+})
 ```
 
-### Test Static Export
+Build and verify:
 
-**With Cursor AI:**
-```
-Run the static export and verify it creates an 'out' folder
-```
-
-**Manually:**
 ```shell
-npm run static
+npm run build
 ```
+
+You should see a `dist/` folder with `index.html` at its root.
 
 ![Lovable.dev static export success](/lovable-static-export.webp)
 
-You should see a new `out` folder containing your static files.
+### Legacy Next.js Lovable projects
 
-## Step 4: Add Capacitor to Your Lovable.dev Project
+If your repo uses Next.js, configure static export and build to `out/`. See [Convert Your Next.js App to Mobile](/blog/building-a-native-mobile-app-with-nextjs-and-capacitor/) for the full `next.config` setup, then use `webDir: 'out'` in Capacitor instead of `dist`.
 
-Now let's transform your Lovable.dev app into a native mobile app using Cursor AI.
+✅ **Success:** A static build folder exists (`dist/` or `out/`) with `index.html`.
 
-### Install and Initialize Capacitor
+## Step 4 — Add Capacitor and Native Platforms
 
-#### Method 1: Using Cursor AI (Recommended)
-
-1. Press `Command+K` (Mac) or `Ctrl+K` (Windows)
-2. Type this command:
-   ```
-   Install Capacitor CLI, initialize it for my app, and add iOS and Android platforms
-   ```
-
-The AI will handle everything automatically, asking you for:
-- **App name**: Your Lovable.dev project name
-- **Bundle ID**: Like `com.yourcompany.yourapp`
-
-![Capacitor initialization](/capacitor-init-lovable.webp)
-
-#### Method 2: Manual Installation
-
-Open terminal (`Shift+Command+T` or `Shift+Ctrl+T`) and run:
+Capacitor wraps your web app in real iOS and Android shells — no rewrite needed.
 
 ```shell
-# Install Capacitor CLI
-npm install -D @capacitor/cli
-
-# Initialize Capacitor
+npm install @capacitor/core @capacitor/cli
 npx cap init
+```
 
-# When prompted, enter:
-# - App name: Your Lovable App
-# - Bundle ID: com.yourcompany.yourapp
+When prompted:
 
-# Install core packages
-npm install @capacitor/core @capacitor/ios @capacitor/android
+| Prompt | Example | Notes |
+| --- | --- | --- |
+| App name | My Lovable App | Shown under the app icon |
+| App Package ID | com.yourcompany.myapp | Reverse-domain style — **cannot change after store publish** |
+| Web assets directory | `dist` | Use `out` for Next.js static export |
 
-# Add platforms
+**Pick a Package ID you actually own.** Bundle IDs are globally unique. Use a reverse-domain ID based on a domain you control (e.g. `com.yourcompany.myapp`) from the start — changing it later means find-and-replacing across `ios/` and `android/` and rebuilding.
+
+```shell
+npm run build
+npm install @capacitor/ios @capacitor/android
 npx cap add ios
 npx cap add android
-```
-
-![Capacitor platforms added](/capacitor-platforms-added.webp)
-
-### Understanding Your New Project Structure
-
-After adding platforms, your project now has:
-
-```
-your-lovable-project/
-├── src/           # Your Next.js source code
-├── public/        # Static assets
-├── out/           # Build output (after npm run static)
-├── ios/           # iOS native project (NEW)
-├── android/       # Android native project (NEW)
-├── capacitor.config.ts  # Capacitor settings
-└── package.json   # Dependencies
-```
-
-**Key Points**:
-- You'll mostly work in `src/` for app changes
-- The `ios/` and `android/` folders are auto-generated
-- Don't edit native folders directly unless necessary
-
-## Step 5: Configure Capacitor
-
-#### Method 1: Using Cursor AI (Recommended)
-
-Ask Cursor AI:
-```
-Update capacitor.config.ts to use 'out' as webDir and set up for HTTPS
-```
-
-#### Method 2: Manual Configuration
-
-Open `capacitor.config.ts` and update:
-```typescript
-import { CapacitorConfig } from '@capacitor/cli';
-
-const config: CapacitorConfig = {
-  appId: 'com.yourcompany.yourapp',
-  appName: 'Your Lovable App',
-  webDir: 'out',
-  bundledWebRuntime: false,
-  server: {
-    androidScheme: 'https'
-  }
-};
-
-export default config;
-```
-
-## Step 6: Build and Sync
-
-#### Method 1: Using Cursor AI (Recommended)
-
-Tell Cursor AI:
-```
-Build the static export and sync it with Capacitor platforms
-```
-
-#### Method 2: Manual Commands
-
-```shell
-# Build static export
-npm run static
-
-# Sync with native projects
 npx cap sync
 ```
 
-![Capacitor sync complete](/capacitor-sync-complete.webp)
+![Capacitor initialization](/capacitor-init-lovable.webp)
 
-## Step 7: Build Store-Ready Binaries with Capgo Builder (Recommended)
+![Capacitor platforms added](/capacitor-platforms-added.webp)
 
-You do not need a Mac or a full local Xcode/Android Studio pipeline to ship to the App Store and Google Play. **[Capgo Builder](https://capgo.app/native-build/)** compiles, signs, and can submit iOS and Android builds from the cloud — the fastest path for vibe-coded apps exported from Lovable.
+Your project now looks like:
 
-### Why Capgo Builder?
+```
+your-lovable-app/
+├── android/              ← native Android project
+├── ios/                  ← native iOS project
+├── dist/                 ← built web app (or out/ for Next.js)
+├── src/                  ← your Lovable app code
+├── capacitor.config.ts
+└── package.json
+```
 
-- **No Mac required for iOS** — build from Windows, Linux, or your AI coding environment
-- **One CLI workflow** — easy to script and hand off to Cursor, Claude Code, or Codex
-- **Pairs with Live Updates** — ship JS/UI fixes over the air; rebuild the native binary only when plugins or permissions change
+**No CocoaPods needed.** Capacitor 8 uses Swift Package Manager for iOS dependencies automatically.
+
+✅ **Success:** `ios/` and `android/` folders appear and the terminal shows `Sync finished`.
+
+## Step 5 — Check Your `.gitignore`
+
+Capgo Builder compiles from your Git repository, so `ios/` and `android/` **must be committed**. A common mistake is ignoring them at the repo root.
+
+Confirm:
+
+- Root `.gitignore` ignores `node_modules` and `dist` (the cloud rebuilds `dist` during web builds)
+- `ios/` and `android/` themselves are **not** ignored
+
+`npx cap add` already adds platform-level `.gitignore` files that ignore build artifacts but keep the project source.
+
+✅ **Success:** `git status` shows `ios/` and `android/` ready to commit (not ignored).
+
+## Step 6 — Commit and Push
+
+```shell
+git add .
+git commit -m "Add Capacitor and native iOS/Android platforms"
+git push
+```
+
+✅ **Success:** Your GitHub repo shows the `ios/` and `android/` folders.
+
+## Step 7 — Build Store-Ready Binaries with Capgo Builder
+
+You do not need a Mac or local Xcode/Android Studio pipeline to ship. **Capgo Builder** compiles, signs, and can submit iOS and Android builds from the cloud.
 
 ### Set up Capgo Builder
-
-After your static export and Capacitor sync work locally:
 
 ```shell
 npx @capgo/cli@latest login
@@ -381,321 +234,253 @@ npx @capgo/cli@latest build init --platform ios
 npx @capgo/cli@latest build init --platform android
 ```
 
-Save signing credentials once (Apple certificates, provisioning profiles, Android keystore). See [Managing Credentials](/docs/builder/credentials/) and [Build iOS from Windows](/blog/build-ios-app-from-windows-capacitor-capgo-build/).
+Save signing credentials once. Use our free tools if you need help generating them:
+
+- [iOS Certificate Generator](/tools/ios-certificate-generator/)
+- [Android Keystore Generator](/tools/android-keystore-generator/)
+- [iOS UDID Finder](/tools/ios-udid-finder/) — register your iPhone for development builds
+
+See [Managing Credentials](/docs/builder/credentials/) and [Build iOS from Windows](/blog/build-ios-app-from-windows-capacitor-capgo-build/).
 
 ### Request a cloud build
 
 ```shell
-npm run static
+npm run build
 npx cap sync
-npx @capgo/cli@latest build com.yourcompany.yourapp --platform ios --build-mode release
-npx @capgo/cli@latest build com.yourcompany.yourapp --platform android --build-mode release
+npx @capgo/cli@latest build com.yourcompany.myapp --platform ios --build-mode release
+npx @capgo/cli@latest build com.yourcompany.myapp --platform android --build-mode release
 ```
 
-Capgo Builder streams build logs in your terminal. With App Store Connect configured, iOS builds can go straight to TestFlight.
+Build logs stream in your terminal. With App Store Connect configured, iOS builds can upload to TestFlight automatically.
 
-Upload your web bundle for OTA updates:
+**Install on a real device:**
+
+- **iOS:** TestFlight (recommended) or a development build with your device UDID registered
+- **Android:** Google Play internal testing track or a signed release APK/AAB
+
+✅ **Success:** A signed build completes and you can install it on a real device.
+
+## Step 8 — Optional: Test Locally in Xcode or Android Studio
+
+If you have a Mac or want emulator testing:
 
 ```shell
-npx @capgo/cli@latest bundle upload --channel production
-```
-
-## Step 8: Open Native IDEs (Optional for Local Testing)
-
-If you have a Mac or want emulator testing before cloud builds, open the native projects locally:
-
-### For iOS Development
-
-#### Method 1: Using Cursor AI (Recommended)
-```
-Open the iOS project in Xcode
-```
-
-#### Method 2: Manual Command
-```shell
-npx cap open ios
+npx cap open ios      # Xcode + iOS Simulator
+npx cap open android  # Android Studio + emulator
 ```
 
 ![Xcode opening Lovable project](/xcode-lovable-project.webp)
 
-### For Android Development
-
-#### Method 1: Using Cursor AI (Recommended)
-```
-Open the Android project in Android Studio
-```
-
-#### Method 2: Manual Command
-```shell
-npx cap open android
-```
-
 ![Android Studio opening Lovable project](/android-studio-lovable-project.webp)
-
-## Step 9: Build and Run Locally (Optional)
-
-### Running on iOS
-
-#### First-Time Xcode Setup
-
-1. **Select a Simulator**:
-   - Click the device selector next to the Play button
-   - Choose "iPhone 14" or any available simulator
-   - If none appear: Xcode > Settings > Platforms > Download iOS Simulator
-
-2. **Handle Code Signing** (for real devices only):
-   - Click your project name in the navigator
-   - Select "Signing & Capabilities"
-   - Check "Automatically manage signing"
-   - Select your Apple Developer account
-   - If you see errors, you need to enroll in Apple Developer Program ($99/year)
-
-3. **Build and Run**:
-   - Click the ▶️ Play button
-   - First build takes 5-10 minutes
-   - Simulator will launch automatically
-
-**Common Issues**:
-- **"Command PhaseScriptExecution failed"**: Run `cd ios && pod install`
-- **"No simulator available"**: Download one in Xcode Settings
-- **"Signing requires a development team"**: Need Apple Developer account
 
 ![Lovable app running on iOS](/lovable-ios-app.webp)
 
-### Running on Android
-
-#### First-Time Android Studio Setup
-
-1. **Install Android SDK** (if prompted):
-   - Android Studio will show "Missing SDK" 
-   - Click "Install missing SDK packages"
-   - Accept licenses and wait for download
-
-2. **Create an Emulator**:
-   - Click "Device Manager" (phone icon)
-   - Click "Create Device"
-   - Select "Pixel 6" > Next
-   - Select "API 33" (or latest) > Download > Next
-   - Click Finish
-
-3. **Build and Run**:
-   - Select your emulator from dropdown
-   - Click green ▶️ Run button
-   - First build takes 5-15 minutes
-   - Emulator will start automatically
-
-**Common Issues**:
-- **"SDK not found"**: Let Android Studio install it
-- **"Gradle sync failed"**: File > Sync Project
-- **Emulator won't start**: Check virtualization is enabled in BIOS
-
 ![Lovable app running on Android](/lovable-android-app.webp)
 
-### Success Indicators
+Use local IDEs for day-to-day debugging. Use **Capgo Builder** when you need signed release binaries.
 
-✅ **iOS Success**: App opens in simulator showing your Lovable.dev content
-✅ **Android Success**: App opens in emulator with your web app running
+## Step 9 — Add a Native Feature: The Camera
 
-If you see a white screen, check the terminal for errors.
+A Capacitor plugin lets JavaScript call real device features. We'll add the Camera plugin so users can snap a photo — something a browser tab cannot do reliably.
 
-## Step 10: Enable Live Reload (Development)
-
-### Method 1: Using Cursor AI (Recommended)
-
-Tell Cursor AI:
-```
-Set up live reload for Capacitor development with my local IP address
-```
-
-The AI will automatically configure everything.
-
-### Method 2: Manual Setup
-
-1. Find your local IP address:
 ```shell
-# macOS
-ipconfig getifaddr en0
-
-# Windows
-ipconfig
+npm install @capacitor/camera
+npx cap sync
 ```
 
-2. Update `capacitor.config.ts`:
+### Declare camera permissions
+
+**iOS** — add to `ios/App/App/Info.plist` inside the top-level `<dict>`:
+
+```xml
+<key>NSCameraUsageDescription</key>
+<string>This app uses the camera to take photos.</string>
+```
+
+**Android** — add inside `<manifest>` in `android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.CAMERA" />
+```
+
+### Use the camera in your app
+
 ```typescript
-import { CapacitorConfig } from '@capacitor/cli';
+import { Camera, CameraResultType } from '@capacitor/camera';
+
+async function takePhoto() {
+  const photo = await Camera.getPhoto({
+    quality: 90,
+    resultType: CameraResultType.Uri,
+  });
+  return photo.webPath;
+}
+```
+
+Capacitor shows the system permission dialog the first time — using the message you wrote in `Info.plist`.
+
+![Native features added](/lovable-native-features.webp)
+
+Adding a plugin requires a **fresh native build** through Capgo Builder before it works on devices.
+
+✅ **Success:** Camera code compiles and `npx cap sync` finishes without errors.
+
+## Step 10 — Add Capgo Live Updates
+
+Every native change — even a typo fix in native config — normally goes through app store review. **Capgo Live Updates** push changes to your app's web layer (HTML, CSS, JS, images) over the air in minutes.
+
+**Install the updater in your first release** so you're never stuck waiting on review when you need to ship a fix.
+
+```shell
+npm install @capgo/capacitor-updater
+npx cap sync
+```
+
+Add to `capacitor.config.ts`:
+
+```typescript
+import type { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
-  appId: 'com.yourcompany.yourapp',
-  appName: 'Your Lovable App',
-  webDir: 'out',
-  bundledWebRuntime: false,
-  server: {
-    url: 'http://YOUR_IP_ADDRESS:3000',
-    cleartext: true,
+  appId: 'com.yourcompany.myapp',
+  appName: 'My Lovable App',
+  webDir: 'dist',
+  plugins: {
+    CapacitorUpdater: {
+      autoUpdate: true,
+    },
   },
 };
 
 export default config;
 ```
 
-3. Apply changes:
+Initialize in your app entry (e.g. `src/main.tsx`):
+
+```typescript
+import { CapacitorUpdater } from '@capgo/capacitor-updater';
+
+void CapacitorUpdater.notifyAppReady();
+```
+
+Commit, push, and run a new Capgo Builder build so the updater SDK is in the native shell.
+
+Upload web bundles after launch:
+
 ```shell
-npx cap copy
+npm run build
+npx @capgo/cli@latest bundle upload --channel production
 ```
 
-![Live reload enabled](/capacitor-live-reload.webp)
+See [Capgo Live Updates docs](/docs/live-updates/getting-started/).
 
-## Step 11: Add Native Features
+✅ **Success:** Updater plugin is installed and `notifyAppReady()` runs on startup.
 
-### Method 1: Using Cursor AI (Recommended)
+## Step 11 — Fix Status Bar Spacing with a Live Update
 
-Tell Cursor AI:
+On a real iPhone, your header may sit **under** the status bar (clock and battery). Modern Capacitor draws edge-to-edge, so your app must respect **safe area insets**: `env(safe-area-inset-top)`, `-bottom`, `-left`, `-right`.
+
+Many Lovable apps already handle the bottom inset but use fixed top padding (like `pt-6`) without the top inset.
+
+**1. Confirm `viewport-fit=cover`** in `index.html`:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 ```
-Add native share functionality to my app using Capacitor Share plugin
+
+**2. Fix top headers** — use `max()` to keep web padding and grow on notched devices:
+
+```css
+/* Before */
+padding-top: 1.5rem;
+
+/* After */
+padding-top: max(1.5rem, env(safe-area-inset-top));
 ```
 
-The AI will handle everything automatically.
+In Tailwind, ask Lovable:
 
-### Method 2: Manual Implementation
+> "The app content runs under the status bar at the top on mobile. Add `env(safe-area-inset-top)` to the top padding of each page header using `max()`, keeping the existing padding as the minimum."
 
-1. Install the Share plugin:
+**3. Ship the fix over the air** — this is pure CSS, no native rebuild needed:
+
 ```shell
-npm install @capacitor/share
+git add .
+git commit -m "Fix top safe area on mobile"
+git push
+npm run build
+npx @capgo/cli@latest bundle upload --channel production
 ```
 
-2. Add to your component:
-```javascript
-import { Share } from '@capacitor/share';
+Force-close the app on your device, reopen it, wait ~15–30 seconds, and open again. The header should sit below the status bar — fixed without store review.
 
-const shareContent = async () => {
-  await Share.share({
-    title: 'Check out my Lovable app!',
-    text: 'Built with Lovable.dev and Capacitor',
-    url: 'https://your-app-url.com',
-    dialogTitle: 'Share with friends',
-  });
-};
+✅ **Success:** Top content clears the status bar after the OTA bundle applies.
 
-// Add to your JSX
-<button onClick={shareContent} className="btn-primary">
-  Share App
-</button>
-```
+For deeper layout work, see [@capgo/tailwind-capacitor](https://github.com/Cap-go/tailwind-capacitor) and [Capacitor edge-to-edge display](/blog/capacitor-edge-to-edge-display-native-config/).
 
-3. Sync changes:
-```shell
-npx cap sync
-```
+## Step 12 — Prepare Your Store Listing
 
-![Native features added](/lovable-native-features.webp)
+Your app is built, installable, and you can push instant updates. Going live on the public stores is mostly paperwork:
 
-### Quick Test: Verify Native Features Work
+- **App icon** — 1024×1024px for iOS (no transparency), 512×512px for Google Play
+- **Screenshots** — Apple requires iPhone 6.9" (1320×2868px) screenshots
+- **App name, subtitle, description, keywords**
+- **Privacy policy URL** — required by both stores, even for free apps
+- **Age rating** — questionnaire in each console
+- **Data collection disclosures** — Apple Privacy Nutrition Labels and Google Data Safety
 
-Test your new native capabilities:
+Generate icons and splash screens:
 
-1. **Share Button**: Click it and see native share dialog
-2. **Camera Access**: Test on real device (simulators have limited camera)
-3. **Check Console**: No errors should appear
-
-If features don't work, ensure you've run `npx cap sync` after adding plugins.
-
-## Step 12: Optimize for Production
-
-### App Icons and Splash Screens
-
-#### Method 1: Using Cursor AI (Recommended)
-```
-Set up app icons and splash screens for my Capacitor app
-```
-
-#### Method 2: Manual Setup
-
-1. Install Capacitor Assets:
 ```shell
 npm install -D @capacitor/assets
-```
-
-2. Create your assets:
-   - Add `assets/icon.png` (1024x1024px)
-   - Add `assets/splash.png` (2732x2732px)
-
-3. Generate all sizes:
-```shell
+# Add assets/icon.png (1024x1024) and assets/splash.png (2732x2732)
 npx capacitor-assets generate
+npx cap sync
 ```
 
 ![App assets generated](/lovable-app-assets.webp)
 
-### Build for Production
+**What's left before "live":**
 
-#### Method 1: Using Cursor AI (Recommended)
-```
-Build my app for production and sync all platforms
-```
+1. **Google Play closed testing** (personal accounts created after Nov 13, 2023): at least 12 testers for 14 consecutive days before production access. iOS has no equivalent.
+2. **Submit for review** — Apple ~3–5 days, Google ~3–7 days after testing requirements are met.
 
-#### Method 2: Manual Build
-```shell
-npm run static
-npx cap sync
-npx cap copy
-```
+See our [first-time app review guide](/blog/first-time-app-review-guide/) for the full checklist.
 
-## Troubleshooting Common Issues
+## Common Errors (and How to Fix Them)
 
-### Build Errors
+- **`Could not find the web assets directory: ./dist`** — Run `npm run build` before `npx cap add` or `npx cap sync`. Make sure `webDir` in `capacitor.config.ts` matches your framework output (`dist` for Vite, `out` for Next.js static export).
+- **"This App ID … is not available"** — Bundle IDs are globally unique. Pick a reverse-domain ID you control.
+- **iOS build fails after changing the bundle ID** — The ID in your native project must match Apple App Store Connect. Find-and-replace across `ios/` and `android/`, commit, rebuild.
+- **White screen on launch** — Set `base: './'` in Vite config, rebuild, and run `npx cap sync`.
+- **Content under the status bar** — Add `viewport-fit=cover` and `env(safe-area-inset-top)` padding (Step 11).
+- **APK signed in debug mode** — Google Play rejects debug builds. Use a release build signed with your keystore.
+- **Deployment rejected — version already exists** — Bump version/build number in native projects and rebuild.
 
-If you encounter build errors:
-
-1. Check that all Lovable.dev dependencies are compatible
-2. Ensure your `next.config.js` has the correct export settings
-3. Verify that static export generates the `out` folder correctly
-
-### Missing Assets
-
-If images or assets don't load:
-
-1. Ensure all asset paths are relative
-2. Check that images are in the `public` folder
-3. Verify that the `images.unoptimized: true` setting is in your config
-
-### Performance Issues
-
-For better performance:
-
-1. Optimize images using Next.js Image optimization
-2. Implement lazy loading for heavy components
-3. Remove unused dependencies from your Lovable.dev project
+For Capgo Builder issues, see [Native Build troubleshooting](/docs/builder/troubleshooting/) and [Live Updates debugging](/docs/plugins/updater/debugging/).
 
 ## Conclusion
 
-Congratulations! You've successfully transformed your Lovable.dev Next.js app into native mobile applications. Your AI-generated web app can now:
-
-- Run natively on iOS and Android devices
-- Access device features like camera and storage
-- Be distributed through app stores
-- Provide a native user experience
+You took a Lovable web app to native iOS and Android — built in the cloud without a Mac, with a real camera feature and a layout fix shipped over the air. That's the hard part done.
 
 ### Next Steps
 
-- **[Capgo Builder](/native-build/)**: Use cloud native builds for TestFlight and Play Store releases
-- **Live Updates**: Implement [Capgo](https://capgo.app/) for over-the-air updates
-- **Push Notifications**: Add the Capacitor Push Notifications plugin
-- **Analytics**: Integrate mobile analytics to track user behavior
-- **Performance Monitoring**: Monitor your app's performance on mobile devices
+- **[Capgo Live Updates](/live-updates/)** — Ship UI and copy fixes without waiting on store review
+- **[Capgo Builder](/native-build/)** — Automate release builds in CI
+- **[Capgo Plugin Directory](/plugins/)** — Biometrics, push notifications, geolocation, and more
+- **Related guides:** [Base44 to mobile](/blog/transform-base44-app-to-mobile-with-capacitor/) · [Bolt.new to mobile](/blog/transform-bolt-new-app-to-mobile-with-capacitor/)
 
-Your Lovable.dev creation is now ready for the mobile world!
+[Sign up for a free Capgo account](/register/) to enable Live Updates and cloud native builds.
 
 ## Resources
 
-- [Lovable.dev Documentation](https://docs.lovable.dev/)
+- [Lovable Documentation](https://docs.lovable.dev/)
 - [Capacitor Documentation](https://capacitorjs.com/docs)
-- [Capgo Builder — Cloud Native Builds](/native-build/)
-- [Capgo - Live Updates for Capacitor Apps](https://capgo.app/)
-- [Base44 to mobile](/blog/transform-base44-app-to-mobile-with-capacitor/)
-- [Next.js Static Export Guide](https://nextjs.org/docs/app/building-your-application/deploying/static-exports)
+- [Capgo Native Builds](/native-build/)
+- [Capgo — Live Updates for Capacitor Apps](https://capgo.app/)
+- [Build iOS from Windows](/blog/build-ios-app-from-windows-capacitor-capgo-build/)
+- [Next.js static export for mobile](/blog/building-a-native-mobile-app-with-nextjs-and-capacitor/)
 
-Learn how Capgo can help you deliver updates to your mobile app instantly, [sign up for a free account](/register/) today.
+## Keep going from Convert Your Lovable App to iOS and Android with Capacitor
 
-## Keep going from Lovable.dev to Native Mobile Apps with Capacitor
-
-If you are using **Lovable.dev to Native Mobile Apps with Capacitor** to plan native plugin work, connect it with [Capgo Plugin Directory](/plugins/) for the product workflow in Capgo Plugin Directory, [Capacitor Plugins by Capgo](/docs/plugins/) for the implementation detail in Capacitor Plugins by Capgo, [Adding or Updating Plugins](/docs/contributing/adding-plugins/) for the implementation detail in Adding or Updating Plugins, [Ionic Enterprise Plugin Alternatives](/ionic-enterprise-plugins/) for the product workflow in Ionic Enterprise Plugin Alternatives, and [Capgo Native Builds](/native-build/) for the product workflow in Capgo Native Builds.
+If you are using **Convert Your Lovable App to iOS and Android with Capacitor** to plan native plugin work, connect it with [Capgo Plugin Directory](/plugins/) for the product workflow in Capgo Plugin Directory, [Capacitor Plugins by Capgo](/docs/plugins/) for the implementation detail in Capacitor Plugins by Capgo, [Capgo Native Builds](/native-build/) for the product workflow in Capgo Native Builds, and [Build iOS from Windows](/blog/build-ios-app-from-windows-capacitor-capgo-build/) for cloud iOS builds without a Mac.


### PR DESCRIPTION
## Summary

- Rewrote the Lovable → Capacitor tutorial to match our Base44 guide structure and current Lovable stack reality (React + Vite SPA, TanStack Start SSR caveat, legacy Next.js path)
- Made the main path cloud-first with Capgo Builder (no Mac/Xcode required), added `.gitignore` + commit steps, bundle ID guidance, camera plugin permissions, Capgo Live Updates setup, safe-area OTA fix walkthrough, store listing checklist, and expanded troubleshooting
- Trimmed outdated Cursor onboarding noise and fixed a stale cross-reference in the Base44 article

## Test plan

- [ ] Open `/blog/transform-lovable-dev-app-to-mobile-with-capacitor/` and verify headings, code blocks, and internal links render
- [ ] Confirm SEO metadata (title, description, keywords) looks correct
- [ ] Spot-check links to Capgo Builder, Live Updates docs, certificate tools, and related guides


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed the guide for converting a Lovable app into iOS and Android apps with Capacitor.
  * Added clearer setup guidance, including build requirements, local testing, live reload, and cloud build steps.
  * Expanded native app sections with camera permissions, live updates, safe-area spacing fixes, and app store preparation tips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->