### PR TITLE
docs: document native store review release options

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -31,11 +31,11 @@ Damon = "Damon"
 # Acronyms and technical terms
 ASO = "ASO"  # App Store Optimization
 ITMS = "ITMS"  # iTunes Music Store
+SME = "SME"  # Small and midsize enterprise
 Hashi = "Hashi"  # HashiCorp (brand name)
 formatable = "formatable"  # NFC event literal from upstream API
 jus = "jus"  # Brazilian justice app package namespace
 Programm = "Programm"  # German app-store title term in TV-Programm
-
 # Translation keys/identifiers - these should remain as-is
 udid = "udid"  # iOS device UDID (technical term)
 UDID = "UDID"  # iOS device UDID (technical term)

--- a/apps/docs/src/content/docs/docs/builder/android.mdx
+++ b/apps/docs/src/content/docs/docs/builder/android.mdx
@@ -453,10 +453,13 @@ npx @capgo/cli@latest build request com.example.app \
   --build-mode release \
   --submit-to-store-review \
   --store-release-name "1.2.3" \
-  --store-release-notes "Bug fixes and performance improvements"
+  --store-release-notes "General improvements" \
+  --store-release-notes-locale "en-US=General improvements" \
+  --store-release-notes-locale "nl-NL=Algemene verbeteringen" \
+  --store-release-notes-locale "fr-FR=Ameliorations generales"
 ```
 
-This requires the same Google Play service account setup as the normal upload path (`PLAY_CONFIG_JSON` in CI or saved Android credentials locally). `--store-release-name` is used as the Google Play release name, and `--store-release-notes` is used as the Play changelog.
+This requires the same Google Play service account setup as the normal upload path (`PLAY_CONFIG_JSON` in CI or saved Android credentials locally). `--store-release-name` is used as the Google Play release name. `--store-release-notes` is the fallback Play changelog, and each `--store-release-notes-locale "locale=notes"` entry writes a localized Play changelog for that locale. Capgo sends the Play release as `completed`; if Managed publishing is enabled in Play Console, Google can still wait for your manual publish after approval.
 
 ## Keep going from Android Builds
 

--- a/apps/docs/src/content/docs/docs/builder/github-actions.mdx
+++ b/apps/docs/src/content/docs/docs/builder/github-actions.mdx
@@ -297,7 +297,7 @@ For test builds, skip store submission: Android uses `--no-playstore-upload`; fo
 
 By default, release builds upload the signed artifact and leave the final store action under your control. For CI releases that should move directly into the store review flow, add `--submit-to-store-review`.
 
-Android uses your `PLAY_CONFIG_JSON` service account and submits the Google Play release instead of leaving it inactive. Add `--store-release-name` and `--store-release-notes` when you want the Play release to carry the same tag and changelog as CI:
+Android uses your `PLAY_CONFIG_JSON` service account and submits the Google Play release instead of leaving it inactive. Add `--store-release-name`, `--store-release-notes`, and optional `--store-release-notes-locale` entries when you want the Play release to carry the same tag and localized changelogs as CI:
 
 ```yaml
 - name: Submit Android release for review
@@ -314,13 +314,14 @@ Android uses your `PLAY_CONFIG_JSON` service account and submits the Google Play
       --build-mode release \
       --submit-to-store-review \
       --store-release-name "${GITHUB_REF_NAME}" \
-      --store-release-notes "Release ${GITHUB_REF_NAME}"
+      --store-release-notes "Release ${GITHUB_REF_NAME}" \
+      --store-release-notes-locale "en-US=Release ${GITHUB_REF_NAME}"
 ```
 
-iOS uses the App Store Connect API key path and submits the build to external TestFlight review. It requires `app_store` distribution and at least one external TestFlight group:
+iOS uses the App Store Connect API key path and submits the processed TestFlight build to App Store review. It requires `app_store` distribution; `--ios-testflight-groups` is optional for external beta distribution and is not required for App Store review:
 
 ```yaml
-- name: Submit iOS build to external TestFlight review
+- name: Submit iOS build to App Store review
   env:
     CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
     BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
