### PR TITLE
[codex] Document native build review submission

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -32,7 +32,6 @@ Damon = "Damon"
 ASO = "ASO"  # App Store Optimization
 SME = "SME"  # Small and medium-sized enterprise
 ITMS = "ITMS"  # iTunes Music Store
-SME = "SME"  # Small and medium-sized enterprise acronym
 Hashi = "Hashi"  # HashiCorp (brand name)
 formatable = "formatable"  # NFC event literal from upstream API
 jus = "jus"  # Brazilian justice app package namespace

--- a/apps/docs/src/content/docs/docs/builder/android.mdx
+++ b/apps/docs/src/content/docs/docs/builder/android.mdx
@@ -443,6 +443,21 @@ bunx @capgo/cli@latest build request com.example.app --platform android
 
 And this will start the build process 🍾🥂
 
+### Submit the Play release for review
+
+By default, Android release builds upload to Google Play and can remain inactive until you finish the release in Play Console. If your CI release should submit the Play release automatically, pass `--submit-to-store-review` with a release build:
+
+```bash
+npx @capgo/cli@latest build request com.example.app \
+  --platform android \
+  --build-mode release \
+  --submit-to-store-review \
+  --store-release-name "1.2.3" \
+  --store-release-notes "Bug fixes and performance improvements"
+```
+
+This requires the same Google Play service account setup as the normal upload path (`PLAY_CONFIG_JSON` in CI or saved Android credentials locally). `--store-release-name` is used as the Google Play release name, and `--store-release-notes` is used as the Play changelog.
+
 ## Keep going from Android Builds
 
 If you are using **Android Builds** to plan CI/CD automation, connect it with [Capgo CI/CD](/ci_cd/) for the product workflow in Capgo CI/CD, [Capgo Native Builds](/native-build/) for the product workflow in Capgo Native Builds, [Capgo Integrations](/integrations/) for the product workflow in Capgo Integrations, [CI/CD Integration](/docs/getting-started/cicd-integration/) for the implementation detail in CI/CD Integration, and [GitHub Actions Integration](/docs/live-updates/integrations/github-actions/) for the implementation detail in GitHub Actions Integration.

--- a/apps/docs/src/content/docs/docs/builder/github-actions.mdx
+++ b/apps/docs/src/content/docs/docs/builder/github-actions.mdx
@@ -325,7 +325,7 @@ iOS uses the App Store Connect API key path and submits the build to external Te
     CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
     BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
     P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-    CAPGO_IOS_PROVISIONING_MAP_BASE64: ${{ secrets.CAPGO_IOS_PROVISIONING_MAP_BASE64 }}
+    CAPGO_IOS_PROVISIONING_MAP: ${{ secrets.CAPGO_IOS_PROVISIONING_MAP }}
     APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
     APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
     APPLE_KEY_CONTENT: ${{ secrets.APPLE_KEY_CONTENT }}

--- a/apps/docs/src/content/docs/docs/builder/github-actions.mdx
+++ b/apps/docs/src/content/docs/docs/builder/github-actions.mdx
@@ -293,6 +293,57 @@ The `paths` filter ensures the workflow doesn't run on doc-only changes. `--no-p
 
 For test builds, skip store submission: Android uses `--no-playstore-upload`; for iOS, build in ad-hoc mode with `--ios-distribution ad_hoc` (which never submits to the App Store). Combine either with `--output-upload` to get a time-limited download URL for the binary.
 
