### PR TITLE
Add after onboarding one-time setup checklist

### DIFF
--- a/apps/docs/src/content/docs/docs/getting-started/add-an-app.mdx
+++ b/apps/docs/src/content/docs/docs/getting-started/add-an-app.mdx
@@ -2,7 +2,7 @@
 title: "Add an App"
 description: "Add an app to your Capgo account, and install the plugin in your app"
 sidebar:
-  order: 3
+  order: 4
 prev: true
 next: true
 ---

--- a/apps/docs/src/content/docs/docs/getting-started/after-onboarding-setup-checklist.mdx
+++ b/apps/docs/src/content/docs/docs/getting-started/after-onboarding-setup-checklist.mdx
@@ -53,7 +53,7 @@ See also [troubleshooting](/docs/getting-started/troubleshooting/).
      --delta
    ```
 
-   The `--bundle` value **must** be valid [semver](https://semver.org/). Check it in the [SemVer tester](https://capgo.app/semver_tester/) before you upload.
+   The `--bundle` value **must** be valid [semantic versioning](/docs/live-updates/channels/#bundle-versioning-and-channels). Validate it in the [SemVer tester](/semver_tester/) before you upload.
 
 6. **Deploy to production** only after testing — from the [dashboard](/docs/webapp/channels/) or CLI.
 
@@ -85,7 +85,7 @@ Do not use channels named after tickets, people, or CI variables like `${inputs_
 
 ## Bundle name vs comment
 
-Bundle names are **required** to follow [semver](https://semver.org/). Capgo uses semver for compatibility checks, channel auto-update rules, and rollbacks. Validate every name in the [SemVer tester](https://capgo.app/semver_tester/) before upload.
+Bundle names are **required** to follow [semantic versioning](/docs/live-updates/channels/#bundle-versioning-and-channels). Capgo uses semver for compatibility checks, channel auto-update rules, and rollbacks. Validate every name in the [SemVer tester](/semver_tester/) before upload.
 
 - **Name** = semver from CI, e.g. `1.8.0`, `1.8.0-beta.1`, or `1.8.0-20260629.42`
 - **Comment** = free text for humans → `commit abc1234 run 28059070270`
@@ -157,7 +157,7 @@ Upload to development (--delta)
 | Too many channels for a simple app | Start with 1–2 channels |
 | Device self-set on production | Off for production, on for test channels |
 | Skipping `--delta` | Add `--delta` to uploads; use `--delta-only` only when you need to save storage |
-| Non-semver bundle names | Use [semver](https://semver.org/) and validate in the [SemVer tester](https://capgo.app/semver_tester/) |
+| Non-semver bundle names | Follow [semantic versioning](/docs/live-updates/channels/#bundle-versioning-and-channels) and validate in the [SemVer tester](/semver_tester/) |
 | Changing versioning scheme over time | Keep semver; use pre-release labels for extra builds (`1.8.0-20260629.1`) |
 | Metadata / preview enabled without reason | Leave off by default |
 

--- a/apps/docs/src/content/docs/docs/getting-started/after-onboarding-setup-checklist.mdx
+++ b/apps/docs/src/content/docs/docs/getting-started/after-onboarding-setup-checklist.mdx
@@ -1,0 +1,167 @@
+---
+title: After onboarding — one-time setup checklist
+description: "What to configure once after onboarding so Capgo runs smoothly: store release, channels, delta upload, CI, and team access."
+sidebar:
+  order: 3
+next: true
+prev: true
+---
+
+import { Aside, Steps, LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+You finished [onboarding](/docs/getting-started/onboarding/) — now configure Capgo **once**. After that, daily work is only **upload → test → deploy**.
+
+<Aside type="caution" title="Ship a new store build first">
+Installing the Capgo plugin in your project is not enough. **OTA updates only work on devices running a native app that already includes the plugin.**
+
+After you add Capgo and call `CapacitorUpdater.notifyAppReady()`:
+
+1. Run `npx cap sync`
+2. Build a new iOS / Android binary
+3. Submit to the App Store, Play Store, TestFlight, or your internal distribution
+
+Users on an older store build **without** the plugin will never receive live updates. Uploading bundles to Capgo only affects devices on a Capgo-enabled binary.
+
+See also [troubleshooting](/docs/getting-started/troubleshooting/).
+</Aside>
+
+**Rule:** channels are release lanes (`development`, `production`), not tickets, features, or developer names.
+
+---
+
+## One-time setup checklist
+
+<Steps>
+
+1. **Create channels** — pick the smallest set that fits (see below).
+
+2. **Set default upload channel** in [app settings](/docs/webapp/main-app-page/):
+   - Solo app → `production`
+   - Team → `development`
+
+3. **Production channel:** public on, device self-set off, block updates under native on, auto-update guard on `major`.
+
+4. **Test channel** (`development` / `staging`): public off, device self-set on for QA.
+
+5. **Upload from CI** with checksum, native deps, and delta:
+
+   ```bash
+   npx @capgo/cli@latest bundle upload \
+     --channel development \
+     --bundle "${APP_VERSION}.${BUILD_NUMBER}" \
+     --comment "commit ${GIT_SHA:0:7} run ${CI_RUN_ID}" \
+     --delta
+   ```
+
+6. **Deploy to production** only after testing — from the [dashboard](/docs/webapp/channels/) or CLI.
+
+7. **Team & security:** invite once, least permissions, [2FA](/docs/webapp/mfa/) for the org, one API key in CI.
+
+</Steps>
+
+Leave encryption, `min_update_version`, metadata, and preview **off** unless you have a clear reason.
+
+---
+
+## Pick your size
+
+**Simple** — 1 app, 1 channel: `production`
+
+**Team** — `development` + `production`. Upload to dev, deploy to prod.
+
+**Native versions** — add channels only when needed, e.g. `production-9.0` + `test-9.0`. Keep store users on the main production channel.
+
+**Many apps** — same simple model per app (usually one `production` each). Do not create extra channels just because the org is big.
+
+**Release train** (optional) — `staging` → `rc` → `production`. Same template on every app that needs it.
+
+<Aside type="caution">
+Do not use channels named after tickets, people, or CI variables like `${inputs_capgo_channel}`.
+</Aside>
+
+---
+
+## Bundle name vs comment
+
+- **Name** = unique version ID from CI → `1.8.0.${BUILD_NUMBER}`
+- **Comment** = what changed → `commit abc1234 run 28059070270`
+
+Never use ticket names or `fix-login-bug` as bundle names. Put release notes in `--comment`, not the name.
+
+---
+
+## Delta upload (recommended)
+
+**Use delta uploads by default.** They send only changed files instead of re-downloading the whole app. Updates are faster, use less data, and work especially well for apps with large assets (images, videos) that rarely change.
+
+Capgo handles checksums and native dependencies automatically. Delta is the third piece you should always enable.
+
+### How to set it up
+
+**1. Add `--delta` to every upload** (local or CI):
+
+```bash
+npx @capgo/cli@latest bundle upload \
+  --channel development \
+  --bundle "${APP_VERSION}.${BUILD_NUMBER}" \
+  --delta
+```
+
+**2. In CI, enforce it** so nobody accidentally uploads a full zip:
+
+```bash
+npx @capgo/cli@latest bundle upload \
+  --channel development \
+  --bundle "${APP_VERSION}.${BUILD_NUMBER}" \
+  --comment "commit ${GIT_SHA:0:7} run ${CI_RUN_ID}" \
+  --delta-only
+```
+
+`--delta-only` means every automated upload is a manifest/delta bundle. Use a normal upload without that flag only when you intentionally need a full bundle.
+
+**3. Nothing to change in the app** — the Capgo plugin on the device reads the manifest and downloads only changed files. No extra plugin config is required for basic delta updates.
+
+<Aside type="tip">
+If `directUpdate` is enabled in `capacitor.config`, the CLI may prompt for delta in local uploads. In CI (non-interactive), delta is used automatically. See [Delta updates](/docs/live-updates/differentials/) for details.
+</Aside>
+
+**What you get:** each file is stored with a checksum → Capgo builds a manifest → devices download only what changed.
+
+---
+
+## Daily workflow
+
+```
+Upload to development (--delta)
+  → test
+  → deploy to production
+  → don't touch channel settings again
+```
+
+---
+
+## Common mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| Expecting OTA before a new store release | Rebuild and ship the native app after adding the plugin |
+| Uploading a bundle but not deploying to a channel | Assign the bundle to a channel (e.g. `production`) |
+| Channel per feature, ticket, or developer | Use permanent release lanes only |
+| Dynamic CI channel names | Fixed names: `development`, `production` |
+| Too many channels for a simple app | Start with 1–2 channels |
+| Device self-set on production | Off for production, on for test channels |
+| Skipping `--delta` | Add `--delta` to every upload; use `--delta-only` in CI |
+| Manual or random bundle names | Automate naming in CI |
+| Changing naming scheme over time | Pick one scheme on day one |
+| Metadata / preview enabled without reason | Leave off by default |
+
+---
+
+## Learn more
+
+<CardGrid stagger>
+  <LinkCard href="/docs/live-updates/channels/" title="Channels" description="Defaults, precedence, and routing." />
+  <LinkCard href="/docs/live-updates/differentials/" title="Delta updates" description="Why and how to use --delta." />
+  <LinkCard href="/docs/getting-started/cicd-integration/" title="CI/CD" description="Automate upload and deploy." />
+  <LinkCard href="/docs/webapp/bundles/" title="Bundles" description="Checksum, dependencies, and metadata." />
+</CardGrid>

--- a/apps/docs/src/content/docs/docs/getting-started/after-onboarding-setup-checklist.mdx
+++ b/apps/docs/src/content/docs/docs/getting-started/after-onboarding-setup-checklist.mdx
@@ -43,15 +43,17 @@ See also [troubleshooting](/docs/getting-started/troubleshooting/).
 
 4. **Test channel** (`development` / `staging`): public off, device self-set on for QA.
 
-5. **Upload from CI** with checksum, native deps, and delta:
+5. **Upload from CI** with `--delta` (checksum and native dependencies are automatic):
 
    ```bash
    npx @capgo/cli@latest bundle upload \
      --channel development \
-     --bundle "${APP_VERSION}.${BUILD_NUMBER}" \
+     --bundle "1.8.0-${BUILD_NUMBER}" \
      --comment "commit ${GIT_SHA:0:7} run ${CI_RUN_ID}" \
      --delta
    ```
+
+   The `--bundle` value **must** be valid [semver](https://semver.org/). Check it in the [SemVer tester](https://capgo.app/semver_tester/) before you upload.
 
 6. **Deploy to production** only after testing — from the [dashboard](/docs/webapp/channels/) or CLI.
 
@@ -83,49 +85,53 @@ Do not use channels named after tickets, people, or CI variables like `${inputs_
 
 ## Bundle name vs comment
 
-- **Name** = unique version ID from CI → `1.8.0.${BUILD_NUMBER}`
-- **Comment** = what changed → `commit abc1234 run 28059070270`
+Bundle names are **required** to follow [semver](https://semver.org/). Capgo uses semver for compatibility checks, channel auto-update rules, and rollbacks. Validate every name in the [SemVer tester](https://capgo.app/semver_tester/) before upload.
 
-Never use ticket names or `fix-login-bug` as bundle names. Put release notes in `--comment`, not the name.
+- **Name** = semver from CI, e.g. `1.8.0`, `1.8.0-beta.1`, or `1.8.0-20260629.42`
+- **Comment** = free text for humans → `commit abc1234 run 28059070270`
+
+Use semver **pre-release** labels (the part after `-`) when you ship many builds under the same `MAJOR.MINOR.PATCH`. For example, keep `1.8.0` and add the date or build counter in the pre-release: `1.8.0-20260629.1`, `1.8.0-beta.2`. Do not invent custom formats like `fix-login-bug` or `2.5.2026062306` — they are not valid semver and uploads will fail or behave unpredictably.
+
+Put release notes in `--comment`, not in the bundle name.
+
+See also [version targeting](/docs/live-updates/version-targeting/) and [bundle versioning](/docs/live-updates/channels/#bundle-versioning-and-channels).
 
 ---
 
-## Delta upload (recommended)
+## Delta upload
 
-**Use delta uploads by default.** They send only changed files instead of re-downloading the whole app. Updates are faster, use less data, and work especially well for apps with large assets (images, videos) that rarely change.
+`--delta` uploads a **manifest** so devices download only changed files instead of the full bundle every time. Checksum is always computed automatically — you do not pass a checksum flag.
 
-Capgo handles checksums and native dependencies automatically. Delta is the third piece you should always enable.
-
-### How to set it up
-
-**1. Add `--delta` to every upload** (local or CI):
+### Default: `--delta` (manifest + zip backup)
 
 ```bash
 npx @capgo/cli@latest bundle upload \
   --channel development \
-  --bundle "${APP_VERSION}.${BUILD_NUMBER}" \
+  --bundle "1.8.0-${BUILD_NUMBER}" \
   --delta
 ```
 
-**2. In CI, enforce it** so nobody accidentally uploads a full zip:
+This is the recommended default for most apps. Capgo stores the manifest **and** keeps the full zip as a backup. Good when storage cost is not your main concern.
+
+### Storage saving: `--delta-only`
 
 ```bash
 npx @capgo/cli@latest bundle upload \
   --channel development \
-  --bundle "${APP_VERSION}.${BUILD_NUMBER}" \
+  --bundle "1.8.0-${BUILD_NUMBER}" \
   --comment "commit ${GIT_SHA:0:7} run ${CI_RUN_ID}" \
   --delta-only
 ```
 
-`--delta-only` means every automated upload is a manifest/delta bundle. Use a normal upload without that flag only when you intentionally need a full bundle.
+Use `--delta-only` when you want to **reduce Capgo storage** — only the delta/manifest files are stored, not the full zip. Choose this for large apps or high upload volume where storage adds up.
 
-**3. Nothing to change in the app** — the Capgo plugin on the device reads the manifest and downloads only changed files. No extra plugin config is required for basic delta updates.
+Trade-off: without the zip backup on the server, you rely fully on the manifest path. Skip `--delta-only` unless you actually need the storage savings.
+
+No extra plugin config is required on the device — the updater reads the manifest and fetches changed files only.
 
 <Aside type="tip">
-If `directUpdate` is enabled in `capacitor.config`, the CLI may prompt for delta in local uploads. In CI (non-interactive), delta is used automatically. See [Delta updates](/docs/live-updates/differentials/) for details.
+See [Delta updates](/docs/live-updates/differentials/) for troubleshooting and `directUpdate` behavior.
 </Aside>
-
-**What you get:** each file is stored with a checksum → Capgo builds a manifest → devices download only what changed.
 
 ---
 
@@ -150,9 +156,9 @@ Upload to development (--delta)
 | Dynamic CI channel names | Fixed names: `development`, `production` |
 | Too many channels for a simple app | Start with 1–2 channels |
 | Device self-set on production | Off for production, on for test channels |
-| Skipping `--delta` | Add `--delta` to every upload; use `--delta-only` in CI |
-| Manual or random bundle names | Automate naming in CI |
-| Changing naming scheme over time | Pick one scheme on day one |
+| Skipping `--delta` | Add `--delta` to uploads; use `--delta-only` only when you need to save storage |
+| Non-semver bundle names | Use [semver](https://semver.org/) and validate in the [SemVer tester](https://capgo.app/semver_tester/) |
+| Changing versioning scheme over time | Keep semver; use pre-release labels for extra builds (`1.8.0-20260629.1`) |
 | Metadata / preview enabled without reason | Leave off by default |
 
 ---

--- a/apps/docs/src/content/docs/docs/getting-started/cicd-integration.mdx
+++ b/apps/docs/src/content/docs/docs/getting-started/cicd-integration.mdx
@@ -2,7 +2,7 @@
 title: CI/CD Integration
 description: Integrating Capgo into your CI/CD pipeline allows you to fully automate the process of building and deploying updates to your app. By leveraging the Capgo CLI and semantic-release, you can ensure consistent, reliable deployments and enable rapid iteration.
 sidebar:
-  order: 5
+  order: 6
 ---
 
 import { Steps, Code } from '@astrojs/starlight/components';

--- a/apps/docs/src/content/docs/docs/getting-started/deploy.mdx
+++ b/apps/docs/src/content/docs/docs/getting-started/deploy.mdx
@@ -2,7 +2,7 @@
 title: Deploy a Live Update
 description: "Learn how to deploy a live update to your app using Capgo's Live Updates feature, enabling real-time UI and logic updates without app store resubmission."
 sidebar:
-  order: 4
+  order: 5
 ---
 import { Steps, LinkCard, Tabs, TabItem } from '@astrojs/starlight/components';
 

--- a/apps/docs/src/content/docs/docs/getting-started/onboarding.mdx
+++ b/apps/docs/src/content/docs/docs/getting-started/onboarding.mdx
@@ -523,6 +523,9 @@ CapacitorUpdater.notifyAppReady()
 Now that you've completed onboarding, explore these topics:
 
 <CardGrid>
+  <a href="/docs/getting-started/after-onboarding-setup-checklist/"><Card title="After onboarding checklist" icon="approve-check">
+    Configure channels, CI, and delta upload once for long-term stability
+  </Card></a>
   <a href="/docs/getting-started/deploy/"><Card title="Deploy Updates" icon="rocket">
     Learn how to deploy updates from the Capgo dashboard
   </Card></a>

--- a/apps/docs/src/content/docs/docs/getting-started/troubleshooting.mdx
+++ b/apps/docs/src/content/docs/docs/getting-started/troubleshooting.mdx
@@ -2,7 +2,7 @@
 title: Troubleshooting
 description: "Resolve common issues encountered while using Capgo with detailed troubleshooting steps and advanced options for upload and debugging."
 sidebar:
-  order: 6
+  order: 7
   next: false
   prev: false
 ---

--- a/apps/docs/src/content/docs/docs/getting-started/wrapping-up.mdx
+++ b/apps/docs/src/content/docs/docs/getting-started/wrapping-up.mdx
@@ -2,7 +2,7 @@
 title: Wrapping up
 description: "Wrap up your Capgo journey with a concise overview of key concepts and next steps, ensuring a solid foundation for future exploration and mastery."
 sidebar:
-  order: 7
+  order: 8
   next: false
   prev: false
 draft: false
@@ -27,6 +27,12 @@ Now that you have completed the quickstart guide, you should have a basic unders
 But there's still more to learn about Capgo! Continue exploring the docs or check out some of these key topics:
 
 <CardGrid stagger>
+  <a href="/docs/getting-started/after-onboarding-setup-checklist/">
+    <Card title="After onboarding checklist" icon="approve-check">
+      One-time channel, CI, and delta upload setup for production.
+    </Card>
+  </a>
+
   <a href="/docs/getting-started/cicd-integration/">
     <Card title="CI/CD Integration" icon="gitlab">
       Already have a CI/CD pipeline? Learn how to incorporate Capgo into your existing workflow.


### PR DESCRIPTION
## Summary
- Adds a new getting started doc: **After onboarding — one-time setup checklist**
- Covers store release requirement, channel setup, delta upload, bundle naming, common mistakes, and daily workflow
- Links the page from onboarding and wrapping up; reorders quickstart sidebar entries

## Test plan
- [ ] Open `/docs/getting-started/after-onboarding-setup-checklist/` locally
- [ ] Confirm sidebar order under Quickstart
- [ ] Verify links from onboarding and wrapping up pages


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “After onboarding — one-time setup checklist” guide with instructions for configuring release channels, CI bundle uploads, production/test rollout flow, and a one-time security checklist.
  * Added navigation cards linking to the checklist from the onboarding and wrap-up pages.

* **Documentation**
  * Reordered several Getting Started docs in the sidebar to improve the learning sequence and navigation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->