### PR TITLE
docs: document Delta update path limitations

### DIFF
--- a/apps/docs/src/content/docs/docs/faq.mdx
+++ b/apps/docs/src/content/docs/docs/faq.mdx
@@ -19,6 +19,15 @@ We use the term "release" to mean preparing a binary for the app stores. In orde
 
 We use the term "bundle" to mean a patch that can be applied to a release to update it to new code. The `npx @capgo/cli@latest bundle upload` command is used to generate a bundle from your new local code which is then shipped to your users.
 
+### Are there Delta update file-path limitations?[](https://capgo.app/docs/faq/#are-there-delta-update-file-path-limitations "Direct link to Are there Delta update file-path limitations?")
+
+Yes:
+
+- **Zero-byte files:** The CLI logs `Ignoring empty file...` and excludes empty files from the Delta manifest. It does not fail the upload, so an empty file can change the resulting bundle without stopping your deployment. Do not include zero-byte files in Delta bundle paths.
+- **Paths with spaces:** Delta uploads fail early with a clear error when a bundle path contains a space. Rename files or directories to remove spaces before uploading a Delta update.
+
+See [Delta updates](/docs/live-updates/differentials/) for setup details.
+
 ### What is the roadmap?[](https://capgo.app/docs/faq/#what-is-the-roadmap "Direct link to What is the roadmap?")
 
 Our project boards are also public and found at: [https://github.com/orgs/Cap-go/projects](https://github.com/orgs/Cap-go/projects/)

--- a/apps/docs/src/content/docs/docs/live-updates/differentials.mdx
+++ b/apps/docs/src/content/docs/docs/live-updates/differentials.mdx
@@ -39,6 +39,11 @@ npx @capgo/cli@latest bundle upload --delta
 
 If `autoUpdate` is set to an instant apply mode (`"atInstall"`, `"onLaunch"`, or `"always"`) in your `capacitor.config`, the CLI detects it. In non-interactive environments it sends Delta (manifest) updates automatically, and in interactive environments it prompts you to confirm before uploading. Legacy `directUpdate` config is still detected. Use `--no-delta` to force a full bundle upload.
 
+## Delta update limitations
+
+- **Empty files:** The CLI logs `Ignoring empty file...` and excludes zero-byte files from the Delta manifest. It does not fail the upload, so adding an empty file can change the resulting bundle without stopping your deployment. Do not include zero-byte files in Delta bundle paths.
+- **Spaces in paths:** Delta uploads fail before uploading files when a bundle path contains a space. Rename the file or directory to remove spaces before uploading a Delta update.
+
 ## Enforcing Delta (Manifest) Updates
 
 If you want to ensure that all uploads are Delta (manifest) updates and prevent any accidental full bundle uploads, you can use the `--delta-only` flag:


### PR DESCRIPTION
## Summary

- document zero-byte file handling for Delta uploads
- document the early failure for spaces in Delta bundle paths
- add the same limitations to the FAQ

## Validation

- `NODE_OPTIONS=--max-old-space-size=16384 bunx astro check` (apps/docs)
- `git diff --check`

## Visual diff

Focused docs visual capture could not run: the docs build process was killed by the local environment before it produced `apps/docs/dist/index.html`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

