### PR TITLE
docs: test native builds without live updates

### DIFF
--- a/apps/docs/src/content/docs/docs/live-updates/update-behavior.mdx
+++ b/apps/docs/src/content/docs/docs/live-updates/update-behavior.mdx
@@ -122,6 +122,72 @@ Learn more in the [Delta (manifest) Updates documentation](/docs/live-updates/di
 - `'always'`: Check on every foreground transition and apply immediately whenever an update is available
 - `'onlyDownload'`: Check and download automatically, emit `updateAvailable`, and never set the next bundle or apply an update automatically
 
+## Test a Native Build Without Live Updates
+
+When testing a new native binary, make sure the app starts from the web assets bundled in that binary instead of a previously downloaded live update. You can use one or combine several of the following safeguards.
+
+### 1. Bump the Native Baseline Version
+
+Set `CapacitorUpdater.version` from the version used for your native release, and increase it for every native build. A newer native baseline makes the installed binary distinct from older bundles and, with the default `resetWhenUpdate: true`, removes downloaded bundles when the newer native app is installed.
+
+```typescript
+import type { CapacitorConfig } from '@capacitor/cli';
+import pkg from './package.json';
+
+const config: CapacitorConfig = {
+  plugins: {
+    CapacitorUpdater: {
+      // Keep this aligned with, and increase it for, every native build.
+      version: pkg.version,
+      autoUpdate: 'atBackground',
+    },
+  },
+};
+
+export default config;
+```
+
+For example, a binary built with `version: '1.4.1'` has a higher native baseline than an existing `1.4.0` bundle. Do not reuse a native version when you need to verify the bundled assets.
+
+### 2. Block Updates for Emulators and Development Builds
+
+In the channel used by the app, disable **Allow emulator devices** and **Allow development builds**. The updater then does not deliver that channel's bundles to simulators/emulators or development-signed native builds. This is useful when those builds should always use their bundled web assets.
+
+### 3. Enable Live Updates Only in Native CI Builds
+
+For teams that want local, emulator, and developer builds to be safe by default, make live updates opt-in through an environment variable. The config below disables update checks unless `CAPGO_LIVE_UPDATES` is exactly `true`:
+
+```typescript
+import type { CapacitorConfig } from '@capacitor/cli';
+import pkg from './package.json';
+
+const liveUpdatesEnabled = process.env.CAPGO_LIVE_UPDATES === 'true';
+
+const config: CapacitorConfig = {
+  appId: 'com.example.app',
+  appName: 'Example App',
+  plugins: {
+    CapacitorUpdater: {
+      // Bump package.json for every native build.
+      version: pkg.version,
+      // Local builds are off; native CI explicitly enables live updates.
+      autoUpdate: liveUpdatesEnabled ? 'atBackground' : false,
+    },
+  },
+};
+
+export default config;
+```
+
+Set the variable only in the CI step that synchronizes and builds the native app:
+
+```yaml
+- run: CAPGO_LIVE_UPDATES=true npx cap sync
+- run: ./build-native-app.sh
+```
+
+Run `npx cap sync` after setting the variable because Capacitor copies this configuration into the native projects during sync. Without the variable, local builds and emulator builds keep `autoUpdate: false` and do not check for live updates.
+
 ```typescript
 import { CapacitorConfig } from '@capacitor/cli';
 


### PR DESCRIPTION
## What changed

- Added a dedicated native-build testing guide with the native baseline, channel policy, and CI-only opt-in strategies.
- Added an optimized WebP of the Capgo channel settings and explained that Allow development build and Allow Emulators must be switched off for this test path.
- Linked the new guide from Update Behavior and the Live Updates overview.

## Console setup

![Channel settings showing the development-build and emulator switches](https://raw.githubusercontent.com/Cap-go/website/codex/native-build-without-live-updates/apps/web/public/native-build-live-updates-channel-settings.webp)

## Why

A previously downloaded bundle can obscure the web assets embedded in a native build during testing.

## Validation

- npx prettier --write on the changed documentation files
- NODE_OPTIONS=--max-old-space-size=16384 bun run check in apps/docs: 0 errors
- Asset inspected after WebP conversion: 1536 x 1200, 28 KB
- CI pending for commit 51449a5