### PR TITLE
docs(updater): align autoUpdate settings with plugin v8.50 JSDoc

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/updater/settings.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/updater/settings.mdx
@@ -139,7 +139,7 @@ Default: `false`
 ## `autoUpdate`
 
 > Configure how the plugin checks for, downloads, and applies live updates.
-> The plugin checks for updates when the app moves to the foreground and, if `periodCheckDelay` is set, on a repeating timer while the app stays open.
+> The plugin checks for updates when the app moves to the foreground and on a repeating timer while the app stays open. `periodCheckDelay` controls that timer interval.
 > Boolean values are still supported for backward compatibility: `true` is the same as `"atBackground"` and `false` is the same as `"off"`.
 > String values merge the previous Auto Update and Direct Update configuration.
 
@@ -211,10 +211,10 @@ Default: `undefined`
 > This option remains supported for existing apps.
 
 Options:
-- `false`: Never do direct updates (use default behavior: download on foreground check, apply when backgrounded)
-- `'atInstall'`: Direct update only after app install or native app store update, otherwise act as `directUpdate = false`
-- `'onLaunch'`: Direct update only when the app is brought to the foreground from a killed state, otherwise act as `directUpdate = false`
-- `'always'`: Direct update on every foreground check whenever an update is available, never act as `directUpdate = false`
+- `false`: Never do direct updates
+- `'atInstall'`: Same as `autoUpdate: "atInstall"`
+- `'onLaunch'`: Same as `autoUpdate: "onLaunch"`
+- `'always'`: Same as `autoUpdate: "always"`
 - `true`: (deprecated) Same as `"always"` for backward compatibility
 
 Available on Android, iOS, and Electron.

--- a/apps/docs/src/content/docs/docs/plugins/updater/settings.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/updater/settings.mdx
@@ -138,16 +138,18 @@ Default: `false`
 
 ## `autoUpdate`
 
-> Configure how the plugin should use Auto Update via an update server.
+> Configure how the plugin checks for, downloads, and applies live updates.
+> The plugin checks for updates when the app moves to the foreground and, if `periodCheckDelay` is set, on a repeating timer while the app stays open.
 > Boolean values are still supported for backward compatibility: `true` is the same as `"atBackground"` and `false` is the same as `"off"`.
+> String values merge the previous Auto Update and Direct Update configuration.
 
 Options:
-- `"off"` or `false`: Disable Auto Update
-- `"atBackground"` or `true`: Check and download automatically, then apply when the app moves to the background
-- `"atInstall"`: Apply immediately only after a fresh install or native app update, otherwise use `"atBackground"`
-- `"onLaunch"`: Apply immediately on launch, otherwise use `"atBackground"` after the launch check
-- `"always"`: Apply immediately whenever Auto Update runs
-- `"onlyDownload"`: Check and download automatically, emit `updateAvailable`, and never set the next bundle automatically
+- `"off"` or `false`: Disable automatic update checks
+- `"atBackground"` or `true`: Check and download automatically on each foreground check, then apply the update the next time the app moves to background
+- `"atInstall"`: Apply immediately only after a fresh install or native app store update; otherwise use `"atBackground"` behavior
+- `"onLaunch"`: Apply immediately only when the app is brought to the foreground from a killed state (cold start). After that first check, fall back to `"atBackground"` behavior
+- `"always"`: Check on every foreground transition and apply immediately whenever an update is available
+- `"onlyDownload"`: Check and download automatically, emit `updateAvailable`, and never set the next bundle or apply an update automatically
 
 Available on Android, iOS, and Electron.
 
@@ -209,11 +211,11 @@ Default: `undefined`
 > This option remains supported for existing apps.
 
 Options:
-- `false`: Never do direct updates
-- `'atInstall'`: Same as `autoUpdate: "atInstall"`
-- `'onLaunch'`: Same as `autoUpdate: "onLaunch"`
-- `'always'`: Same as `autoUpdate: "always"`
-- `true`: (deprecated) Same as "always" for backward compatibility
+- `false`: Never do direct updates (use default behavior: download on foreground check, apply when backgrounded)
+- `'atInstall'`: Direct update only after app install or native app store update, otherwise act as `directUpdate = false`
+- `'onLaunch'`: Direct update only when the app is brought to the foreground from a killed state, otherwise act as `directUpdate = false`
+- `'always'`: Direct update on every foreground check whenever an update is available, never act as `directUpdate = false`
+- `true`: (deprecated) Same as `"always"` for backward compatibility
 
 Available on Android, iOS, and Electron.
 


### PR DESCRIPTION
## Summary
- Update the `autoUpdate` settings docs to match the clarified behavior in `@capgo/capacitor-updater` v8.50 (PR #829).
- Document when update checks run (foreground transitions and optional `periodCheckDelay` timer).
- Clarify `onLaunch` as cold-start-only instant apply, and `always` as check-on-every-foreground with immediate apply.
- Align deprecated `directUpdate` option descriptions with the same wording.

## Test plan
- [ ] Docs build passes in CI
- [ ] Review `/docs/plugins/updater/settings/#autoupdate` renders correctly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how update settings behave, including when checks run, how repeating checks work, and how legacy boolean values map to current options.
  * Updated the available auto-update modes with clearer descriptions of when updates are downloaded, applied, or deferred.
  * Refined direct-update guidance to show exactly how each mode behaves in different app states, including backward-compatible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->