+### Submit the store release for review
+
+By default, release builds upload the signed artifact and leave the final store action under your control. For CI releases that should move directly into the store review flow, add `--submit-to-store-review`.
+
+Android uses your `PLAY_CONFIG_JSON` service account and submits the Google Play release instead of leaving it inactive. Add `--store-release-name` and `--store-release-notes` when you want the Play release to carry the same tag and changelog as CI:
+
+```yaml
+- name: Submit Android release for review
+  env:
+    CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
+    ANDROID_KEYSTORE_FILE: ${{ secrets.ANDROID_KEYSTORE_FILE }}
+    KEYSTORE_KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+    KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+    KEYSTORE_STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
+    PLAY_CONFIG_JSON: ${{ secrets.PLAY_CONFIG_JSON }}
+  run: |
+    npx @capgo/cli@latest build request com.example.app \
+      --platform android \
+      --build-mode release \
+      --submit-to-store-review \
+      --store-release-name "${GITHUB_REF_NAME}" \
+      --store-release-notes "Release ${GITHUB_REF_NAME}"
+```
+
+iOS uses the App Store Connect API key path and submits the build to external TestFlight review. It requires `app_store` distribution and at least one external TestFlight group:
+
+```yaml
+- name: Submit iOS build to external TestFlight review
+  env:
+    CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
+    BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+    P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+    CAPGO_IOS_PROVISIONING_MAP_BASE64: ${{ secrets.CAPGO_IOS_PROVISIONING_MAP_BASE64 }}
+    APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
+    APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
+    APPLE_KEY_CONTENT: ${{ secrets.APPLE_KEY_CONTENT }}
+    APP_STORE_CONNECT_TEAM_ID: ${{ secrets.APP_STORE_CONNECT_TEAM_ID }}
+  run: |
+    npx @capgo/cli@latest build request com.example.app \
+      --platform ios \
+      --build-mode release \
+      --ios-distribution app_store \
+      --submit-to-store-review \
+      --ios-testflight-groups "External Testers" \
+      --store-release-notes "Release ${GITHUB_REF_NAME}"
+```
+
+<Aside type="caution">
+This path only submits the build artifact. Store listing metadata, tester groups, review contact details, compliance answers, and rollout choices still need to be ready in App Store Connect or Google Play Console before CI runs it.
+</Aside>
+
 ### Read the build output URL and QR code
 
 Pass `--output-record <path>` to persist the build artifact URL and QR code to disk when the build succeeds, then read it back in subsequent steps with `build last-output`. No log scraping, no regex.

--- a/apps/docs/src/content/docs/docs/builder/ios.mdx
+++ b/apps/docs/src/content/docs/docs/builder/ios.mdx
@@ -615,6 +615,22 @@ bunx @capgo/cli@latest build request --platform ios
 Congratulations 🎉
 At this point, you have successfully built your app and it is ready to be submitted to the App Store.
 
+### Submit to external TestFlight review
+
+The normal App Store build path uploads the build to App Store Connect/TestFlight. If your CI release should also submit that build to external TestFlight review, pass `--submit-to-store-review` and select the external groups that should receive the build:
+
+```bash
+npx @capgo/cli@latest build request com.example.app \
+  --platform ios \
+  --build-mode release \
+  --ios-distribution app_store \
+  --submit-to-store-review \
+  --ios-testflight-groups "External Testers" \
+  --store-release-notes "Bug fixes and performance improvements"
+```
+
+This requires App Store Connect API key credentials (`APPLE_KEY_ID`, `APPLE_ISSUER_ID`, `APPLE_KEY_CONTENT`, and `APP_STORE_CONNECT_TEAM_ID`). App-specific password uploads and `ad_hoc` distribution cannot submit a build for review. `--store-release-notes` is used as the TestFlight "What to Test" text.
+
 ## Ad-Hoc Distribution Mode
 
 By default, Capgo builds iOS apps for App Store distribution (TestFlight + App Store). If you need ad-hoc builds instead (for internal testing or CI artifact collection), you can use the `--ios-distribution` flag.

--- a/apps/docs/src/content/docs/docs/cli/reference/build.mdx
+++ b/apps/docs/src/content/docs/docs/cli/reference/build.mdx
@@ -65,6 +65,10 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--play-config-json** | <code>string</code> | Android: Base64-encoded Google Play service account JSON |
 | **--android-flavor** | <code>string</code> | Android: Product flavor to build (e.g. production). Required if your project has multiple flavors. |
 | **--no-playstore-upload** | <code>boolean</code> | Skip Play Store upload for this build (nulls out saved play config). Requires --output-upload. |