@@ -336,8 +337,10 @@ iOS uses the App Store Connect API key path and submits the build to external Te
       --build-mode release \
       --ios-distribution app_store \
       --submit-to-store-review \
-      --ios-testflight-groups "External Testers" \
-      --store-release-notes "Release ${GITHUB_REF_NAME}"
+      --store-release-name "${GITHUB_REF_NAME}" \
+      --store-release-notes "Release ${GITHUB_REF_NAME}" \
+      --store-release-notes-locale "en-US=Release ${GITHUB_REF_NAME}" \
+      --no-ios-automatic-release
 ```
 
 <Aside type="caution">

--- a/apps/docs/src/content/docs/docs/builder/ios.mdx
+++ b/apps/docs/src/content/docs/docs/builder/ios.mdx
@@ -615,9 +615,9 @@ bunx @capgo/cli@latest build request --platform ios
 Congratulations 🎉
 At this point, you have successfully built your app and it is ready to be submitted to the App Store.
 
-### Submit to external TestFlight review
+### Submit to App Store review
 
-The normal App Store build path uploads the build to App Store Connect/TestFlight. If your CI release should also submit that build to external TestFlight review, pass `--submit-to-store-review` and select the external groups that should receive the build:
+The normal App Store build path uploads the build to App Store Connect/TestFlight. If your CI release should also attach the processed TestFlight build to the App Store version and submit it for App Review, pass `--submit-to-store-review` with a release build:
 
 ```bash
 npx @capgo/cli@latest build request com.example.app \
@@ -625,11 +625,15 @@ npx @capgo/cli@latest build request com.example.app \
   --build-mode release \
   --ios-distribution app_store \
   --submit-to-store-review \
