### PR TITLE
docs: add Apple JWT clock troubleshooting

### DIFF
--- a/apps/docs/src/content/docs/docs/builder/ios.mdx
+++ b/apps/docs/src/content/docs/docs/builder/ios.mdx
@@ -529,6 +529,12 @@ If all went well, you will see the following output:
 
 ![Capgo CLI credentials save output](/native-build-assets/credentials-save.webp)
 
+:::tip[Apple auth failed? Sync your clock]
+If the App Store Connect API key looks correct but authentication still fails, sync your computer clock and retry. Capgo signs Apple's JWT with your local system time, and Apple rejects tokens that expire more than 20 minutes in the future. A clock that is only a few seconds out of sync can be enough to fail this step.
+
+See the [builder troubleshooting guide](/docs/builder/troubleshooting/#app-store-connect-authentication-failed) for clock sync steps.
+:::
+
 ### CI/CD setup (GitHub Actions)
 
 If you already completed [Team ID](#team-id), [Apple key, Apple key ID and Apple issuer ID](#apple-key-apple-key-id-and-apple-issuer-id), [Certificate](#certificate), and [Provisioning profile](#provisioning-profile), you already have everything needed for CI/CD.

--- a/apps/docs/src/content/docs/docs/builder/troubleshooting.mdx
+++ b/apps/docs/src/content/docs/docs/builder/troubleshooting.mdx
@@ -194,7 +194,17 @@ Very large projects may hit the build-time limit (see [Known Limitations](#known
    - Check APPLE_ISSUER_ID (should be UUID format)
    - Verify APPLE_KEY_CONTENT is correctly base64-encoded
 
-2. **Test API key locally**
+2. **Sync your computer clock**
+   - App Store Connect authentication uses short-lived JWTs generated from your local system time
+   - Apple rejects tokens that expire more than 20 minutes in the future, so even small clock drift can make an otherwise valid key fail
+   - On Windows, open **Settings > Time & language > Date & time** and click **Sync now**
+   - On macOS, open **System Settings > General > Date & Time** and enable automatic time
+   - On Linux, check `timedatectl status` and enable NTP if needed
+   - After syncing, re-run the Capgo build or credential command
+
+   See Apple's [Generating Tokens for API Requests](https://developer.apple.com/documentation/appstoreconnectapi/generating-tokens-for-api-requests) documentation for the App Store Connect token lifetime rule.
+
+3. **Test API key locally**
    ```bash
    # Decode key
    echo $APPLE_KEY_CONTENT | base64 -d > AuthKey.p8
@@ -203,11 +213,11 @@ Very large projects may hit the build-time limit (see [Known Limitations](#known
    fastlane pilot list
    ```
 
-3. **Check API key permissions**
+4. **Check API key permissions**
    - Key needs "Developer" role or higher
-   - Verify in App Store Connect → Users and Access → Keys
+   - Verify in App Store Connect -> Users and Access -> Keys
 
-4. **Ensure key is not revoked**
+5. **Ensure key is not revoked**
    - Check in App Store Connect
    - Generate new key if needed
 


### PR DESCRIPTION
## Summary
- Add a clock-sync check to App Store Connect authentication troubleshooting for Capgo Native Build.
- Add an iOS build guide callout near the credential-save step so users retry with a synced clock before chasing valid Apple API keys.
- Link to Apple's App Store Connect JWT token lifetime documentation.

## Tests
- `bunx prettier --write apps/docs/src/content/docs/docs/builder/troubleshooting.mdx apps/docs/src/content/docs/docs/builder/ios.mdx`
- `bun run ci:verify:docs` (passes; Astro reports an existing hint in `src/components/BuildCredentialsQuestionnaire.astro` about `questionFlow`)
- `bun run build:docs`
- `bun run visual-diff:capture:before -- --suite docs --routes /docs/builder/ios/,/docs/builder/troubleshooting/`
- `bun run visual-diff:capture:after -- --suite docs --routes /docs/builder/ios/,/docs/builder/troubleshooting/`
- `bun run visual-diff:compare`

## Visual diff

Generated with `bun run visual-diff:compare` (4 screenshots, fuzz 1%).

| Status | Suite | Route | Viewport | Diff (px) |
| --- | --- | --- | --- | ---: |
| changed | docs | /docs/builder/ios// | desktop | 5255520 |
| changed | docs | /docs/builder/ios// | mobile | 3270900 |
| changed | docs | /docs/builder/troubleshooting// | desktop | 2946720 |
| changed | docs | /docs/builder/troubleshooting// | mobile | 1696580 |

**Summary:**
- identical: 0
- minor: 0
- changed: 4

## Screenshot

![Apple auth clock sync troubleshooting callout](https://files.catbox.moe/m3v0e6.webp)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for fixing Apple authentication issues by syncing your computer clock and retrying.
  * Expanded troubleshooting steps for App Store Connect authentication failures, including updated step order and clearer API key permission requirements.
  * Added a link to the clock-sync troubleshooting instructions for quicker resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->