### PR TITLE
fix: use Affonso worker /r proxy paths

### DIFF
--- a/apps/web/src/components/Affonso.astro
+++ b/apps/web/src/components/Affonso.astro
@@ -1,13 +1,13 @@
 ---
-// Affonso affiliate tracking pixel (proxied via aff.capgo.app)
+// Affonso affiliate tracking pixel (proxied via aff.capgo.app/r)
 ---
 
 <script
   is:inline
   async
   defer
-  src="https://aff.capgo.app/js/pixel.min.js"
+  src="https://aff.capgo.app/r/pixel.js"
   data-affonso="cmrf1otzw000iftgnev91n1xa"
   data-cookie_duration="30"
-  data-api-base="https://aff.capgo.app/v1"
+  data-api-base="https://aff.capgo.app/r"
 ></script>


### PR DESCRIPTION
## Summary
- Point the Affonso pixel at the real `aff.capgo.app` worker routes:
  - `src=https://aff.capgo.app/r/pixel.js`
  - `data-api-base=https://aff.capgo.app/r` (pixel calls `/track` + `/signups`)

## Why
The worker only maps `/r/*`. Old landing URLs (`/js/pixel.min.js`, `/v1/*`) miss the map, fall through to `fetch(request)`, and return Cloudflare **522**.

Verified live:
- `https://aff.capgo.app/r/pixel.js` → **200**
- `https://aff.capgo.app/js/pixel.min.js` → **522**

## Test plan
- [ ] Network tab shows `aff.capgo.app/r/pixel.js` 200 on production after deploy
- [ ] Affiliate visit with `?atp=test` sets cookie / hits `/r/track`
- [ ] Signup still calls Affonso via `/r/signups`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated affiliate tracking configuration to use the correct proxied endpoint.
  * Improved tracking reliability and compatibility with the proxy path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->