### PR TITLE
docs: add capacitor-uwb plugin documentation

### DIFF
--- a/apps/docs/src/config/sidebar.mjs
+++ b/apps/docs/src/config/sidebar.mjs
@@ -247,6 +247,7 @@ const pluginEntries = [
   ['Twilio Video', 'twilio-video'],
   ['Twilio Voice', 'twilio-voice'],
   ['Uploader', 'uploader'],
+  ['UWB', 'uwb', [linkItem('iOS setup', '/docs/plugins/uwb/ios'), linkItem('Android setup', '/docs/plugins/uwb/android')]],
   ['Video Player', 'video-player'],
   ['Video Thumbnails', 'video-thumbnails'],
   ['Volume Buttons', 'volume-buttons'],

--- a/apps/docs/src/config/sidebar.mjs
+++ b/apps/docs/src/config/sidebar.mjs
@@ -247,7 +247,7 @@ const pluginEntries = [
   ['Twilio Video', 'twilio-video'],
   ['Twilio Voice', 'twilio-voice'],
   ['Uploader', 'uploader'],
-  ['UWB', 'uwb', [linkItem('iOS setup', '/docs/plugins/uwb/ios'), linkItem('Android setup', '/docs/plugins/uwb/android')]],
+  ['UWB', 'uwb'],
   ['Video Player', 'video-player'],
   ['Video Thumbnails', 'video-thumbnails'],
   ['Volume Buttons', 'volume-buttons'],

--- a/apps/docs/src/content/docs/docs/plugins/uwb/android.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/uwb/android.mdx
@@ -1,0 +1,68 @@
+---
+title: Android Setup
+description: Configure Jetpack UWB controller and controlee sessions in Capacitor apps.
+sidebar:
+  order: 4
+---
+
+## Android native system used
+
+On Android, this plugin uses **Jetpack UWB** from `androidx.core.uwb`.
+
+## Requirements
+
+- Android 12+
+- Device with UWB hardware
+- UWB enabled in system settings
+
+## Manifest and permissions
+
+The plugin declares:
+
+```xml
+<uses-permission android:name="android.permission.UWB_RANGING" />
+<uses-feature android:name="android.hardware.uwb" android:required="false" />
+```
+
+No additional manifest changes are required in most apps.
+
+## Controller flow
+
+```typescript
+import { CapacitorUwb } from '@capgo/capacitor-uwb';
+
+const controller = await CapacitorUwb.startControllerSession();
+
+// Share controller.rangingParameters and controller.localAddress out-of-band
+```
+
+If you already know the controlee address, pass it when starting the controller session:
+
+```typescript
+await CapacitorUwb.startControllerSession({
+  peerAddress: '<controlee-address-base64>',
+});
+```
+
+## Controlee flow
+
+```typescript
+await CapacitorUwb.startControleeSession({
+  rangingParameters: {
+    sessionId: 12345,
+    sessionKeyInfo: '<base64>',
+    complexChannel: { channel: 9, preambleIndex: 10 },
+    peerAddress: '<controller-address-base64>',
+  },
+});
+```
+
+## Events
+
+- `rangingUpdate` emits distance and angle measurements when available.
+- `sessionStateChanged` emits lifecycle states such as `running`, `invalidated`, and `peerDisconnected`.
+
+## Notes
+
+- `startControllerSession()` and `startControleeSession()` are Android-only APIs.
+- The plugin does not provide BLE or backend transport for exchanging ranging parameters.

--- a/apps/docs/src/content/docs/docs/plugins/uwb/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/uwb/getting-started.mdx
@@ -75,7 +75,6 @@ await CapacitorUwb.startControleeSession({
   },
 });
 ```
-```
 
 See [Android setup](/docs/plugins/uwb/android/) for hardware and permission requirements.
 

--- a/apps/docs/src/content/docs/docs/plugins/uwb/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/uwb/getting-started.mdx
@@ -60,16 +60,21 @@ See [iOS setup](/docs/plugins/uwb/ios/) for capability and permission requiremen
 
 ## Android Controller / Controlee Session
 
-1. The controller calls `startControllerSession()` and shares the returned `rangingParameters`.
-2. The controlee calls `startControleeSession({ rangingParameters })`.
-3. Optionally pass `peerAddress` to the controller once the controlee address is known.
+1. The controller calls `startControllerSession()` and shares the returned `rangingParameters` and `localAddress`.
+2. The controlee builds its own `rangingParameters`, using the controller `localAddress` as `peerAddress`.
+3. The controlee calls `startControleeSession({ rangingParameters })`.
+4. Optionally pass `peerAddress` to the controller once the controlee address is known.
 
 ```typescript
 const controller = await CapacitorUwb.startControllerSession();
 
 await CapacitorUwb.startControleeSession({
-  rangingParameters: controller.rangingParameters,
+  rangingParameters: {
+    ...controller.rangingParameters,
+    peerAddress: controller.localAddress,
+  },
 });
+```
 ```
 
 See [Android setup](/docs/plugins/uwb/android/) for hardware and permission requirements.

--- a/apps/docs/src/content/docs/docs/plugins/uwb/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/uwb/getting-started.mdx
@@ -1,0 +1,97 @@
+---
+title: Getting Started
+description: "Install @capgo/capacitor-uwb and start UWB ranging on iOS and Android."
+sidebar:
+  order: 2
+---
+
+## Install
+
+You can use our AI-Assisted Setup to install the plugin. Add the Capgo skills to your AI tool using the following command:
+
+```bash
+npx skills add https://github.com/Cap-go/capgo-skills --skill capacitor-plugins
+```
+
+Then use the following prompt:
+
+```text
+Use the `capacitor-plugins` skill from `Cap-go/capgo-skills` to install the `@capgo/capacitor-uwb` plugin in my project.
+```
+
+If you prefer Manual Setup, install the plugin by running the following commands and follow the platform-specific instructions below:
+
+```bash
+bun add @capgo/capacitor-uwb
+bunx cap sync
+```
+
+## Import
+
+```typescript
+import { CapacitorUwb } from '@capgo/capacitor-uwb';
+```
+
+## Check Availability
+
+```typescript
+const availability = await CapacitorUwb.isAvailable();
+
+if (!availability.supported) {
+  console.log('This device does not support UWB.');
+}
+```
+
+## iOS Peer Session
+
+1. Call `getDiscoveryToken()` on both devices.
+2. Exchange the returned base64 tokens out-of-band.
+3. Start ranging with the peer token.
+
+```typescript
+const { discoveryToken } = await CapacitorUwb.getDiscoveryToken();
+
+await CapacitorUwb.startPeerSession({
+  peerDiscoveryToken: '<peer-token-base64>',
+});
+```
+
+See [iOS setup](/docs/plugins/uwb/ios/) for capability and permission requirements.
+
+## Android Controller / Controlee Session
+
+1. The controller calls `startControllerSession()` and shares the returned `rangingParameters`.
+2. The controlee calls `startControleeSession({ rangingParameters })`.
+3. Optionally pass `peerAddress` to the controller once the controlee address is known.
+
+```typescript
+const controller = await CapacitorUwb.startControllerSession();
+
+await CapacitorUwb.startControleeSession({
+  rangingParameters: controller.rangingParameters,
+});
+```
+
+See [Android setup](/docs/plugins/uwb/android/) for hardware and permission requirements.
+
+## Listen For Updates
+
+```typescript
+await CapacitorUwb.addListener('rangingUpdate', (event) => {
+  console.log(event.distanceMeters, event.direction);
+});
+
+await CapacitorUwb.addListener('sessionStateChanged', (event) => {
+  console.log(event.state, event.reason);
+});
+```
+
+## Stop The Session
+
+```typescript
+await CapacitorUwb.stopSession();
+```
+
+## Source Of Truth
+
+This page is generated from the plugin's `src/definitions.ts`. Update the TypeScript definitions and run `bun run docgen` in the plugin repository to refresh the generated API docs.

--- a/apps/docs/src/content/docs/docs/plugins/uwb/index.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/uwb/index.mdx
@@ -1,0 +1,70 @@
+---
+title: "@capgo/capacitor-uwb"
+description: Ultra-Wideband ranging for peer distance and direction on iOS Nearby Interaction and Android Jetpack UWB.
+tableOfContents: false
+next: false
+prev: false
+sidebar:
+  order: 1
+  label: "Introduction"
+hero:
+  tagline: Measure precise distance and direction between UWB-capable devices using native iOS and Android ranging APIs.
+  image:
+    file: ~public/icons/plugins/uwb.svg
+  actions:
+    - text: Get started
+      link: /docs/plugins/uwb/getting-started/
+      icon: right-arrow
+      variant: primary
+    - text: GitHub
+      link: https://github.com/Cap-go/capacitor-uwb/
+      icon: external
+      variant: minimal
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+## Overview
+
+Capacitor plugin for Ultra-Wideband (UWB) ranging on iOS and Android.
+
+<CardGrid stagger>
+  <Card title="iOS Nearby Interaction" icon="device-mobile">
+    Exchange `NIDiscoveryToken` values and run peer sessions with Apple's Nearby Interaction framework.
+  </Card>
+  <Card title="Android Jetpack UWB" icon="setting">
+    Start controller and controlee sessions with `androidx.core.uwb` ranging parameters.
+  </Card>
+  <Card title="Live Ranging Events" icon="rocket">
+    Listen for distance, direction, and session lifecycle updates from JavaScript.
+  </Card>
+  <Card title="Out-of-Band Exchange" icon="puzzle">
+    Bring your own transport for token and parameter exchange, such as BLE, MultipeerConnectivity, or a backend.
+  </Card>
+</CardGrid>
+
+## Core Capabilities
+
+- `isAvailable` - Check whether UWB is supported and currently available.
+- `getDiscoveryToken` - Get the local Nearby Interaction discovery token on iOS.
+- `startPeerSession` - Start an iOS peer ranging session.
+- `startControllerSession` - Start an Android controller session and return shareable parameters.
+- `startControleeSession` - Start an Android controlee session from controller parameters.
+- `stopSession` - Stop the active ranging session.
+
+## Public API
+
+| Method | Description |
+| --- | --- |
+| `isAvailable` | Check whether UWB is supported and currently available on the device. |
+| `getDiscoveryToken` | Get the local Nearby Interaction discovery token on iOS. |
+| `startPeerSession` | Start a Nearby Interaction peer session on iOS. |
+| `startControllerSession` | Start an Android UWB controller session and return shareable parameters. |
+| `startControleeSession` | Start an Android UWB controlee session with parameters from the controller. |
+| `stopSession` | Stop the active UWB ranging session. |
+| `addListener` | Listen for `rangingUpdate` and `sessionStateChanged` events. |
+| `getPluginVersion` | Get the current native plugin version. |
+
+## Source Of Truth
+
+This reference is synced from `src/definitions.ts` in [capacitor-uwb](https://github.com/Cap-go/capacitor-uwb/).

--- a/apps/docs/src/content/docs/docs/plugins/uwb/ios.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/uwb/ios.mdx
@@ -1,0 +1,53 @@
+---
+title: iOS Setup
+description: Configure Apple Nearby Interaction for UWB peer ranging in Capacitor apps.
+sidebar:
+  order: 3
+---
+
+## iOS native system used
+
+On iOS, this plugin uses **Nearby Interaction** from the `NearbyInteraction` framework.
+
+## Requirements
+
+- iOS 15+
+- Physical device with UWB hardware
+- Nearby Interaction capability enabled in Xcode
+
+## Xcode setup
+
+1. Open your iOS app target in Xcode.
+2. Go to **Signing & Capabilities**.
+3. Click **+ Capability** and add **Nearby Interaction**.
+4. Add a usage description to `Info.plist`:
+
+```xml
+<key>NSNearbyInteractionUsageDescription</key>
+<string>This app uses Ultra Wideband to measure distance to nearby devices.</string>
+```
+
+## Client flow
+
+```typescript
+import { CapacitorUwb } from '@capgo/capacitor-uwb';
+
+const { discoveryToken } = await CapacitorUwb.getDiscoveryToken();
+
+await CapacitorUwb.startPeerSession({
+  peerDiscoveryToken: '<peer-token-base64>',
+  isCameraAssistanceEnabled: false,
+});
+```
+
+Share each device's `discoveryToken` with the other peer using your own transport layer. The plugin does not perform discovery or networking for you.
+
+## Events
+
+- `rangingUpdate` emits distance and direction updates when available.
+- `sessionStateChanged` emits lifecycle states such as `running`, `suspended`, `invalidated`, and `peerDisconnected`.
+
+## Notes
+
+- `getDiscoveryToken()` and `startPeerSession()` are iOS-only APIs.
+- Camera assistance is available on iOS 16+ when supported by the device.

--- a/apps/web/public/icons/plugins/uwb.svg
+++ b/apps/web/public/icons/plugins/uwb.svg
@@ -1,0 +1,7 @@
+<svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="56" height="56" rx="12" fill="#1D4ED8" />
+  <circle cx="28" cy="28" r="4" fill="white" />
+  <path d="M28 16C33.5228 16 38 20.4772 38 26" stroke="white" stroke-width="2.5" stroke-linecap="round" />
+  <path d="M28 12C36.2843 12 43 18.7157 43 27" stroke="white" stroke-width="2.5" stroke-linecap="round" opacity="0.75" />
+  <path d="M28 20C30.7614 20 33 22.2386 33 25" stroke="white" stroke-width="2.5" stroke-linecap="round" opacity="0.9" />
+</svg>

--- a/apps/web/src/config/plugins.ts
+++ b/apps/web/src/config/plugins.ts
@@ -54,6 +54,7 @@ const actionDefinitionRows =
 @capgo/electron-updater|github.com/Cap-go|OTA live updates for Electron apps with the same API surface as capacitor-updater|https://github.com/Cap-go/electron-updater/|Electron Updater
 @capgo/cordova-updater|github.com/Cap-go|OTA live updates for Cordova iOS and Android with the same API as capacitor-updater|https://github.com/Cap-go/cordova-updater/|Cordova Updater
 @capgo/capacitor-uploader|github.com/Cap-go|Upload large files reliably in background with progress tracking and retry support|https://github.com/Cap-go/capacitor-uploader/|Uploader
+@capgo/capacitor-uwb|github.com/Cap-go|Ultra-Wideband ranging for peer distance and direction on iOS Nearby Interaction and Android Jetpack UWB|https://github.com/Cap-go/capacitor-uwb/|UWB
 @revenuecat/purchases-capacitor|github.com/Cap-go|Implement in-app subscriptions and purchases with RevenueCat SDK for cross-platform monetization|https://github.com/RevenueCat/purchases-capacitor/|Purchases
 @capgo/capacitor-flash|github.com/Cap-go|Control device flashlight and torch with simple on/off toggle functionality|https://github.com/Cap-go/capacitor-flash/|Flash
 @capgo/capacitor-screen-recorder|github.com/Cap-go|Capture screen recordings with audio for tutorials, demos, and bug reports|https://github.com/Cap-go/capacitor-screen-recorder/|Screen Recorder
@@ -205,6 +206,7 @@ const pluginIconsByName: Record<string, string> = {
   '@capgo/capacitor-updater': 'ArrowPath',
   '@capgo/electron-updater': 'ArrowPath',
   '@capgo/cordova-updater': 'ArrowPath',
+  '@capgo/capacitor-uwb': 'Signal',
   '@capgo/capacitor-uploader': 'ArrowUpOnSquare',
   '@revenuecat/purchases-capacitor': 'CurrencyDollar',
   '@capgo/capacitor-flash': 'Bolt',
@@ -430,6 +432,7 @@ const pluginNamesByCategory = {
     '@capgo/capacitor-android-kiosk',
     '@capgo/capacitor-background-task',
     '@capgo/capacitor-health',
+    '@capgo/capacitor-uwb',
     '@capgo/capacitor-llm',
     '@capgo/capacitor-proximity',
     '@capgo/capacitor-sim',

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-uwb.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-uwb.md
@@ -1,0 +1,61 @@
+---
+locale: en
+---
+# Using @capgo/capacitor-uwb
+
+Capacitor plugin for Ultra-Wideband (UWB) ranging on iOS and Android.
+
+## Install
+
+```bash
+bun add @capgo/capacitor-uwb
+bunx cap sync
+```
+
+## What This Plugin Exposes
+
+- `isAvailable` - Check whether UWB is supported and currently available.
+- `getDiscoveryToken` - Get the local Nearby Interaction discovery token on iOS.
+- `startPeerSession` - Start an iOS peer ranging session.
+- `startControllerSession` - Start an Android controller session and return shareable parameters.
+- `startControleeSession` - Start an Android controlee session from controller parameters.
+- `stopSession` - Stop the active ranging session.
+
+## Example Usage
+
+### Check availability
+
+```typescript
+import { CapacitorUwb } from '@capgo/capacitor-uwb';
+
+const availability = await CapacitorUwb.isAvailable();
+```
+
+### iOS peer ranging
+
+```typescript
+const { discoveryToken } = await CapacitorUwb.getDiscoveryToken();
+
+await CapacitorUwb.startPeerSession({
+  peerDiscoveryToken: '<peer-token-base64>',
+});
+```
+
+### Android controller / controlee
+
+```typescript
+const controller = await CapacitorUwb.startControllerSession();
+
+await CapacitorUwb.startControleeSession({
+  rangingParameters: controller.rangingParameters,
+});
+```
+
+## Full Reference
+
+- GitHub: https://github.com/Cap-go/capacitor-uwb/
+- Docs: /docs/plugins/uwb/
+
+## Keep going from Using @capgo/capacitor-uwb
+
+If you are using **Using @capgo/capacitor-uwb** to plan native plugin work, connect it with [@capgo/capacitor-uwb](/docs/plugins/uwb/) for the implementation detail in @capgo/capacitor-uwb, [Getting Started](/docs/plugins/uwb/getting-started/) for the implementation detail in Getting Started, [Capgo Plugin Directory](/plugins/) for the product workflow in Capgo Plugin Directory, [Capacitor Plugins by Capgo](/docs/plugins/) for the implementation detail in Capacitor Plugins by Capgo, and [Adding or Updating Plugins](/docs/contributing/adding-plugins/) for the implementation detail in Adding or Updating Plugins.


### PR DESCRIPTION
## Summary
- Add docs pages for `@capgo/capacitor-uwb` at `/docs/plugins/uwb/`
- Register the plugin in `apps/web/src/config/plugins.ts` and the docs sidebar
- Add plugin icon and SEO tutorial page for `capacitor-uwb`

## Test plan
- [ ] Docs site builds successfully in CI
- [ ] `/docs/plugins/uwb/` renders overview, getting started, iOS, and Android pages
- [ ] Plugin appears in the plugin directory under Device APIs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documentation and tutorial content for the UWB (`@capgo/capacitor-uwb`) plugin, including iOS and Android setup guides.
  * Updated the plugins navigation/listings so the UWB plugin is now discoverable in both docs and the web experience.
  * Included public API overviews, setup instructions, and example usage for starting/stopping sessions and handling plugin events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->