### PR TITLE
chore: allow SME acronym in typo checks

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -31,6 +31,7 @@ Damon = "Damon"
 # Acronyms and technical terms
 ASO = "ASO"  # App Store Optimization
 ITMS = "ITMS"  # iTunes Music Store
+SME = "SME"  # Small and medium-sized enterprise acronym
 Hashi = "Hashi"  # HashiCorp (brand name)
 formatable = "formatable"  # NFC event literal from upstream API
 jus = "jus"  # Brazilian justice app package namespace


### PR DESCRIPTION
## Summary
- Add `SME` to `_typos.toml` extend-words allowlist.
- Fixes false positive in `app-authorization.md` where typos flagged SME (small and medium-sized enterprise) as a typo.

## Test plan
- [x] `bunx typos .` passes locally
- [ ] Spell Check with Typos passes in CI


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated typo-checking rules to recognize the `SME` acronym, preventing it from being flagged as a typo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->