+| **--submit-to-store-review** | <code>boolean</code> | Submit the uploaded store release instead of leaving it for manual review: Android completes the Play release; iOS submits the build to external TestFlight review. |
+| **--store-release-name** | <code>string</code> | Store release name for review submission. Android uses it as the Google Play release name. |
+| **--store-release-notes** | <code>string</code> | Store release notes or changelog for review submission. iOS uses it as TestFlight "What to Test" text. |
+| **--ios-testflight-groups** | <code>string</code> | iOS: comma-separated external TestFlight group names or IDs for --submit-to-store-review. Required when submitting iOS for review. |
 | **--output-upload** | <code>boolean</code> | Override output upload behavior for this build only (enable). Precedence: CLI > env > saved credentials |
 | **--no-output-upload** | <code>boolean</code> | Override output upload behavior for this build only (disable). Precedence: CLI > env > saved credentials |
 | **--output-retention** | <code>string</code> | Override output link TTL for this build only (1h to 7d). Examples: 1h, 6h, 2d. Precedence: CLI > env > saved credentials |

--- a/src/content/docs/docs/cli/reference/build.mdx
+++ b/src/content/docs/docs/cli/reference/build.mdx
@@ -70,6 +70,10 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--play-config-json** | <code>string</code> | Android: Base64-encoded Google Play service account JSON |
 | **--android-flavor** | <code>string</code> | Android: Product flavor to build (e.g. production). Required if your project has multiple flavors. |
 | **--no-playstore-upload** | <code>boolean</code> | Skip Play Store upload for this build (nulls out saved play config). Requires --output-upload. |
+| **--submit-to-store-review** | <code>boolean</code> | Submit the uploaded store release instead of leaving it for manual review: Android completes the Play release; iOS submits the build to external TestFlight review. |
+| **--store-release-name** | <code>string</code> | Store release name for review submission. Android uses it as the Google Play release name. |
+| **--store-release-notes** | <code>string</code> | Store release notes or changelog for review submission. iOS uses it as TestFlight "What to Test" text. |
+| **--ios-testflight-groups** | <code>string</code> | iOS: comma-separated external TestFlight group names or IDs for --submit-to-store-review. Required when submitting iOS for review. |
 | **--output-upload** | <code>boolean</code> | Override output upload behavior for this build only (enable). Precedence: CLI > env > saved credentials |
 | **--no-output-upload** | <code>boolean</code> | Override output upload behavior for this build only (disable). Precedence: CLI > env > saved credentials |
 | **--output-retention** | <code>string</code> | Override output link TTL for this build only (1h to 7d). Examples: 1h, 6h, 2d. Precedence: CLI > env > saved credentials |


### PR DESCRIPTION
## Summary

- Document `--submit-to-store-review` for Capgo native build CI workflows.
- Add Android and iOS examples for submitting Play releases and external TestFlight review from `build request`.
- Add the new review-submission flags to both CLI reference copies.
- Remove a duplicate `SME` entry from `_typos.toml` so the typo workflow can parse the config.

## Validation

- `bunx prettier --write apps/docs/src/content/docs/docs/builder/github-actions.mdx apps/docs/src/content/docs/docs/builder/android.mdx apps/docs/src/content/docs/docs/builder/ios.mdx apps/docs/src/content/docs/docs/cli/reference/build.mdx src/content/docs/docs/cli/reference/build.mdx`
- `typos .`
- `bun run ci:verify:docs`

Note: `astro check` still reports the existing hint in `src/components/BuildCredentialsQuestionnaire.astro` about `questionFlow`, but the docs check and build complete with 0 errors.

## Visuals

Docs-only content update; no visual diff required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for submitting store releases for review during build workflows, including Android Google Play and iOS external TestFlight review.
  - Introduced new command options for review submission, release naming, release notes, and iOS TestFlight group selection.

- **Documentation**
  - Expanded Android, iOS, GitHub Actions, and CLI docs with setup steps, examples, and platform-specific requirements for release review flows.

- **Chores**
  - Removed an outdated typo-dictionary entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->