### PR TITLE
docs(builder): CI guides for OTA vs native, UI triggers, and webhooks

### DIFF
--- a/apps/docs/src/config/llmsCustomSets.ts
+++ b/apps/docs/src/config/llmsCustomSets.ts
@@ -1,4 +1,4 @@
-const llmsCustomSetRows = String.raw`Capgo Builder|cloud native iOS and Android builds with Capgo Build, CI triggers, and webhooks|docs/builder/**
+const llmsCustomSetRows = String.raw`Capgo Builder|cloud-based native iOS and Android builds with Capgo Build, CI triggers, and webhooks|docs/builder/**
 Capgo CLI|full reference documentation for capgo CLI to upload and manage your live updates|docs/cli/**
 Plugin Live updates|full reference documentation for plugin live updates for Capacitor, Cordova, and Electron|docs/live-updates/**|docs/plugins/updater/**|docs/plugins/cordova-updater/**|docs/plugins/electron-updater/**
 Console Tutorial|step-by-step tutorial to get started with Capgo Console and live updates|docs/webapp/**

--- a/apps/docs/src/config/llmsCustomSets.ts
+++ b/apps/docs/src/config/llmsCustomSets.ts
@@ -1,4 +1,5 @@
-const llmsCustomSetRows = String.raw`Capgo CLI|full reference documentation for capgo CLI to upload and manage your live updates|docs/cli/**
+const llmsCustomSetRows = String.raw`Capgo Builder|cloud native iOS and Android builds with Capgo Build, CI triggers, and webhooks|docs/builder/**
+Capgo CLI|full reference documentation for capgo CLI to upload and manage your live updates|docs/cli/**
 Plugin Live updates|full reference documentation for plugin live updates for Capacitor, Cordova, and Electron|docs/live-updates/**|docs/plugins/updater/**|docs/plugins/cordova-updater/**|docs/plugins/electron-updater/**
 Console Tutorial|step-by-step tutorial to get started with Capgo Console and live updates|docs/webapp/**
 Public API|full reference documentation for public API|docs/public-api/**

--- a/apps/docs/src/content/docs/docs/builder/ci-ota-or-native.mdx
+++ b/apps/docs/src/content/docs/docs/builder/ci-ota-or-native.mdx
@@ -223,14 +223,28 @@ deploy:
   needs: [build_web]
   script:
     - |
-      TYPE=$(npx @capgo/cli@latest bundle releaseType "$APP_ID" --channel "$CHANNEL" | tr -d '[:space:]')
+      BEFORE="${CI_COMMIT_BEFORE_SHA:-}"
+      if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+        BEFORE="$(git rev-parse HEAD~1 2>/dev/null || echo '')"
+      fi
+      if [ -z "$BEFORE" ] || git diff --name-only "$BEFORE" "$CI_COMMIT_SHA" \
+        | grep -qE '^(ios/|android/|capacitor\.config\.)'; then
+        TYPE=native
+      else
+        TYPE=$(npx @capgo/cli@latest bundle releaseType "$APP_ID" --channel "$CHANNEL" | tr -d '[:space:]')
+      fi
       echo "Capgo release type: $TYPE"
       if [ "$TYPE" = "OTA" ]; then
-        npx @capgo/cli@latest bundle upload "$APP_ID"           --channel "$CHANNEL"           --fail-on-incompatible
+        npx @capgo/cli@latest bundle upload "$APP_ID" \
+          --channel "$CHANNEL" \
+          --fail-on-incompatible
       elif [ "$TYPE" = "native" ]; then
         npx cap sync
         npx @capgo/cli@latest build request "$APP_ID" --platform ios --build-mode release
         npx @capgo/cli@latest build request "$APP_ID" --platform android --build-mode release
+        npx @capgo/cli@latest bundle upload "$APP_ID" \
+          --channel "$CHANNEL" \
+          --auto-min-update-version
       else
         echo "Unexpected release type: $TYPE" >&2
         exit 1

--- a/apps/docs/src/content/docs/docs/builder/ci-ota-or-native.mdx
+++ b/apps/docs/src/content/docs/docs/builder/ci-ota-or-native.mdx
@@ -31,6 +31,8 @@ npx @capgo/cli@latest bundle releaseType com.example.app --channel production
 
 `OTA` means the native packages match what is already live on the channel. `native` means a plugin, Capacitor version, or other native dependency changed — an over-the-air bundle alone cannot update those devices safely.
 
+`releaseType` compares **native package metadata** (Capacitor/Cordova plugins and versions). It does **not** see every edit under `ios/`, `android/`, or `capacitor.config.*`. Gate those paths in git first, then use `releaseType` for dependency compatibility — the examples below do both.
+
 See [Native Compatibility](/docs/live-updates/compatibility/) for the full rules and the manual `bundle compatibility` table.
 
 <Aside type="tip">
@@ -49,13 +51,14 @@ Gate every production pipeline on `releaseType`. It is cheaper than guessing, an
 <MermaidGraph graph={releaseDecisionGraph} ariaLabel="Flowchart of CI deciding between live update and Capgo Build" />
 
 1. Build web assets as usual.
-2. Ask Capgo whether this commit is OTA-safe.
-3. If `OTA`, upload the bundle.
-4. If `native`, run Capgo Build (and optionally still upload a bundle with `--fail-on-incompatible` / `--auto-min-update-version` once the binary is ready — see [Prevent incompatible deliveries](/docs/live-updates/compatibility/#prevent-incompatible-deliveries)).
+2. If the commit touches `ios/`, `android/`, or `capacitor.config.*`, force the native path.
+3. Otherwise ask Capgo `releaseType` whether the commit is OTA-safe.
+4. If `OTA`, upload the bundle (with `--fail-on-incompatible` as a safety rail).
+5. If `native`, run Capgo Build, then upload the matching bundle with `--auto-min-update-version` so the channel's native metadata advances (use the [metadata strategy](/docs/live-updates/compatibility/#prevent-incompatible-deliveries)). Do **not** use `--fail-on-incompatible` for that baseline upload — the new native packages are supposed to differ.
 
 ## GitHub Actions
 
-One workflow that branches on `releaseType`:
+One workflow that gates native paths, then branches on `releaseType`:
 
 ```yaml
 # .github/workflows/capgo-release.yml
@@ -72,6 +75,8 @@ jobs:
       release_type: ${{ steps.verdict.outputs.type }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -85,7 +90,17 @@ jobs:
         env:
           CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
         run: |
-          TYPE=$(npx @capgo/cli@latest bundle releaseType com.example.app --channel production | tr -d '[:space:]')
+          BEFORE="${{ github.event.before }}"
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            BEFORE="$(git rev-parse HEAD~1)"
+          fi
+          if git diff --name-only "$BEFORE" "${{ github.sha }}" \
+            | grep -qE '^(ios/|android/|capacitor\.config\.)'; then
+            TYPE=native
+            echo "Native path or Capacitor config changed — forcing native"
+          else
+            TYPE=$(npx @capgo/cli@latest bundle releaseType com.example.app --channel production | tr -d '[:space:]')
+          fi
           echo "type=$TYPE" >> "$GITHUB_OUTPUT"
           echo "Capgo release type: $TYPE"
 
@@ -131,7 +146,7 @@ jobs:
           CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          CAPGO_IOS_PROVISIONING_MAP_BASE64: ${{ secrets.CAPGO_IOS_PROVISIONING_MAP_BASE64 }}
+          CAPGO_IOS_PROVISIONING_MAP: ${{ secrets.CAPGO_IOS_PROVISIONING_MAP }}
           APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
           APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
           APPLE_KEY_CONTENT: ${{ secrets.APPLE_KEY_CONTENT }}
@@ -145,12 +160,33 @@ jobs:
           npx @capgo/cli@latest build request com.example.app \
             --platform ${{ matrix.platform }} \
             --build-mode release
+
+  native_bundle:
+    needs: [decide, native_build]
+    if: needs.decide.outputs.release_type == 'native'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - name: Upload bundle for new native baseline
+        env:
+          CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
+        run: |
+          # One-time: channel set production --disable-auto-update metadata
+          npx @capgo/cli@latest bundle upload com.example.app \
+            --channel production \
+            --auto-min-update-version
 ```
 
 Replace `com.example.app` and wire the signing secrets as described in [GitHub Actions for Capgo Build](/docs/builder/github-actions/).
 
 <Aside>
-`--fail-on-incompatible` on the OTA job is a second safety rail: if the verdict ever races with another deploy, the upload still fails closed instead of shipping an incompatible bundle.
+`--fail-on-incompatible` belongs on the OTA job only. After a native binary ships, upload the matching bundle with `--auto-min-update-version` so later `releaseType` checks see the new native packages.
 </Aside>
 
 ## GitLab CI
@@ -215,40 +251,36 @@ The same three steps work anywhere:
 | OTA path | `npx @capgo/cli@latest bundle upload APP_ID --channel production --fail-on-incompatible` |
 | Native path | `npx @capgo/cli@latest build request APP_ID --platform ios` (or `android`) `--build-mode release` |
 
-Map the shell exit / stdout into your platform's conditionals:
+Map the shell exit / stdout into your platform's conditionals (or keep a single job with a shell `if`, like GitLab above):
 
 - **Azure Pipelines** — set an output variable from a script step, then use `condition: eq(variables['releaseType'], 'OTA')`
-- **Bitbucket Pipelines** — write the verdict to a file artifact and branch with separate steps + `condition`
-- **CircleCI** — persist `RELEASE_TYPE` in a workspace and use `when` clauses
+- **Bitbucket Pipelines** — write `RELEASE_TYPE=…` to `$BITBUCKET_PIPELINES_VARIABLES_PATH`, declare it under `output-variables`, and branch later steps with `condition: state: RELEASE_TYPE == "OTA"` (file artifacts alone cannot drive `condition`)
+- **CircleCI** — `when` is evaluated at config-compile time, so branch with a runtime shell `if` (or dynamic config / continuation), not a workspace value in `when`
 - **Jenkins** — capture stdout into an env var and use `when { environment name: 'RELEASE_TYPE', value: 'OTA' }`
 
 ## Paths Filters (Optional Speedup)
 
-`releaseType` is authoritative, but you can skip the job entirely for docs-only commits:
+Path filters are a cost optimization, not a substitute for the Capgo check. Prefer excluding docs-only paths rather than maintaining a fragile allowlist — web builds often also depend on `vite.config.*`, `tsconfig*.json`, and framework config files:
 
 ```yaml
 on:
   push:
     branches: [main]
-    paths:
-      - 'src/**'
-      - 'public/**'
-      - 'android/**'
-      - 'ios/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'capacitor.config.*'
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/**'
 ```
 
-Still run `releaseType` for any commit that touches app code — path filters are a cost optimization, not a substitute for the Capgo check.
+If you use an allowlist instead, include every input your web and native builds read, not only `src/` and `package.json`.
 
 ## After a Native Verdict
 
 When CI chooses native:
 
 1. Capgo Build produces signed binaries and can submit to TestFlight / Play (see [configuration](/docs/builder/configuration/)).
-2. Once users install the new binary, later JavaScript-only commits return to `OTA` again.
-3. If you upload a bundle alongside the native release, use the [metadata strategy + `--auto-min-update-version`](/docs/live-updates/compatibility/#prevent-incompatible-deliveries) so older binaries never receive the incompatible bundle.
+2. Upload the matching JS bundle with `--auto-min-update-version` (metadata strategy) so the channel records the new native packages — otherwise the next JS-only commit still returns `native`.
+3. Once users install the new binary, later JavaScript-only commits return to `OTA` again.
 
 ## Related Guides
 

--- a/apps/docs/src/content/docs/docs/builder/ci-ota-or-native.mdx
+++ b/apps/docs/src/content/docs/docs/builder/ci-ota-or-native.mdx
@@ -1,0 +1,276 @@
+---
+title: Auto Choose Live Update or Native Build
+description: Set up CI/CD that detects whether a change can ship as a Capgo live update or needs a Capgo Build native binary, then runs the right path automatically.
+sidebar:
+  order: 9
+  label: Auto OTA or Native
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+import MermaidGraph from '@/components/MermaidGraph.astro';
+
+export const releaseDecisionGraph = `flowchart TD
+  A[Push / merge] --> B[Install + web build]
+  B --> C["bundle releaseType"]
+  C -->|OTA| D["bundle upload"]
+  C -->|native| E["build request iOS + Android"]
+  E --> F[Store / TestFlight / Play]
+`;
+
+Most Capacitor releases are JavaScript-only and should ship as a [live update](/docs/live-updates/). Some changes touch native code and need a new binary from [Capgo Build](/docs/builder/). This guide shows how to make GitHub Actions, GitLab CI, or any other CI/CD platform pick the correct path on every push — without a human deciding.
+
+## The Decision
+
+Capgo already knows which path is safe. After your web build (and before you upload or request a native build), run:
+
+```bash
+npx @capgo/cli@latest bundle releaseType com.example.app --channel production
+# → OTA      ship with bundle upload
+# → native   ship with Capgo Build
+```
+
+`OTA` means the native packages match what is already live on the channel. `native` means a plugin, Capacitor version, or other native dependency changed — an over-the-air bundle alone cannot update those devices safely.
+
+See [Native Compatibility](/docs/live-updates/compatibility/) for the full rules and the manual `bundle compatibility` table.
+
+<Aside type="tip">
+Gate every production pipeline on `releaseType`. It is cheaper than guessing, and it avoids shipping a live update that crashes devices still on the older native binary.
+</Aside>
+
+## Prerequisites
+
+- Capgo app registered and a [Capgo API key](/docs/webapp/api-keys/) in CI secrets as `CAPGO_TOKEN`
+- Live Updates upload working (`bundle upload`) — see [CI/CD Integration](/docs/getting-started/cicd-integration/)
+- Capgo Build credentials in CI if you expect native jobs — see [GitHub Actions](/docs/builder/github-actions/) or [Credentials](/docs/builder/credentials/)
+- A channel name that matches production (examples use `production`)
+
+## How the Pipeline Should Work
+
+<MermaidGraph graph={releaseDecisionGraph} ariaLabel="Flowchart of CI deciding between live update and Capgo Build" />
+
+1. Build web assets as usual.
+2. Ask Capgo whether this commit is OTA-safe.
+3. If `OTA`, upload the bundle.
+4. If `native`, run Capgo Build (and optionally still upload a bundle with `--fail-on-incompatible` / `--auto-min-update-version` once the binary is ready — see [Prevent incompatible deliveries](/docs/live-updates/compatibility/#prevent-incompatible-deliveries)).
+
+## GitHub Actions
+
+One workflow that branches on `releaseType`:
+
+```yaml
+# .github/workflows/capgo-release.yml
+name: Capgo Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  decide:
+    runs-on: ubuntu-latest
+    outputs:
+      release_type: ${{ steps.verdict.outputs.type }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Decide OTA vs native
+        id: verdict
+        env:
+          CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
+        run: |
+          TYPE=$(npx @capgo/cli@latest bundle releaseType com.example.app --channel production | tr -d '[:space:]')
+          echo "type=$TYPE" >> "$GITHUB_OUTPUT"
+          echo "Capgo release type: $TYPE"
+
+  live_update:
+    needs: decide
+    if: needs.decide.outputs.release_type == 'OTA'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - name: Upload live update
+        env:
+          CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
+        run: |
+          npx @capgo/cli@latest bundle upload com.example.app \
+            --channel production \
+            --fail-on-incompatible
+
+  native_build:
+    needs: decide
+    if: needs.decide.outputs.release_type == 'native'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ios, android]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - run: npx cap sync ${{ matrix.platform }}
+      - name: Capgo Build ${{ matrix.platform }}
+        env:
+          CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          CAPGO_IOS_PROVISIONING_MAP_BASE64: ${{ secrets.CAPGO_IOS_PROVISIONING_MAP_BASE64 }}
+          APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
+          APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
+          APPLE_KEY_CONTENT: ${{ secrets.APPLE_KEY_CONTENT }}
+          APP_STORE_CONNECT_TEAM_ID: ${{ secrets.APP_STORE_CONNECT_TEAM_ID }}
+          ANDROID_KEYSTORE_FILE: ${{ secrets.ANDROID_KEYSTORE_FILE }}
+          KEYSTORE_KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+          KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+          KEYSTORE_STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
+          PLAY_CONFIG_JSON: ${{ secrets.PLAY_CONFIG_JSON }}
+        run: |
+          npx @capgo/cli@latest build request com.example.app \
+            --platform ${{ matrix.platform }} \
+            --build-mode release
+```
+
+Replace `com.example.app` and wire the signing secrets as described in [GitHub Actions for Capgo Build](/docs/builder/github-actions/).
+
+<Aside>
+`--fail-on-incompatible` on the OTA job is a second safety rail: if the verdict ever races with another deploy, the upload still fails closed instead of shipping an incompatible bundle.
+</Aside>
+
+## GitLab CI
+
+GitLab evaluates `rules` when the pipeline is created, so branch with a shell `if` inside one deploy job (or generate a [dynamic child pipeline](https://docs.gitlab.com/ee/ci/pipelines/downstream_pipelines.html#dynamic-child-pipelines) if you need separate native matrix jobs):
+
+```yaml
+# .gitlab-ci.yml
+image: node:24
+
+stages:
+  - build
+  - deploy
+
+variables:
+  APP_ID: com.example.app
+  CHANNEL: production
+
+build_web:
+  stage: build
+  script:
+    - npm ci
+    - npm run build
+  artifacts:
+    paths:
+      - dist/
+      - node_modules/
+    expire_in: 1 hour
+  only:
+    - main
+
+deploy:
+  stage: deploy
+  needs: [build_web]
+  script:
+    - |
+      TYPE=$(npx @capgo/cli@latest bundle releaseType "$APP_ID" --channel "$CHANNEL" | tr -d '[:space:]')
+      echo "Capgo release type: $TYPE"
+      if [ "$TYPE" = "OTA" ]; then
+        npx @capgo/cli@latest bundle upload "$APP_ID"           --channel "$CHANNEL"           --fail-on-incompatible
+      elif [ "$TYPE" = "native" ]; then
+        npx cap sync
+        npx @capgo/cli@latest build request "$APP_ID" --platform ios --build-mode release
+        npx @capgo/cli@latest build request "$APP_ID" --platform android --build-mode release
+      else
+        echo "Unexpected release type: $TYPE" >&2
+        exit 1
+      fi
+  only:
+    - main
+```
+
+Store `CAPGO_TOKEN` and Capgo Build signing variables as masked/protected CI/CD variables.
+
+## Other CI Platforms
+
+The same three steps work anywhere:
+
+| Step | Command |
+|------|---------|
+| Verdict | `npx @capgo/cli@latest bundle releaseType APP_ID --channel production` |
+| OTA path | `npx @capgo/cli@latest bundle upload APP_ID --channel production --fail-on-incompatible` |
+| Native path | `npx @capgo/cli@latest build request APP_ID --platform ios` (or `android`) `--build-mode release` |
+
+Map the shell exit / stdout into your platform's conditionals:
+
+- **Azure Pipelines** — set an output variable from a script step, then use `condition: eq(variables['releaseType'], 'OTA')`
+- **Bitbucket Pipelines** — write the verdict to a file artifact and branch with separate steps + `condition`
+- **CircleCI** — persist `RELEASE_TYPE` in a workspace and use `when` clauses
+- **Jenkins** — capture stdout into an env var and use `when { environment name: 'RELEASE_TYPE', value: 'OTA' }`
+
+## Paths Filters (Optional Speedup)
+
+`releaseType` is authoritative, but you can skip the job entirely for docs-only commits:
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'android/**'
+      - 'ios/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'capacitor.config.*'
+```
+
+Still run `releaseType` for any commit that touches app code — path filters are a cost optimization, not a substitute for the Capgo check.
+
+## After a Native Verdict
+
+When CI chooses native:
+
+1. Capgo Build produces signed binaries and can submit to TestFlight / Play (see [configuration](/docs/builder/configuration/)).
+2. Once users install the new binary, later JavaScript-only commits return to `OTA` again.
+3. If you upload a bundle alongside the native release, use the [metadata strategy + `--auto-min-update-version`](/docs/live-updates/compatibility/#prevent-incompatible-deliveries) so older binaries never receive the incompatible bundle.
+
+## Related Guides
+
+<CardGrid>
+  <LinkCard
+    title="Native Compatibility"
+    description="Why Capgo returns OTA vs native and how to block bad uploads."
+    href="/docs/live-updates/compatibility/"
+  />
+  <LinkCard
+    title="GitHub Actions (Capgo Build)"
+    description="Signing secrets and full native build workflows."
+    href="/docs/builder/github-actions/"
+  />
+  <LinkCard
+    title="Trigger Builds from the CI UI"
+    description="Run a native build on demand from GitHub, GitLab, or Bitbucket."
+    href="/docs/builder/ci-ui-trigger/"
+  />
+  <LinkCard
+    title="Trigger Builds via Webhook"
+    description="Fire Capgo Build from an admin dashboard or any HTTP client."
+    href="/docs/builder/webhooks/"
+  />
+</CardGrid>

--- a/apps/docs/src/content/docs/docs/builder/ci-ota-or-native.mdx
+++ b/apps/docs/src/content/docs/docs/builder/ci-ota-or-native.mdx
@@ -92,12 +92,12 @@ jobs:
         run: |
           BEFORE="${{ github.event.before }}"
           if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-            BEFORE="$(git rev-parse HEAD~1)"
+            BEFORE="$(git rev-parse HEAD~1 2>/dev/null || echo '')"
           fi
-          if git diff --name-only "$BEFORE" "${{ github.sha }}" \
+          if [ -z "$BEFORE" ] || git diff --name-only "$BEFORE" "${{ github.sha }}" \
             | grep -qE '^(ios/|android/|capacitor\.config\.)'; then
             TYPE=native
-            echo "Native path or Capacitor config changed — forcing native"
+            echo "Native path/config changed (or no prior commit) — forcing native"
           else
             TYPE=$(npx @capgo/cli@latest bundle releaseType com.example.app --channel production | tr -d '[:space:]')
           fi

--- a/apps/docs/src/content/docs/docs/builder/ci-ui-trigger.mdx
+++ b/apps/docs/src/content/docs/docs/builder/ci-ui-trigger.mdx
@@ -17,7 +17,7 @@ Sometimes you need a signed iOS or Android binary without merging a PR or cuttin
     Click Run workflow / Run pipeline. Capgo Build compiles from the branch you pick.
   </Card>
   <Card title="Safe Inputs" icon="setting">
-    Platform, build mode, and channel stay as dropdowns — no secret editing mid-run.
+    Platform and build mode use constrained choices where the host supports them (GitHub / Bitbucket / Azure). GitLab variables remain editable per run unless you define [pipeline inputs](https://docs.gitlab.com/ee/ci/yaml/#specinputs) with `options`.
   </Card>
   <Card title="Same Secrets as CI" icon="approve-check">
     Reuse the Capgo Build credentials already in your repo. Nothing new on laptops.
@@ -63,6 +63,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.mode == 'release' && 'production' || 'build-debug' }}
     strategy:
       fail-fast: false
       matrix:
@@ -83,7 +84,7 @@ jobs:
           CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          CAPGO_IOS_PROVISIONING_MAP_BASE64: ${{ secrets.CAPGO_IOS_PROVISIONING_MAP_BASE64 }}
+          CAPGO_IOS_PROVISIONING_MAP: ${{ secrets.CAPGO_IOS_PROVISIONING_MAP }}
           APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
           APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
           APPLE_KEY_CONTENT: ${{ secrets.APPLE_KEY_CONTENT }}
@@ -117,7 +118,7 @@ jobs:
 
 </Steps>
 
-Anyone with write access can start a build. Restrict the workflow with [GitHub Environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) (for example require reviewers before `release` mode) if you need an approval gate.
+Anyone with **write** access can start a build. The sample maps `release` runs to a GitHub Environment named `production` — create that environment and add required reviewers so store builds wait for approval. Without `environment:` on the job, environment protection rules never apply.
 
 <Aside type="tip">
 Prefer the API or another tool to click the button? Use [`gh workflow run`](https://cli.github.com/manual/gh_workflow_run) or see [Trigger Builds via Webhook](/docs/builder/webhooks/) for `repository_dispatch`.
@@ -149,8 +150,12 @@ capgo_native_manual:
         --platform "$PLATFORM" \
         --build-mode "$BUILD_MODE"
   rules:
+    # Actions / Pipelines UI → manual play button
     - if: '$CI_PIPELINE_SOURCE == "web"'
       when: manual
+    # Pipeline trigger token / webhook → run automatically
+    - if: '$CI_PIPELINE_SOURCE == "trigger"'
+      when: on_success
     - when: never
 ```
 
@@ -202,7 +207,8 @@ Run it from **Pipelines → Run pipeline → Custom: capgo-native-build**. Store
 
 ```yaml
 # azure-pipelines-capgo-manual.yml
-trigger: none   # UI / manual only
+trigger: none   # disable CI push triggers
+pr: none        # also disable PR triggers (GitHub/Bitbucket-backed projects)
 
 parameters:
   - name: platform
@@ -239,7 +245,7 @@ steps:
       # map other signing secrets from Library → Variable groups
 ```
 
-`trigger: none` means the pipeline only starts from **Pipelines → Run pipeline** (or a webhook). Add `CAPGO_TOKEN` and signing values to a variable group marked secret.
+`trigger: none` and `pr: none` keep the pipeline off automatic CI/PR runs so it starts from **Pipelines → Run pipeline** (or a webhook). If the project uses Azure Repos branch policies that queue this pipeline, disable that policy separately. Add `CAPGO_TOKEN` and signing values to a variable group marked secret.
 
 ## Recommended Inputs
 
@@ -255,7 +261,7 @@ For downloadable QA artifacts, combine debug Android with `--no-playstore-upload
 
 - Prefer environment protection rules (GitHub) or protected variables (GitLab) for `release` builds that submit to stores.
 - Do not put signing passwords in workflow `inputs` — only in secrets/variables.
-- Limit who can run workflows with branch protections and team permissions on the repo.
+- Limit who can run workflows with repository roles and team permissions (write access is required on GitHub). Branch protection alone does not control **Run workflow**; add an in-workflow authorization check if only a narrower group may start builds.
 
 ## Related Guides
 

--- a/apps/docs/src/content/docs/docs/builder/ci-ui-trigger.mdx
+++ b/apps/docs/src/content/docs/docs/builder/ci-ui-trigger.mdx
@@ -1,0 +1,278 @@
+---
+title: Trigger Native Builds from the CI UI
+description: Run Capgo Build on demand from the GitHub Actions, GitLab, Bitbucket, or Azure DevOps UI — no git tag or push required.
+sidebar:
+  order: 10
+  label: Trigger from CI UI
+---
+
+import { Steps, Aside, Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
+
+Sometimes you need a signed iOS or Android binary without merging a PR or cutting a release tag — a QA build, a store resubmit, or a one-off TestFlight. Every major code host can start a pipeline from its web UI. This guide shows how to wire that UI to Capgo Build.
+
+## What You Get
+
+<CardGrid>
+  <Card title="No Git Ceremony" icon="rocket">
+    Click Run workflow / Run pipeline. Capgo Build compiles from the branch you pick.
+  </Card>
+  <Card title="Safe Inputs" icon="setting">
+    Platform, build mode, and channel stay as dropdowns — no secret editing mid-run.
+  </Card>
+  <Card title="Same Secrets as CI" icon="approve-check">
+    Reuse the Capgo Build credentials already in your repo. Nothing new on laptops.
+  </Card>
+</CardGrid>
+
+## Prerequisites
+
+- Capgo Build working once locally or in CI — see [Getting Started](/docs/builder/getting-started/)
+- Signing secrets already in the host (for GitHub, [export with the CLI and `gh secret set -f`](/docs/builder/github-actions/#setup))
+- `CAPGO_TOKEN` stored as a masked secret / CI variable
+
+## GitHub Actions
+
+GitHub's **Actions** tab can start any workflow that declares `workflow_dispatch`.
+
+### 1. Add the workflow
+
+```yaml
+# .github/workflows/capgo-build-manual.yml
+name: Capgo Build (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Platform to build
+        required: true
+        default: both
+        type: choice
+        options: [ios, android, both]
+      mode:
+        description: Build mode
+        required: true
+        default: debug
+        type: choice
+        options: [debug, release]
+      ref_note:
+        description: Optional note for the run summary
+        required: false
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJSON(inputs.platform == 'both' && '["ios","android"]' || format('["{0}"]', inputs.platform)) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build
+      - run: npx cap sync ${{ matrix.platform }}
+
+      - name: Capgo Build
+        env:
+          CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          CAPGO_IOS_PROVISIONING_MAP_BASE64: ${{ secrets.CAPGO_IOS_PROVISIONING_MAP_BASE64 }}
+          APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
+          APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
+          APPLE_KEY_CONTENT: ${{ secrets.APPLE_KEY_CONTENT }}
+          APP_STORE_CONNECT_TEAM_ID: ${{ secrets.APP_STORE_CONNECT_TEAM_ID }}
+          ANDROID_KEYSTORE_FILE: ${{ secrets.ANDROID_KEYSTORE_FILE }}
+          KEYSTORE_KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+          KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+          KEYSTORE_STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
+          PLAY_CONFIG_JSON: ${{ secrets.PLAY_CONFIG_JSON }}
+        run: |
+          EXTRA=""
+          if [ "${{ inputs.mode }}" = "debug" ] && [ "${{ matrix.platform }}" = "android" ]; then
+            EXTRA="--no-playstore-upload --output-upload"
+          fi
+          npx @capgo/cli@latest build request com.example.app \
+            --platform ${{ matrix.platform }} \
+            --build-mode ${{ inputs.mode }} \
+            $EXTRA
+```
+
+### 2. Run it from the UI
+
+<Steps>
+
+1. Open the GitHub repository in the browser
+2. Go to **Actions**
+3. Select **Capgo Build (Manual)**
+4. Click **Run workflow**
+5. Pick the branch, platform, and mode
+6. Confirm **Run workflow**
+
+</Steps>
+
+Anyone with write access can start a build. Restrict the workflow with [GitHub Environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) (for example require reviewers before `release` mode) if you need an approval gate.
+
+<Aside type="tip">
+Prefer the API or another tool to click the button? Use [`gh workflow run`](https://cli.github.com/manual/gh_workflow_run) or see [Trigger Builds via Webhook](/docs/builder/webhooks/) for `repository_dispatch`.
+</Aside>
+
+## GitLab CI
+
+GitLab can run a job from **Build → Pipelines → Run pipeline** when the job is available for that branch.
+
+```yaml
+# Job fragment for .gitlab-ci.yml
+stages:
+  - build
+
+variables:
+  APP_ID: com.example.app
+  PLATFORM: android   # override from Run pipeline UI
+  BUILD_MODE: debug
+
+capgo_native_manual:
+  stage: build
+  when: manual
+  script:
+    - npm ci
+    - npm run build
+    - npx cap sync "$PLATFORM"
+    - |
+      npx @capgo/cli@latest build request "$APP_ID" \
+        --platform "$PLATFORM" \
+        --build-mode "$BUILD_MODE"
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+      when: manual
+    - when: never
+```
+
+<Steps>
+
+1. Open the GitLab project
+2. Go to **Build → Pipelines → Run pipeline**
+3. Choose the branch
+4. Optionally set `PLATFORM` / `BUILD_MODE` variables for this run
+5. Start the pipeline, then click the play button on **capgo_native_manual**
+
+</Steps>
+
+`when: manual` keeps the job from firing on every push; the web UI (or a [pipeline trigger token](/docs/builder/webhooks/#gitlab-pipeline-trigger)) starts it on demand.
+
+## Bitbucket Pipelines
+
+Use a custom pipeline so the Bitbucket UI can pass variables:
+
+```yaml
+# bitbucket-pipelines.yml
+pipelines:
+  custom:
+    capgo-native-build:
+      - variables:
+          - name: PLATFORM
+            default: android
+            allowed-values:
+              - ios
+              - android
+          - name: BUILD_MODE
+            default: debug
+            allowed-values:
+              - debug
+              - release
+      - step:
+          name: Capgo Build
+          image: node:24
+          script:
+            - npm ci
+            - npm run build
+            - npx cap sync "$PLATFORM"
+            - npx @capgo/cli@latest build request com.example.app --platform "$PLATFORM" --build-mode "$BUILD_MODE"
+```
+
+Run it from **Pipelines → Run pipeline → Custom: capgo-native-build**. Store `CAPGO_TOKEN` and signing material under **Repository settings → Pipelines → Repository variables**.
+
+## Azure DevOps
+
+```yaml
+# azure-pipelines-capgo-manual.yml
+trigger: none   # UI / manual only
+
+parameters:
+  - name: platform
+    displayName: Platform
+    type: string
+    default: android
+    values:
+      - ios
+      - android
+  - name: buildMode
+    displayName: Build mode
+    type: string
+    default: debug
+    values:
+      - debug
+      - release
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '24.x'
+  - script: |
+      npm ci
+      npm run build
+      npx cap sync ${{ parameters.platform }}
+      npx @capgo/cli@latest build request com.example.app \
+        --platform ${{ parameters.platform }} \
+        --build-mode ${{ parameters.buildMode }}
+    env:
+      CAPGO_TOKEN: $(CAPGO_TOKEN)
+      # map other signing secrets from Library → Variable groups
+```
+
+`trigger: none` means the pipeline only starts from **Pipelines → Run pipeline** (or a webhook). Add `CAPGO_TOKEN` and signing values to a variable group marked secret.
+
+## Recommended Inputs
+
+| Input | Suggested values | Notes |
+|-------|------------------|-------|
+| Platform | `ios`, `android`, `both` | Matrix when `both` |
+| Mode | `debug`, `release` | Debug + `--output-upload` for QA links |
+| iOS distribution | `app_store`, `ad_hoc` | Ad-hoc never submits to App Store |
+
+For downloadable QA artifacts, combine debug Android with `--no-playstore-upload --output-upload` and read the URL with [`build last-output`](/docs/builder/github-actions/#read-the-build-output-url-and-qr-code).
+
+## Security Notes
+
+- Prefer environment protection rules (GitHub) or protected variables (GitLab) for `release` builds that submit to stores.
+- Do not put signing passwords in workflow `inputs` — only in secrets/variables.
+- Limit who can run workflows with branch protections and team permissions on the repo.
+
+## Related Guides
+
+<CardGrid>
+  <LinkCard
+    title="GitHub Actions (full setup)"
+    description="Export credentials and push/tag workflows."
+    href="/docs/builder/github-actions/"
+  />
+  <LinkCard
+    title="Auto OTA or Native"
+    description="Let CI choose live update vs Capgo Build on every push."
+    href="/docs/builder/ci-ota-or-native/"
+  />
+  <LinkCard
+    title="Trigger via Webhook"
+    description="Call the same pipelines from an admin dashboard over HTTP."
+    href="/docs/builder/webhooks/"
+  />
+</CardGrid>

--- a/apps/docs/src/content/docs/docs/builder/github-actions.mdx
+++ b/apps/docs/src/content/docs/docs/builder/github-actions.mdx
@@ -439,19 +439,24 @@ For platform-specific build failures, see the [Troubleshooting guide](/docs/buil
 
 <CardGrid>
   <LinkCard
+    title="Auto OTA or Native"
+    description="Branch CI between live update upload and Capgo Build."
+    href="/docs/builder/ci-ota-or-native/"
+  />
+  <LinkCard
+    title="Trigger from CI UI"
+    description="Run Capgo Build from the Actions tab on demand."
+    href="/docs/builder/ci-ui-trigger/"
+  />
+  <LinkCard
+    title="Build Webhooks"
+    description="Start the same workflow from an admin dashboard HTTP call."
+    href="/docs/builder/webhooks/"
+  />
+  <LinkCard
     title="Credentials Setup"
     description="Full reference for preparing iOS and Android credentials as base64 secrets."
     href="/docs/builder/credentials/"
-  />
-  <LinkCard
-    title="iOS Builds"
-    description="Deeper guide to certificates, profiles, and App Store submission."
-    href="/docs/builder/ios/"
-  />
-  <LinkCard
-    title="Android Builds"
-    description="Keystore setup, Play Store service accounts, and flavor handling."
-    href="/docs/builder/android/"
   />
   <LinkCard
     title="Configuration Options"

--- a/apps/docs/src/content/docs/docs/builder/index.mdx
+++ b/apps/docs/src/content/docs/docs/builder/index.mdx
@@ -139,13 +139,23 @@ Build time is the only cost:
     href="/docs/builder/credentials/"
   />
   <LinkCard 
-    title="iOS Builds" 
-    description="Complete guide to building and submitting iOS apps."
-    href="/docs/builder/ios/"
+    title="Auto OTA or Native" 
+    description="CI that picks live update vs Capgo Build automatically."
+    href="/docs/builder/ci-ota-or-native/"
   />
   <LinkCard 
-    title="Android Builds" 
-    description="Complete guide to building and submitting Android apps."
-    href="/docs/builder/android/"
+    title="Trigger from CI UI" 
+    description="Start a native build from GitHub, GitLab, Bitbucket, or Azure."
+    href="/docs/builder/ci-ui-trigger/"
+  />
+  <LinkCard 
+    title="Build Webhooks" 
+    description="Fire Capgo Build from an admin dashboard over HTTP."
+    href="/docs/builder/webhooks/"
+  />
+  <LinkCard 
+    title="GitHub Actions" 
+    description="Full Capgo Build CI setup with secrets and release workflows."
+    href="/docs/builder/github-actions/"
   />
 </CardGrid>

--- a/apps/docs/src/content/docs/docs/builder/webhooks.mdx
+++ b/apps/docs/src/content/docs/docs/builder/webhooks.mdx
@@ -1,0 +1,265 @@
+---
+title: Trigger Native Builds via Webhook
+description: Expose an HTTP webhook that starts a Capgo Build from your admin dashboard, CMS, or any system that can POST a URL.
+sidebar:
+  order: 11
+  label: Build Webhooks
+---
+
+import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
+import MermaidGraph from '@/components/MermaidGraph.astro';
+
+export const webhookBuildGraph = `sequenceDiagram
+  participant Admin as Admin dashboard
+  participant Hook as Webhook endpoint
+  participant CI as GitHub / GitLab
+  participant Capgo as Capgo Build
+
+  Admin->>Hook: POST /native-build (secret)
+  Hook->>CI: repository_dispatch / pipeline trigger
+  CI->>CI: checkout, npm ci, cap sync
+  CI->>Capgo: build request
+  Capgo-->>CI: signed binary / store upload
+`;
+
+Capgo Build is normally started from a laptop or CI job. Teams that ship from an **admin dashboard**, CMS, or internal portal often want a single **HTTP webhook**: press a button in their own UI, and a signed native build starts. This guide shows the standard pattern — a thin authenticated HTTP call into your code host, which runs the same Capgo Build workflow you already use.
+
+<Aside>
+Capgo organization webhooks (Dashboard → Organization → Webhooks) notify *your* URLs about Capgo events (bundles, channels, members). This page is the other direction: **your** system calls a URL to **start** a Capgo Build.
+</Aside>
+
+## Architecture
+
+<MermaidGraph graph={webhookBuildGraph} ariaLabel="Sequence diagram of admin webhook triggering Capgo Build through CI" />
+
+You do **not** need Capgo to expose a public “build webhook.” Your CI already has the signing secrets; the webhook's only job is to start that CI job safely.
+
+## Prerequisites
+
+- A Capgo Build workflow that already works from the [CI UI](/docs/builder/ci-ui-trigger/) or on push ([GitHub Actions](/docs/builder/github-actions/))
+- Permission to create a fine-grained GitHub token, GitLab trigger token, or equivalent
+- A shared secret your admin dashboard will send (header or body)
+
+## Option A — GitHub `repository_dispatch` (recommended)
+
+GitHub accepts an authenticated API call that starts a workflow listening for `repository_dispatch`. Any dashboard that can `POST` JSON can fire it.
+
+### 1. Workflow that listens for the webhook
+
+```yaml
+# .github/workflows/capgo-build-webhook.yml
+name: Capgo Build (Webhook)
+
+on:
+  repository_dispatch:
+    types: [capgo-native-build]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJSON(github.event.client_payload.platform == 'both' && '["ios","android"]' || format('["{0}"]', github.event.client_payload.platform || 'android')) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.ref || github.event.repository.default_branch }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build
+      - run: npx cap sync ${{ matrix.platform }}
+
+      - name: Capgo Build
+        env:
+          CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          CAPGO_IOS_PROVISIONING_MAP_BASE64: ${{ secrets.CAPGO_IOS_PROVISIONING_MAP_BASE64 }}
+          APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
+          APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
+          APPLE_KEY_CONTENT: ${{ secrets.APPLE_KEY_CONTENT }}
+          APP_STORE_CONNECT_TEAM_ID: ${{ secrets.APP_STORE_CONNECT_TEAM_ID }}
+          ANDROID_KEYSTORE_FILE: ${{ secrets.ANDROID_KEYSTORE_FILE }}
+          KEYSTORE_KEY_ALIAS: ${{ secrets.KEYSTORE_KEY_ALIAS }}
+          KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+          KEYSTORE_STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
+          PLAY_CONFIG_JSON: ${{ secrets.PLAY_CONFIG_JSON }}
+        run: |
+          MODE="${{ github.event.client_payload.mode || 'release' }}"
+          npx @capgo/cli@latest build request com.example.app \
+            --platform ${{ matrix.platform }} \
+            --build-mode "$MODE"
+```
+
+### 2. Create a GitHub token
+
+Create a fine-grained personal access token (or GitHub App installation token) with **Contents: Read and write** on the repository (required for `repository_dispatch`). Store it only in your admin backend — never in the browser.
+
+### 3. Call the webhook from your admin dashboard
+
+Your backend (not the end-user browser) should send:
+
+```bash
+curl -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/OWNER/REPO/dispatches \
+  -d '{
+    "event_type": "capgo-native-build",
+    "client_payload": {
+      "platform": "both",
+      "mode": "release",
+      "ref": "main",
+      "requested_by": "admin@example.com"
+    }
+  }'
+```
+
+| Field | Purpose |
+|-------|---------|
+| `event_type` | Must match `types` in the workflow (`capgo-native-build`) |
+| `client_payload.platform` | `ios`, `android`, or `both` |
+| `client_payload.mode` | `debug` or `release` |
+| `client_payload.ref` | Branch or tag to build (optional) |
+
+Wire the same JSON POST to a button in your admin UI ("Build native apps"). The dashboard only needs to reach **your** backend; the backend holds `GITHUB_TOKEN`.
+
+<Aside type="caution">
+Never embed the GitHub token in frontend JavaScript. The admin page should call your server; your server calls GitHub.
+</Aside>
+
+## Option B — Tiny proxy webhook (any host)
+
+If the admin tool can only POST to a URL you control (Zapier, Make, Cloudflare Worker, Express route), put a short proxy in front of GitHub:
+
+```js
+// Example Cloudflare Worker / Node handler (sketch)
+export default {
+  async fetch(request, env) {
+    if (request.method !== 'POST') {
+      return new Response('Method not allowed', { status: 405 })
+    }
+    if (request.headers.get('x-webhook-secret') !== env.WEBHOOK_SECRET) {
+      return new Response('Unauthorized', { status: 401 })
+    }
+    const body = await request.json().catch(() => ({}))
+    const res = await fetch(
+      `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/dispatches`,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        body: JSON.stringify({
+          event_type: 'capgo-native-build',
+          client_payload: {
+            platform: body.platform || 'both',
+            mode: body.mode || 'release',
+            ref: body.ref || 'main',
+          },
+        }),
+      },
+    )
+    return new Response(res.status === 204 ? 'Build queued' : await res.text(), {
+      status: res.status === 204 ? 200 : res.status,
+    })
+  },
+}
+```
+
+Then configure the admin product:
+
+| Setting | Value |
+|---------|-------|
+| URL | `https://your-worker.example.com/native-build` |
+| Method | `POST` |
+| Header | `x-webhook-secret: <shared secret>` |
+| Body | `{ "platform": "both", "mode": "release" }` |
+
+This is the usual shape for connecting a webhook to an on-admin dashboard: the dashboard stores one URL and one secret; Capgo credentials stay in GitHub Actions.
+
+## GitLab Pipeline Trigger
+
+GitLab exposes [pipeline trigger tokens](https://docs.gitlab.com/ee/ci/triggers/) that are natural webhook targets.
+
+```yaml
+# .gitlab-ci.yml fragment
+capgo_native_webhook:
+  stage: build
+  script:
+    - npm ci && npm run build
+    - npx cap sync "${PLATFORM:-android}"
+    - npx @capgo/cli@latest build request com.example.app --platform "${PLATFORM:-android}" --build-mode "${BUILD_MODE:-release}"
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "trigger"'
+```
+
+Create a trigger token under **Settings → CI/CD → Pipeline trigger tokens**, then from the admin backend:
+
+```bash
+curl -X POST \
+  -F token=$GITLAB_TRIGGER_TOKEN \
+  -F ref=main \
+  -F "variables[PLATFORM]=android" \
+  -F "variables[BUILD_MODE]=release" \
+  https://gitlab.com/api/v4/projects/PROJECT_ID/trigger/pipeline
+```
+
+For both platforms, either fire two triggers or expand the job into a parallel matrix the same way as the GitHub example.
+
+## Bitbucket and Azure
+
+| Platform | Webhook mechanism |
+|----------|-------------------|
+| **Bitbucket** | [Pipeline trigger URL](https://support.atlassian.com/bitbucket-cloud/docs/pipeline-triggers/) or custom pipeline + app password `POST` |
+| **Azure DevOps** | [Pipeline run REST API](https://learn.microsoft.com/en-us/rest/api/azure/devops/pipelines/runs/run-pipeline) with a PAT; use the manual pipeline from [Trigger from CI UI](/docs/builder/ci-ui-trigger/#azure-devops) |
+
+Pattern is identical: admin → your secret check → host API → Capgo Build job.
+
+## Payload Checklist for Admin Tools
+
+When the dashboard form is built, collect at least:
+
+- **Platform** — ios / android / both
+- **Mode** — debug (QA) or release (store)
+- **Git ref** — branch or tag to build
+- **Actor** — email or user id for audit logs (pass through `client_payload`)
+
+Optional: after the run, have CI post back to the admin API with the download URL from [`--output-record` / `build last-output`](/docs/builder/github-actions/#read-the-build-output-url-and-qr-code).
+
+## Security
+
+- Authenticate every webhook (`x-webhook-secret`, HMAC signature, or mTLS).
+- Keep GitHub/GitLab tokens server-side only.
+- Prefer tokens scoped to a single repository.
+- Rate-limit the proxy; native builds cost build minutes.
+- For store-submitting releases, require an extra confirmation flag in the payload and enforce it in the workflow (`if: github.event.client_payload.confirm_store == true`).
+
+## Related Guides
+
+<CardGrid>
+  <LinkCard
+    title="Trigger from CI UI"
+    description="Same Capgo Build job, started from the Actions / Pipelines tab."
+    href="/docs/builder/ci-ui-trigger/"
+  />
+  <LinkCard
+    title="GitHub Actions setup"
+    description="Credential export and secret names used by these workflows."
+    href="/docs/builder/github-actions/"
+  />
+  <LinkCard
+    title="Auto OTA or Native"
+    description="On git push, choose live update vs native automatically."
+    href="/docs/builder/ci-ota-or-native/"
+  />
+</CardGrid>

--- a/apps/docs/src/content/docs/docs/builder/webhooks.mdx
+++ b/apps/docs/src/content/docs/docs/builder/webhooks.mdx
@@ -46,6 +46,8 @@ GitHub accepts an authenticated API call that starts a workflow listening for `r
 
 ### 1. Workflow that listens for the webhook
 
+Validate the payload **before** checkout and before any secret-bearing step. Pass accepted values through job outputs / env vars — never interpolate `client_payload` directly into `run:` scripts ([script injection guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)).
+
 ```yaml
 # .github/workflows/capgo-build-webhook.yml
 name: Capgo Build (Webhook)
@@ -55,16 +57,59 @@ on:
     types: [capgo-native-build]
 
 jobs:
-  build:
+  validate:
     runs-on: ubuntu-latest
+    outputs:
+      platform: ${{ steps.check.outputs.platform }}
+      mode: ${{ steps.check.outputs.mode }}
+      ref: ${{ steps.check.outputs.ref }}
+      platforms_json: ${{ steps.check.outputs.platforms_json }}
+    steps:
+      - id: check
+        env:
+          RAW_PLATFORM: ${{ github.event.client_payload.platform }}
+          RAW_MODE: ${{ github.event.client_payload.mode }}
+          RAW_REF: ${{ github.event.client_payload.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          PLATFORM="${RAW_PLATFORM:-android}"
+          MODE="${RAW_MODE:-release}"
+          REF="${RAW_REF:-$DEFAULT_BRANCH}"
+          case "$PLATFORM" in ios|android|both) ;; *)
+            echo "Invalid platform: $PLATFORM" >&2; exit 1;;
+          esac
+          case "$MODE" in debug|release) ;; *)
+            echo "Invalid mode: $MODE" >&2; exit 1;;
+          esac
+          # Allowlist branches / tags / full SHAs only
+          if [[ ! "$REF" =~ ^(main|master|production|release/[A-Za-z0-9._-]+|[0-9a-f]{40})$ ]]; then
+            echo "Ref not allowlisted: $REF" >&2
+            exit 1
+          fi
+          if [ "$PLATFORM" = "both" ]; then
+            PLATFORMS_JSON='["ios","android"]'
+          else
+            PLATFORMS_JSON=$(printf '["%s"]' "$PLATFORM")
+          fi
+          {
+            echo "platform=$PLATFORM"
+            echo "mode=$MODE"
+            echo "ref=$REF"
+            echo "platforms_json=$PLATFORMS_JSON"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: ${{ needs.validate.outputs.mode == 'release' && 'production' || 'build-debug' }}
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ fromJSON(github.event.client_payload.platform == 'both' && '["ios","android"]' || format('["{0}"]', github.event.client_payload.platform || 'android')) }}
+        platform: ${{ fromJSON(needs.validate.outputs.platforms_json) }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.client_payload.ref || github.event.repository.default_branch }}
+          ref: ${{ needs.validate.outputs.ref }}
 
       - uses: actions/setup-node@v6
         with:
@@ -73,14 +118,17 @@ jobs:
 
       - run: npm ci
       - run: npm run build
-      - run: npx cap sync ${{ matrix.platform }}
+      - name: Sync native project
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: npx cap sync "$PLATFORM"
 
       - name: Capgo Build
         env:
           CAPGO_TOKEN: ${{ secrets.CAPGO_TOKEN }}
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          CAPGO_IOS_PROVISIONING_MAP_BASE64: ${{ secrets.CAPGO_IOS_PROVISIONING_MAP_BASE64 }}
+          CAPGO_IOS_PROVISIONING_MAP: ${{ secrets.CAPGO_IOS_PROVISIONING_MAP }}
           APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
           APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
           APPLE_KEY_CONTENT: ${{ secrets.APPLE_KEY_CONTENT }}
@@ -90,10 +138,11 @@ jobs:
           KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
           KEYSTORE_STORE_PASSWORD: ${{ secrets.KEYSTORE_STORE_PASSWORD }}
           PLAY_CONFIG_JSON: ${{ secrets.PLAY_CONFIG_JSON }}
+          PLATFORM: ${{ matrix.platform }}
+          MODE: ${{ needs.validate.outputs.mode }}
         run: |
-          MODE="${{ github.event.client_payload.mode || 'release' }}"
           npx @capgo/cli@latest build request com.example.app \
-            --platform ${{ matrix.platform }} \
+            --platform "$PLATFORM" \
             --build-mode "$MODE"
 ```
 
@@ -150,6 +199,18 @@ export default {
       return new Response('Unauthorized', { status: 401 })
     }
     const body = await request.json().catch(() => ({}))
+    const platform = body.platform || 'both'
+    const mode = body.mode || 'release'
+    const ref = body.ref || 'main'
+    if (!['ios', 'android', 'both'].includes(platform)) {
+      return new Response('Invalid platform', { status: 400 })
+    }
+    if (!['debug', 'release'].includes(mode)) {
+      return new Response('Invalid mode', { status: 400 })
+    }
+    if (!/^(main|master|production|release\/[A-Za-z0-9._-]+|[0-9a-f]{40})$/.test(ref)) {
+      return new Response('Ref not allowlisted', { status: 400 })
+    }
     const res = await fetch(
       `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/dispatches`,
       {
@@ -161,11 +222,7 @@ export default {
         },
         body: JSON.stringify({
           event_type: 'capgo-native-build',
-          client_payload: {
-            platform: body.platform || 'both',
-            mode: body.mode || 'release',
-            ref: body.ref || 'main',
-          },
+          client_payload: { platform, mode, ref },
         }),
       },
     )
@@ -239,10 +296,12 @@ Optional: after the run, have CI post back to the admin API with the download UR
 ## Security
 
 - Authenticate every webhook (`x-webhook-secret`, HMAC signature, or mTLS).
+- Allowlist `platform`, `mode`, and `ref` in both the proxy and the workflow `validate` job — treat `client_payload` as untrusted input.
+- Pass accepted values through env vars / job outputs; do not interpolate payload fields into `run:` scripts.
 - Keep GitHub/GitLab tokens server-side only.
 - Prefer tokens scoped to a single repository.
 - Rate-limit the proxy; native builds cost build minutes.
-- For store-submitting releases, require an extra confirmation flag in the payload and enforce it in the workflow (`if: github.event.client_payload.confirm_store == true`).
+- For store-submitting releases, map `release` to a protected GitHub Environment (as in the sample) or require an extra confirmation flag checked in `validate`.
 
 ## Related Guides
 

--- a/apps/docs/src/content/docs/docs/live-updates/compatibility.mdx
+++ b/apps/docs/src/content/docs/docs/live-updates/compatibility.mdx
@@ -143,6 +143,11 @@ See [Version Targeting](/docs/live-updates/version-targeting/) for the full set 
 ## Related
 
 <CardGrid>
+  <a href="/docs/builder/ci-ota-or-native/">
+    <Card title="Auto OTA or Native" icon="rocket">
+      Wire `bundle releaseType` into GitHub Actions or GitLab so CI picks live update vs Capgo Build.
+    </Card>
+  </a>
   <a href="/docs/live-updates/version-targeting/">
     <Card title="Version Targeting" icon="bars">
       Deliver only compatible bundles using channels, semver rules, and the metadata strategy.


### PR DESCRIPTION
## Summary
- Add three Capgo Builder guides: auto-choose live update vs native build in CI, trigger native builds from the code-host UI, and start builds via webhook from an admin dashboard
- Cross-link from Builder intro, GitHub Actions, and Native Compatibility
- Register Capgo Builder in docs `llmsCustomSets`

## Test plan
- [ ] Open `/docs/builder/ci-ota-or-native/`, `/docs/builder/ci-ui-trigger/`, `/docs/builder/webhooks/` in docs preview
- [ ] Confirm guides appear under Capgo Builder sidebar (orders 9–11)
- [ ] Spot-check YAML examples for GitHub Actions / GitLab / webhook `repository_dispatch`
- [ ] Verify LinkCards on `/docs/builder/` and `/docs/builder/github-actions/` resolve


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guides for automatically choosing between OTA live updates and native builds in CI/CD pipelines.
  * Introduced “Trigger from CI UI” instructions for running native builds on demand from popular CI web interfaces.
  * Added a “Build Webhooks” guide for starting native builds via authenticated HTTP webhooks.
  * Updated Builder navigation and related links to highlight the new guides.
  * Renamed the documentation entry from “Capgo CLI” to “Capgo Builder.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->