-  --ios-testflight-groups "External Testers" \
-  --store-release-notes "Bug fixes and performance improvements"
+  --store-release-name "1.2.3" \
+  --store-release-notes "General improvements" \
+  --store-release-notes-locale "en-US=General improvements" \
+  --store-release-notes-locale "nl-NL=Algemene verbeteringen" \
+  --store-release-notes-locale "fr-FR=Ameliorations generales" \
+  --no-ios-automatic-release
 ```
 
-This requires App Store Connect API key credentials (`APPLE_KEY_ID`, `APPLE_ISSUER_ID`, `APPLE_KEY_CONTENT`, and `APP_STORE_CONNECT_TEAM_ID`). App-specific password uploads and `ad_hoc` distribution cannot submit a build for review. `--store-release-notes` is used as the TestFlight "What to Test" text.
+This requires App Store Connect API key credentials (`APPLE_KEY_ID`, `APPLE_ISSUER_ID`, `APPLE_KEY_CONTENT`, and `APP_STORE_CONNECT_TEAM_ID`). App-specific password uploads and `ad_hoc` distribution cannot submit a build for review. `--store-release-name` is the App Store version; if omitted, Capgo reads `MARKETING_VERSION` from the Xcode project. `--store-release-notes` is the fallback App Store What's New text, and each `--store-release-notes-locale "locale=notes"` entry can override it for a store localization. Use `--ios-automatic-release` to release automatically after Apple approval, or `--no-ios-automatic-release` to wait for a manual release. `--ios-testflight-groups` is still available for external beta distribution, but it is not required for App Store review submission.
 
 ## Ad-Hoc Distribution Mode
 

--- a/apps/docs/src/content/docs/docs/cli/reference/build.mdx
+++ b/apps/docs/src/content/docs/docs/cli/reference/build.mdx
@@ -65,10 +65,13 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--play-config-json** | <code>string</code> | Android: Base64-encoded Google Play service account JSON |
 | **--android-flavor** | <code>string</code> | Android: Product flavor to build (e.g. production). Required if your project has multiple flavors. |
 | **--no-playstore-upload** | <code>boolean</code> | Skip Play Store upload for this build (nulls out saved play config). Requires --output-upload. |
-| **--submit-to-store-review** | <code>boolean</code> | Submit the uploaded store release instead of leaving it for manual review: Android completes the Play release; iOS submits the build to external TestFlight review. |
-| **--store-release-name** | <code>string</code> | Store release name for review submission. Android uses it as the Google Play release name. |
-| **--store-release-notes** | <code>string</code> | Store release notes or changelog for review submission. iOS uses it as TestFlight "What to Test" text. |
-| **--ios-testflight-groups** | <code>string</code> | iOS: comma-separated external TestFlight group names or IDs for --submit-to-store-review. Required when submitting iOS for review. |
+| **--submit-to-store-review** | <code>boolean</code> | Submit the uploaded release for store review: Android completes the Play release; iOS submits the processed TestFlight build to App Store review. |
+| **--store-release-name** | <code>string</code> | Store release name/version. Android uses it as the Google Play release name; iOS uses it as the App Store version. |
+| **--store-release-notes** | <code>string</code> | Default store release notes. Android uses it as the Play changelog; iOS uses it as the fallback App Store What's New text. |
+| **--store-release-notes-locale** | <code>string</code> | Localized store release notes, repeatable as <code>locale=notes</code>, for example <code>--store-release-notes-locale "fr-FR=Corrections"</code>. |
+| **--ios-testflight-groups** | <code>string</code> | iOS only: optional comma-separated TestFlight external group names or IDs for beta distribution. |
+| **--ios-automatic-release** | <code>boolean</code> | iOS only: automatically release the App Store version after Apple approval. Default is manual release. |
+| **--no-ios-automatic-release** | <code>boolean</code> | iOS only: keep the approved App Store version waiting for manual release. |
 | **--output-upload** | <code>boolean</code> | Override output upload behavior for this build only (enable). Precedence: CLI > env > saved credentials |
 | **--no-output-upload** | <code>boolean</code> | Override output upload behavior for this build only (disable). Precedence: CLI > env > saved credentials |
 | **--output-retention** | <code>string</code> | Override output link TTL for this build only (1h to 7d). Examples: 1h, 6h, 2d. Precedence: CLI > env > saved credentials |
@@ -78,6 +81,23 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--supa-host** | <code>string</code> | Custom Supabase host URL (for self-hosting or Capgo development) |
 | **--supa-anon** | <code>string</code> | Custom Supabase anon key (for self-hosting) |
 | **--verbose** | <code>boolean</code> | Enable verbose output with detailed logging |
+
+`--submit-to-store-review`, `--store-release-name`, `--store-release-notes`, and `--store-release-notes-locale` work on both Android and iOS. Use `--store-release-notes` as the fallback text, then repeat `--store-release-notes-locale "locale=notes"` for each store localization:
+
+```bash
+npx @capgo/cli@latest build request com.example.app \
+  --platform ios \
+  --build-mode release \
+  --submit-to-store-review \
+  --store-release-name "1.2.3" \
+  --store-release-notes "General improvements" \
+  --store-release-notes-locale "en-US=General improvements" \
+  --store-release-notes-locale "nl-NL=Algemene verbeteringen" \
+  --store-release-notes-locale "fr-FR=Ameliorations generales" \
+  --no-ios-automatic-release
+```
+
+In CI you can also provide the same localized notes as JSON with `CAPGO_STORE_RELEASE_NOTES_LOCALIZED`, for example `{"en-US":"General improvements","nl-NL":"Algemene verbeteringen"}`.
 
 ### <a id="build-credentials"></a> 🔹 **Credentials**
 

--- a/src/content/docs/docs/cli/reference/build.mdx
+++ b/src/content/docs/docs/cli/reference/build.mdx
@@ -70,10 +70,13 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--play-config-json** | <code>string</code> | Android: Base64-encoded Google Play service account JSON |
 | **--android-flavor** | <code>string</code> | Android: Product flavor to build (e.g. production). Required if your project has multiple flavors. |
 | **--no-playstore-upload** | <code>boolean</code> | Skip Play Store upload for this build (nulls out saved play config). Requires --output-upload. |
-| **--submit-to-store-review** | <code>boolean</code> | Submit the uploaded store release instead of leaving it for manual review: Android completes the Play release; iOS submits the build to external TestFlight review. |
-| **--store-release-name** | <code>string</code> | Store release name for review submission. Android uses it as the Google Play release name. |
-| **--store-release-notes** | <code>string</code> | Store release notes or changelog for review submission. iOS uses it as TestFlight "What to Test" text. |
-| **--ios-testflight-groups** | <code>string</code> | iOS: comma-separated external TestFlight group names or IDs for --submit-to-store-review. Required when submitting iOS for review. |
+| **--submit-to-store-review** | <code>boolean</code> | Submit the uploaded release for store review: Android completes the Play release; iOS submits the processed TestFlight build to App Store review. |
+| **--store-release-name** | <code>string</code> | Store release name/version. Android uses it as the Google Play release name; iOS uses it as the App Store version. |
+| **--store-release-notes** | <code>string</code> | Default store release notes. Android uses it as the Play changelog; iOS uses it as the fallback App Store What's New text. |
+| **--store-release-notes-locale** | <code>string</code> | Localized store release notes, repeatable as <code>locale=notes</code>, for example <code>--store-release-notes-locale "fr-FR=Corrections"</code>. |
+| **--ios-testflight-groups** | <code>string</code> | iOS only: optional comma-separated TestFlight external group names or IDs for beta distribution. |
+| **--ios-automatic-release** | <code>boolean</code> | iOS only: automatically release the App Store version after Apple approval. Default is manual release. |
+| **--no-ios-automatic-release** | <code>boolean</code> | iOS only: keep the approved App Store version waiting for manual release. |
 | **--output-upload** | <code>boolean</code> | Override output upload behavior for this build only (enable). Precedence: CLI > env > saved credentials |
 | **--no-output-upload** | <code>boolean</code> | Override output upload behavior for this build only (disable). Precedence: CLI > env > saved credentials |
 | **--output-retention** | <code>string</code> | Override output link TTL for this build only (1h to 7d). Examples: 1h, 6h, 2d. Precedence: CLI > env > saved credentials |
@@ -83,6 +86,23 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--supa-host** | <code>string</code> | Custom Supabase host URL (for self-hosting or Capgo development) |
 | **--supa-anon** | <code>string</code> | Custom Supabase anon key (for self-hosting) |
 | **--verbose** | <code>boolean</code> | Enable verbose output with detailed logging |
+
+`--submit-to-store-review`, `--store-release-name`, `--store-release-notes`, and `--store-release-notes-locale` work on both Android and iOS. Use `--store-release-notes` as the fallback text, then repeat `--store-release-notes-locale "locale=notes"` for each store localization:
+
+```bash
+npx @capgo/cli@latest build request com.example.app \
+  --platform ios \
+  --build-mode release \
+  --submit-to-store-review \
+  --store-release-name "1.2.3" \
+  --store-release-notes "General improvements" \
+  --store-release-notes-locale "en-US=General improvements" \
+  --store-release-notes-locale "nl-NL=Algemene verbeteringen" \
+  --store-release-notes-locale "fr-FR=Ameliorations generales" \
+  --no-ios-automatic-release
+```
+
+In CI you can also provide the same localized notes as JSON with `CAPGO_STORE_RELEASE_NOTES_LOCALIZED`, for example `{"en-US":"General improvements","nl-NL":"Algemene verbeteringen"}`.
 
 ### <a id="build-credentials"></a> 🔹 **Credentials**
 


### PR DESCRIPTION
## Summary
- Document localized release notes with repeatable `--store-release-notes-locale` examples.
- Clarify which store review flags are shared by Android/iOS and which ones are iOS-only.
- Document `--ios-automatic-release` / `--no-ios-automatic-release` and the App Store review path.
- Add `SME` to the typo dictionary for an existing valid acronym on current main.

## Test plan
- `bunx prettier --write apps/docs/src/content/docs/docs/cli/reference/build.mdx src/content/docs/docs/cli/reference/build.mdx apps/docs/src/content/docs/docs/builder/android.mdx apps/docs/src/content/docs/docs/builder/ios.mdx apps/docs/src/content/docs/docs/builder/github-actions.mdx`
- `typos .`
- `typos apps/docs/src/content/docs/docs/builder/android.mdx apps/docs/src/content/docs/docs/builder/github-actions.mdx apps/docs/src/content/docs/docs/builder/ios.mdx apps/docs/src/content/docs/docs/cli/reference/build.mdx src/content/docs/docs/cli/reference/build.mdx`
- `bun run ci:verify:docs`
