### PR TITLE
fix: keep locale on translation cache miss

### DIFF
--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -1,4 +1,4 @@
-import { __translationWorkerTest, TranslationCoordinator } from '../src/index'
+import worker, { __translationWorkerTest, TranslationCoordinator } from '../src/index'
 
 function assert(condition: unknown, message: string): void {
   if (!condition) throw new Error(message)
@@ -184,3 +184,126 @@ response = await coordinator.fetch(coordinatorRequest({ ...queueJob, priority: t
 assert(response.ok, 'Coordinator rejected duplicate source-specific refresh')
 assert((await response.json()).queued === false, 'Coordinator enqueued a duplicate source-specific refresh after older job completion')
 assert(priorityQueued.length === 2, 'Coordinator sent duplicate source-specific refresh messages')
+
+const originalCaches = Object.getOwnPropertyDescriptor(globalThis, 'caches')
+const cacheEntries = new Map<string, Response>()
+const cacheKey = (key: RequestInfo | URL): string => {
+  if (typeof key === 'string') return key
+  if (key instanceof URL) return key.toString()
+  return key.url
+}
+
+Object.defineProperty(globalThis, 'caches', {
+  configurable: true,
+  value: {
+    default: {
+      match: async (key: RequestInfo | URL) => cacheEntries.get(cacheKey(key))?.clone(),
+      put: async (key: RequestInfo | URL, response: Response) => {
+        cacheEntries.set(cacheKey(key), response.clone())
+      },
+      delete: async (key: RequestInfo | URL) => cacheEntries.delete(cacheKey(key)),
+    },
+  },
+})
+
+try {
+  const storedTranslations = new Map<string, string>()
+  const translationJobs: Array<Record<string, unknown>> = []
+  const sourceHtml = '<!doctype html><html lang="en"><head><title>Docs title</title></head><body><main><h1>Read our guides</h1></main></body></html>'
+  const env = {
+    AI: {
+      run: async (_model: string, input: { messages: Array<{ content: string }> }) => {
+        const lastMessage = input.messages[input.messages.length - 1]
+        const payload = JSON.parse(lastMessage?.content ?? '{}') as { texts?: string[] }
+        return {
+          response: JSON.stringify({
+            translations: (payload.texts ?? []).map((text) => {
+              if (text.includes('Read our guides')) return 'Leggi le nostre guide'
+              if (text.includes('Docs title')) return 'Titolo documentazione'
+              return 'IT ' + text
+            }),
+          }),
+        }
+      },
+    },
+    WEB: {
+      fetch: async () => {
+        throw new Error('The docs request unexpectedly used the web origin')
+      },
+    },
+    DOCS: {
+      fetch: async () => new Response(sourceHtml, { headers: { 'Content-Type': 'text/html; charset=utf-8' } }),
+    },
+    TRANSLATION_QUEUE: {
+      send: async (job: Record<string, unknown>) => {
+        translationJobs.push(job)
+      },
+    },
+    TRANSLATION_STORE: {
+      get: async (key: string) => {
+        const value = storedTranslations.get(key)
+        return value === undefined ? null : { text: async () => value }
+      },
+      put: async (key: string, value: string) => {
+        storedTranslations.set(key, value)
+      },
+      delete: async (key: string) => {
+        storedTranslations.delete(key)
+      },
+    },
+  }
+  const request = new Request('https://capgo.app/it/docs/')
+  const pendingResponse = await worker.fetch(request, env as any)
+
+  assert(pendingResponse.status === 503, 'A translation cache miss did not return a temporary localized response')
+  assert(pendingResponse.headers.get('Location') === null, 'A translation cache miss redirected visitors away from the localized URL')
+  assert(pendingResponse.headers.get('Refresh') === '5', 'A translation cache miss did not schedule a localized retry')
+  assert(pendingResponse.headers.get('Retry-After') === '5', 'A translation cache miss did not advertise when to retry')
+  assert(pendingResponse.headers.get('X-Capgo-Translation-Cache') === 'MISS', 'A translation cache miss did not report its cache state')
+  assert(pendingResponse.headers.get('X-Capgo-Translation-Fallback') === 'temporary-english-retry', 'A translation cache miss did not report the retry fallback')
+  assert((await pendingResponse.text()).includes('Read our guides'), 'A translation cache miss did not keep the source document available while it is translated')
+  assert(translationJobs.length === 1, 'A translation cache miss did not enqueue the localized document')
+  assert(translationJobs[0]?.url === 'https://capgo.app/it/docs/', 'The cache-miss job lost the localized URL')
+  assert(translationJobs[0]?.locale === 'it', 'The cache-miss job lost the requested locale')
+  assert(translationJobs[0]?.reason === 'miss', 'The cache-miss job did not identify the cache-miss reason')
+
+  const pendingHeadResponse = await worker.fetch(new Request(request.url, { method: 'HEAD' }), env as any)
+  assert(pendingHeadResponse.status === 503, 'A HEAD translation cache miss did not match the GET temporary response')
+  assert(pendingHeadResponse.headers.get('Location') === null, 'A HEAD translation cache miss redirected visitors away from the localized URL')
+  assert(pendingHeadResponse.headers.get('Refresh') === '5', 'A HEAD translation cache miss did not schedule a localized retry')
+  assert((await pendingHeadResponse.text()) === '', 'A HEAD translation cache miss returned a response body')
+  assert(translationJobs.length === 1, 'A HEAD translation cache miss enqueued a duplicate localized document')
+
+  await worker.queue({ messages: [{ body: translationJobs[0] as any }] }, env as any)
+  const translatedResponse = await worker.fetch(request, env as any)
+
+  assert(translatedResponse.status === 200, 'A completed cache-miss translation was not served successfully')
+  assert(translatedResponse.headers.get('X-Capgo-Translation-Cache') === 'HIT', 'A completed cache-miss translation was not cached')
+  assert((await translatedResponse.text()).includes('Leggi le nostre guide'), 'A completed cache-miss translation did not contain the translated document')
+
+  const originalConsoleError = console.error
+  let enqueueFailureResponse: Response | null = null
+  try {
+    console.error = () => undefined
+    enqueueFailureResponse = await worker.fetch(new Request('https://capgo.app/fr/docs/'), {
+      ...env,
+      TRANSLATION_QUEUE: {
+        send: async () => {
+          throw new Error('Expected queue failure')
+        },
+      },
+    } as any)
+  } finally {
+    console.error = originalConsoleError
+  }
+  if (!enqueueFailureResponse) throw new Error('A queue failure did not return a response')
+  assert(enqueueFailureResponse.status === 302, 'A failed translation enqueue did not use the safe English fallback')
+  assert(enqueueFailureResponse.headers.get('Location') === '/docs/', 'A failed translation enqueue redirected to the wrong English document')
+  assert(enqueueFailureResponse.headers.get('X-Capgo-Translation-Fallback') === 'temporary-english-redirect', 'A failed translation enqueue kept retrying without a queued job')
+} finally {
+  if (originalCaches) {
+    Object.defineProperty(globalThis, 'caches', originalCaches)
+  } else {
+    delete (globalThis as { caches?: unknown }).caches
+  }
+}

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -160,6 +160,7 @@ const FRESH_MS = 24 * 60 * 60 * 1000
 const CACHE_KEEP_SECONDS = 7 * 24 * 60 * 60
 const TRANSLATION_SOURCE_CHECK_SECONDS = 5 * 60
 const TRANSLATION_PENDING_SECONDS = 10 * 60
+const TRANSLATION_RETRY_SECONDS = 5
 const TRANSLATION_COORDINATOR_PENDING_MS = 15 * 60 * 1000
 const TRANSLATION_CACHE_VERSION = '2026-05-10-ahrefs-head-assets-v1'
 const TRANSLATION_SOURCE_HASH_HEADER = 'X-Capgo-Translation-Source-Hash'
@@ -592,6 +593,26 @@ function temporaryEnglishRedirectResponse(requestUrl: URL, isHead = false): Resp
     'X-Capgo-Translation-Fallback': 'temporary-english-redirect',
   })
   return withResponseHeaders(new Response(null, { status: 302, headers }), 'BYPASS', isHead)
+}
+
+async function temporaryEnglishRetryResponse(request: Request, env: Env, requestUrl: URL, locale: Locale, isHead = false): Promise<Response> {
+  const originResponse = await fetchEnglishOrigin(request, env, requestUrl)
+  if (isRedirect(originResponse)) return withResponseHeaders(localizeRedirect(originResponse, requestUrl, locale), 'BYPASS', isHead)
+  if (!originResponse.ok || !isHtmlResponse(originResponse)) return withResponseHeaders(originResponse, 'BYPASS', isHead)
+
+  const headers = new Headers(originResponse.headers)
+  headers.set('Refresh', String(TRANSLATION_RETRY_SECONDS))
+  headers.set('Retry-After', String(TRANSLATION_RETRY_SECONDS))
+  headers.set('X-Capgo-Translation-Fallback', 'temporary-english-retry')
+  return withResponseHeaders(
+    new Response(isHead ? null : originResponse.body, {
+      status: 503,
+      statusText: 'Translation pending',
+      headers,
+    }),
+    'MISS',
+    isHead,
+  )
 }
 
 function toCachedResponse(response: Response, sourceHash?: string): Response {
@@ -2148,15 +2169,17 @@ async function enqueueTranslation(env: Env, requestUrl: URL, locale: Locale, rea
   await putTranslationPendingMarkerSafely(requestUrl, locale, reason, priority, sourceHash)
 }
 
-async function enqueueTranslationSafely(env: Env, requestUrl: URL, locale: Locale, reason: TranslationQueueReason, priority: boolean, sourceHash?: string): Promise<void> {
+async function enqueueTranslationSafely(env: Env, requestUrl: URL, locale: Locale, reason: TranslationQueueReason, priority: boolean, sourceHash?: string): Promise<boolean> {
   try {
     await enqueueTranslation(env, requestUrl, locale, reason, priority, sourceHash)
+    return true
   } catch (error) {
     console.error('Failed to enqueue translated page', { pathname: requestUrl.pathname, locale, reason, error: errorMessage(error) })
+    return false
   }
 }
 
-function scheduleTranslationBackgroundTask(ctx: WorkerExecutionContext | undefined, task: Promise<void>): void {
+function scheduleTranslationBackgroundTask(ctx: WorkerExecutionContext | undefined, task: Promise<unknown>): void {
   if (ctx) {
     ctx.waitUntil(task)
     return
@@ -2286,12 +2309,9 @@ async function serveTranslated(request: Request, env: Env, requestUrl: URL, loca
     return withResponseHeaders(storedResponse, isStale ? 'STALE' : 'HIT', isHead)
   }
 
-  if (request.method !== 'GET') {
-    return temporaryEnglishRedirectResponse(requestUrl, isHead)
-  }
-
-  await enqueueTranslationSafely(env, requestUrl, locale, 'miss', priority)
-  return temporaryEnglishRedirectResponse(requestUrl, isHead)
+  const enqueued = await enqueueTranslationSafely(env, requestUrl, locale, 'miss', priority)
+  if (!enqueued) return temporaryEnglishRedirectResponse(requestUrl, isHead)
+  return await temporaryEnglishRetryResponse(request, env, requestUrl, locale, isHead)
 }
 
 function jsonResponse(body: unknown, status = 200): Response {


### PR DESCRIPTION
## Summary

- keep localized docs URLs in place during a cold translation cache miss
- when a translation job queues successfully, return the temporary English source as a no-store 503 with Refresh and Retry-After instead of redirecting to /docs/
- retain the existing English redirect if the queue cannot accept the job
- cover enqueue, queue processing, HEAD parity, and localized cache-hit behavior with Worker regression tests

## Validation

- bun run ci:verify:translation

## Visual impact

No layout or rendered-content change; this is Worker response behavior only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live edge response semantics for localized pages on cache miss (503 vs redirect), which affects SEO, bookmarks, and crawlers; fallbacks and regression tests limit blast radius.
> 
> **Overview**
> **On a cold translation cache miss**, successful queue enqueue no longer **302s** visitors to the English path. The worker now serves the **English origin HTML** at the **localized URL** as a **503** with **`Refresh`** / **`Retry-After`** (5s), **`X-Capgo-Translation-Cache: MISS`**, and **`X-Capgo-Translation-Fallback: temporary-english-retry`**. **HEAD** requests follow the same path (empty body, same headers).
> 
> If **`enqueueTranslationSafely`** fails, behavior is unchanged: **302** to the default-locale path with **`temporary-english-redirect`**.
> 
> **`verify-parser.ts`** adds end-to-end Worker tests for cache miss, HEAD parity, post-queue **HIT**, and enqueue failure fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d742838d08f913a30ac7ecbe2441c63f7e547db8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->