### PR TITLE
feat: add Affonso affiliate tracking

### DIFF
--- a/apps/web/src/components/Affonso.astro
+++ b/apps/web/src/components/Affonso.astro
@@ -1,0 +1,13 @@
+---
+// Affonso affiliate tracking pixel (proxied via aff.capgo.app)
+---
+
+<script
+  is:inline
+  async
+  defer
+  src="https://aff.capgo.app/js/pixel.min.js"
+  data-affonso="cmrf1otzw000iftgnev91n1xa"
+  data-cookie_duration="30"
+  data-api-base="https://aff.capgo.app/v1"
+></script>

--- a/apps/web/src/layouts/Layout.astro
+++ b/apps/web/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ import Header from '../components/Header.astro'
 import MetaPixel from '../components/MetaPixel.astro'
 import MetaPixelNoscript from '../components/MetaPixelNoscript.astro'
 import SEO from '../components/SEO.astro'
+import Affonso from '../components/Affonso.astro'
 import PostHog from '../components/posthog.astro'
 import WebMcpTools from '../components/WebMcpTools.astro'
 import globalStylesHref from '../css/global.css?url'
@@ -55,6 +56,7 @@ const enableThirdPartyScripts = !isLocalhost && !disableThirdPartyScripts
     <SEO {...content} />
     {enableThirdPartyScripts && <MetaPixel />}
     {enableThirdPartyScripts && <PostHog />}
+    {enableThirdPartyScripts && <Affonso />}
   </head>
   <body class="bg-gray-900 text-pretty text-white antialiased">
     {enableThirdPartyScripts && <MetaPixelNoscript />}

--- a/apps/web/src/pages/register.astro
+++ b/apps/web/src/pages/register.astro
@@ -281,6 +281,14 @@ const content = {
         last_name: lastName.value,
       })
     }
+    if ((window as any).Affonso?.signup) {
+      const fullName = `${firstName.value} ${lastName.value}`.trim()
+      ;(window as any).Affonso.signup({
+        email: email.value,
+        externalUserId: (user as any)?.user?.id,
+        name: fullName || undefined,
+      })
+    }
     const consoleUrl = `https://console.capgo.app/login/?access_token=${session.data.session?.access_token}&refresh_token=${session.data.session?.refresh_token}&to=/app`
     await new Promise((resolve) => setTimeout(resolve, 400))
     window.location.href = consoleUrl


### PR DESCRIPTION
## Summary
- Add Affonso tracking pixel in site layout `<head>`, loaded through the first-party proxy `aff.capgo.app`
- Track successful `/register` signups with `Affonso.signup()` (email, user id, name)
- Add **Affiliate program** footer link under Company → https://capgo.affonso.io

## Visual
![Affiliate program footer link](https://raw.githubusercontent.com/Cap-go/website/feat/affonso-affiliate-tracking/docs/pr-assets/affonso-footer-affiliate.webp)

## Proxy status (tracking 522)
`https://aff.capgo.app/js/pixel.min.js` currently returns **Cloudflare 522** (origin connection timed out). Landing code is correct; the Affonso proxy origin behind `aff.capgo.app` is down/unreachable. Tracking will start once that proxy is healthy.

## Test plan
- [ ] Confirm footer **Affiliate program** opens https://capgo.affonso.io
- [ ] Fix/deploy Affonso proxy so `https://aff.capgo.app/js/pixel.min.js` returns 200
- [ ] Visit with `?atp=test` and verify `affonso_referral` cookie
- [ ] Complete test signup and confirm LEAD in Affonso
- [ ] Confirm pixel absent on localhost / `disableThirdPartyScripts` pages