### PR TITLE
feat: add Android and iOS version distribution chart pages

### DIFF
--- a/.github/workflows/scrape-distribution-charts.yml
+++ b/.github/workflows/scrape-distribution-charts.yml
@@ -5,8 +5,9 @@ on:
     - cron: '0 7 * * *'
   workflow_dispatch:
 
-permissions:
-  contents: write
+concurrency:
+  group: scrape-distribution-charts
+  cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -16,8 +17,14 @@ jobs:
     name: Scrape Android and iOS distribution data
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # contents: write required so git-auto-commit can push updated JSON when data changes.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          # Needed by git-auto-commit-action to push commits.
+          persist-credentials: true
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
@@ -31,6 +38,7 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
+      # --ignore-scripts: avoid running dependency lifecycle scripts during CI install.
       - run: bun install --frozen-lockfile --ignore-scripts
       - run: bun run scrape:distribution-charts
       - name: Commit changes if data differs

--- a/.github/workflows/scrape-distribution-charts.yml
+++ b/.github/workflows/scrape-distribution-charts.yml
@@ -1,0 +1,40 @@
+name: Scrape distribution charts
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  scrape:
+    name: Scrape Android and iOS distribution data
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.14
+      - name: Cache bun modules
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+      - run: bun install --frozen-lockfile
+      - run: bun run scrape:distribution-charts
+      - name: Commit changes if data differs
+        uses: stefanzweifel/git-auto-commit-action@8621497c0c1376e06561dd4e2e3ebae1941d66ea
+        with:
+          commit_message: 'chore: update Android and iOS distribution data [skip ci]'
+          file_pattern: 'apps/web/src/data/android-distribution.json apps/web/src/data/ios-distribution.json'

--- a/.github/workflows/scrape-distribution-charts.yml
+++ b/.github/workflows/scrape-distribution-charts.yml
@@ -18,23 +18,23 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: 1.3.14
       - name: Cache bun modules
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
-      - run: bun install --frozen-lockfile
+      - run: bun install --frozen-lockfile --ignore-scripts
       - run: bun run scrape:distribution-charts
       - name: Commit changes if data differs
         uses: stefanzweifel/git-auto-commit-action@8621497c0c1376e06561dd4e2e3ebae1941d66ea
         with:
-          commit_message: 'chore: update Android and iOS distribution data [skip ci]'
+          commit_message: 'chore: update Android and iOS distribution data'
           file_pattern: 'apps/web/src/data/android-distribution.json apps/web/src/data/ios-distribution.json'

--- a/apps/web/src/components/DistributionRefreshPanel.astro
+++ b/apps/web/src/components/DistributionRefreshPanel.astro
@@ -1,0 +1,46 @@
+---
+import { getRelativeLocaleUrl } from '@/services/links'
+
+interface Props {
+  accent: 'green' | 'blue'
+  companionHref: string
+  companionLabel: string
+  class?: string
+}
+
+const { accent, companionHref, companionLabel, class: className = '' } = Astro.props
+const locale = Astro.locals.locale
+
+const primaryClass =
+  accent === 'green'
+    ? 'bg-green-400 text-neutral-950 hover:bg-green-300 focus-visible:outline-green-300'
+    : 'bg-blue-400 text-neutral-950 hover:bg-blue-300 focus-visible:outline-blue-300'
+---
+
+<section class:list={['bg-slate-950 py-16 sm:py-20', className]}>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <div class="border-t border-white/10 pt-10">
+      <h2 class="max-w-[35ch] text-2xl font-semibold tracking-tight text-balance text-white sm:text-3xl">How this data is kept current</h2>
+      <p class="mt-4 max-w-[56ch] text-base text-pretty text-slate-300 sm:text-sm/6">
+        A daily job fetches the latest numbers from the sources above. If the figures changed, the JSON files are committed automatically; if not, the repo stays untouched. The
+        pages read these files at build time, so the charts stay in sync with the latest published data.
+      </p>
+      <div class="mt-6 flex flex-col gap-3 sm:flex-row">
+        <a
+          href={getRelativeLocaleUrl(locale, companionHref)}
+          class:list={['inline-flex items-center justify-center rounded-xl px-4 py-3 text-sm font-semibold focus-visible:outline-2 focus-visible:outline-offset-2', primaryClass]}
+        >
+          {companionLabel}
+        </a>
+        <a
+          href="https://github.com/Cap-go/website/tree/main/apps/web/src/data"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center justify-center rounded-xl border border-white/15 px-4 py-3 text-sm font-semibold text-white hover:border-white/30 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        >
+          View raw data
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/apps/web/src/components/DistributionTargetChart.astro
+++ b/apps/web/src/components/DistributionTargetChart.astro
@@ -1,0 +1,213 @@
+---
+export interface TargetRow {
+  id: string
+  label: string
+  detail?: string
+  reach: number
+}
+
+interface Props {
+  platform: 'android' | 'ios'
+  rows: TargetRow[]
+  versionLabel: string
+  targetNoun: string
+  class?: string
+}
+
+const { platform, rows, versionLabel, targetNoun, class: className = '' } = Astro.props
+const sorted = [...rows].sort((a, b) => b.reach - a.reach)
+const defaultTarget = 95
+const defaultRow = [...sorted].filter((row) => row.reach >= defaultTarget).sort((a, b) => a.reach - b.reach)[0] ?? sorted[0]
+const barFrom = platform === 'android' ? 'from-green-400' : 'from-blue-400'
+const barTo = platform === 'android' ? 'to-blue-500' : 'to-cyan-400'
+const ring = platform === 'android' ? 'focus-visible:outline-green-300' : 'focus-visible:outline-blue-300'
+const accentText = platform === 'android' ? 'text-green-300' : 'text-blue-300'
+const rootId = `${platform}-target-chart`
+---
+
+<section
+  id={rootId}
+  class:list={['border-b border-white/10 bg-slate-950 py-16 sm:py-20', className]}
+  data-platform={platform}
+  data-rows={JSON.stringify(sorted)}
+  data-default-id={defaultRow?.id ?? ''}
+  data-default-target={String(defaultTarget)}
+  data-target-noun={targetNoun}
+>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <p class:list={['font-mono text-sm font-semibold tracking-wide uppercase', accentText]}>Choose your minimum</p>
+    <h2 class="mt-3 max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">
+      What {targetNoun} covers your users?
+    </h2>
+    <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">
+      Pick a minimum {versionLabel}, or set the user coverage you need. The chart answers: if this is your floor, what share of devices can install your app.
+    </p>
+
+    <div class="mt-8 grid gap-4 sm:grid-cols-2">
+      <div class="flex flex-col gap-2">
+        <label for={`${rootId}-version`} class="text-base font-medium text-white sm:text-sm">Minimum {versionLabel}</label>
+        <div class="inline-grid grid-cols-[1fr_--spacing(8)]">
+          <select
+            id={`${rootId}-version`}
+            name="minimumVersion"
+            class:list={[
+              'col-span-full row-start-1 w-full appearance-none rounded-xl border-0 bg-white/5 py-3 pr-8 pl-4 text-base text-white ring-1 ring-white/15 sm:text-sm',
+              ring,
+              'focus-visible:outline-2 focus-visible:-outline-offset-1',
+            ]}
+          >
+            {
+              sorted.map((row) => (
+                <option value={row.id} selected={row.id === defaultRow?.id}>
+                  {row.label} — {row.reach.toFixed(row.reach % 1 === 0 ? 0 : 1)}%
+                </option>
+              ))
+            }
+          </select>
+          <svg viewBox="0 0 8 5" width="8" height="5" fill="none" class="pointer-events-none col-start-2 row-start-1 place-self-center text-slate-300" aria-hidden="true">
+            <path d="M.5.5 4 4 7.5.5" stroke="currentcolor"></path>
+          </svg>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <label for={`${rootId}-percent`} class="text-base font-medium text-white sm:text-sm">
+          Target coverage
+          <span id={`${rootId}-percent-value`} class="ml-2 font-mono text-slate-300 tabular-nums">{defaultTarget}%</span>
+        </label>
+        <input
+          id={`${rootId}-percent`}
+          name="targetCoverage"
+          type="range"
+          min="50"
+          max="99"
+          step="1"
+          value={String(defaultTarget)}
+          class:list={['w-full accent-current', accentText]}
+          aria-valuemin={50}
+          aria-valuemax={99}
+          aria-valuenow={defaultTarget}
+        />
+        <p class="text-base text-slate-400 sm:text-sm">
+          Finds the newest {versionLabel} that still reaches at least this many users.
+        </p>
+      </div>
+    </div>
+
+    <div id={`${rootId}-result`} class="mt-8 rounded-2xl border border-white/10 bg-white/5 px-5 py-4" aria-live="polite">
+      <p id={`${rootId}-result-text`} class="text-base text-pretty text-slate-200 sm:text-sm">Loading target…</p>
+    </div>
+
+    <div class="mt-10 divide-y divide-white/10 border-y border-white/10" role="list" id={`${rootId}-list`}>
+      {
+        sorted.map((row) => (
+          <button
+            type="button"
+            role="listitem"
+            data-row-id={row.id}
+            data-reach={String(row.reach)}
+            class:list={[
+              'grid w-full items-center gap-4 py-4 text-left sm:grid-cols-[minmax(10rem,220px)_1fr_5rem]',
+              'focus-visible:outline-2 focus-visible:outline-offset-2',
+              ring,
+            ]}
+          >
+            <div class="min-w-0">
+              <p class="font-medium text-white">{row.label}</p>
+              {row.detail && <p class="mt-1 text-base text-slate-400 sm:text-sm">{row.detail}</p>}
+            </div>
+            <div class="h-3 w-full overflow-hidden rounded-full bg-white/10" aria-hidden="true">
+              <div class:list={['h-full w-(--bar-width) rounded-full bg-linear-to-r', barFrom, barTo]} style={`--bar-width: ${Math.min(100, row.reach)}%`} />
+            </div>
+            <p class="text-right font-mono text-base font-semibold text-white tabular-nums sm:text-sm">{row.reach.toFixed(row.reach % 1 === 0 ? 0 : 1)}%</p>
+          </button>
+        ))
+      }
+    </div>
+  </div>
+</section>
+
+<script>
+  function formatPercent(value: number) {
+    return `${value.toFixed(value < 1 ? 1 : value % 1 === 0 ? 0 : 1).replace(/\.0$/, '')}%`
+  }
+
+  function initTargetChart(root: HTMLElement) {
+    type Row = { id: string; label: string; detail?: string; reach: number }
+    const rows = JSON.parse(root.dataset.rows || '[]') as Row[]
+    const versionSelect = root.querySelector<HTMLSelectElement>('select[name="minimumVersion"]')
+    const percentInput = root.querySelector<HTMLInputElement>('input[name="targetCoverage"]')
+    const percentValue = root.querySelector<HTMLElement>('[id$="-percent-value"]')
+    const resultText = root.querySelector<HTMLElement>('[id$="-result-text"]')
+    const targetNoun = root.dataset.targetNoun || 'target'
+    if (!versionSelect || !percentInput || !resultText) return
+
+    let syncing = false
+
+    const rowById = new Map(rows.map((row) => [row.id, row]))
+
+    function newestMeeting(target: number): Row | undefined {
+      return rows.filter((row) => row.reach >= target).sort((a, b) => a.reach - b.reach)[0]
+    }
+
+    function paintSelection(id: string) {
+      root.querySelectorAll<HTMLElement>('[data-row-id]').forEach((el) => {
+        const active = el.dataset.rowId === id
+        el.classList.toggle('bg-white/5', active)
+        el.setAttribute('aria-pressed', active ? 'true' : 'false')
+      })
+    }
+
+    function renderFromVersion(id: string) {
+      const row = rowById.get(id)
+      if (!row) return
+      paintSelection(id)
+      resultText!.textContent = `If you set ${row.label} as your minimum ${targetNoun}, you cover about ${formatPercent(row.reach)} of active devices.`
+    }
+
+    function renderFromPercent(target: number) {
+      percentValue && (percentValue.textContent = `${target}%`)
+      percentInput!.setAttribute('aria-valuenow', String(target))
+      const row = newestMeeting(target)
+      if (!row) {
+        resultText!.textContent = `No ${targetNoun} in this dataset reaches ${target}%. Lower the coverage target.`
+        return
+      }
+      syncing = true
+      versionSelect!.value = row.id
+      syncing = false
+      paintSelection(row.id)
+      resultText!.textContent = `To cover at least ${target}% of users, set your minimum ${targetNoun} to ${row.label} (${formatPercent(row.reach)} covered).`
+    }
+
+    versionSelect.addEventListener('change', () => {
+      if (syncing) return
+      renderFromVersion(versionSelect.value)
+    })
+
+    percentInput.addEventListener('input', () => {
+      renderFromPercent(Number(percentInput.value))
+    })
+
+    root.querySelectorAll<HTMLButtonElement>('[data-row-id]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const id = button.dataset.rowId
+        if (!id) return
+        syncing = true
+        versionSelect.value = id
+        syncing = false
+        renderFromVersion(id)
+      })
+    })
+
+    const initialId = root.dataset.defaultId || versionSelect.value
+    const initialTarget = Number(root.dataset.defaultTarget || percentInput.value)
+    percentInput.value = String(initialTarget)
+    renderFromPercent(initialTarget)
+    if (initialId && versionSelect.value !== initialId) {
+      // keep percent-driven default; already applied
+    }
+  }
+
+  document.querySelectorAll<HTMLElement>('[data-rows]').forEach(initTargetChart)
+</script>

--- a/apps/web/src/components/DistributionTargetChart.astro
+++ b/apps/web/src/components/DistributionTargetChart.astro
@@ -1,4 +1,6 @@
 ---
+import { formatPercent } from '@/lib/formatPercent'
+
 export interface TargetRow {
   id: string
   label: string
@@ -59,7 +61,7 @@ const rootId = `${platform}-target-chart`
             {
               sorted.map((row) => (
                 <option value={row.id} selected={row.id === defaultRow?.id}>
-                  {row.label} — {row.reach.toFixed(row.reach % 1 === 0 ? 0 : 1)}%
+                  {row.label} — {formatPercent(row.reach)}
                 </option>
               ))
             }
@@ -98,39 +100,38 @@ const rootId = `${platform}-target-chart`
       <p id={`${rootId}-result-text`} class="text-base text-pretty text-slate-200 sm:text-sm">Loading target…</p>
     </div>
 
-    <div class="mt-10 divide-y divide-white/10 border-y border-white/10" role="list" id={`${rootId}-list`}>
+    <ul class="mt-10 divide-y divide-white/10 border-y border-white/10" role="list">
       {
         sorted.map((row) => (
-          <button
-            type="button"
-            role="listitem"
-            data-row-id={row.id}
-            data-reach={String(row.reach)}
-            class:list={[
-              'grid w-full items-center gap-4 py-4 text-left sm:grid-cols-[minmax(10rem,220px)_1fr_5rem]',
-              'focus-visible:outline-2 focus-visible:outline-offset-2',
-              ring,
-            ]}
-          >
-            <div class="min-w-0">
-              <p class="font-medium text-white">{row.label}</p>
-              {row.detail && <p class="mt-1 text-base text-slate-400 sm:text-sm">{row.detail}</p>}
-            </div>
-            <div class="h-3 w-full overflow-hidden rounded-full bg-white/10" aria-hidden="true">
-              <div class:list={['h-full w-(--bar-width) rounded-full bg-linear-to-r', barFrom, barTo]} style={`--bar-width: ${Math.min(100, row.reach)}%`} />
-            </div>
-            <p class="text-right font-mono text-base font-semibold text-white tabular-nums sm:text-sm">{row.reach.toFixed(row.reach % 1 === 0 ? 0 : 1)}%</p>
-          </button>
+          <li>
+            <button
+              type="button"
+              data-row-id={row.id}
+              data-reach={String(row.reach)}
+              class:list={[
+                'grid w-full items-center gap-4 py-4 text-left sm:grid-cols-[minmax(10rem,220px)_1fr_5rem]',
+                'focus-visible:outline-2 focus-visible:outline-offset-2',
+                ring,
+              ]}
+            >
+              <div class="min-w-0">
+                <p class="font-medium text-white">{row.label}</p>
+                {row.detail && <p class="mt-1 text-base text-slate-400 sm:text-sm">{row.detail}</p>}
+              </div>
+              <div class="h-3 w-full overflow-hidden rounded-full bg-white/10" aria-hidden="true">
+                <div class:list={['h-full w-(--bar-width) rounded-full bg-linear-to-r', barFrom, barTo]} style={`--bar-width: ${Math.min(100, row.reach)}%`} />
+              </div>
+              <p class="text-right font-mono text-base font-semibold text-white tabular-nums sm:text-sm">{formatPercent(row.reach)}</p>
+            </button>
+          </li>
         ))
       }
-    </div>
+    </ul>
   </div>
 </section>
 
 <script>
-  function formatPercent(value: number) {
-    return `${value.toFixed(value < 1 ? 1 : value % 1 === 0 ? 0 : 1).replace(/\.0$/, '')}%`
-  }
+  import { formatPercent } from '../lib/formatPercent'
 
   function initTargetChart(root: HTMLElement) {
     type Row = { id: string; label: string; detail?: string; reach: number }
@@ -143,7 +144,6 @@ const rootId = `${platform}-target-chart`
     if (!versionSelect || !percentInput || !resultText) return
 
     let syncing = false
-
     const rowById = new Map(rows.map((row) => [row.id, row]))
 
     function newestMeeting(target: number): Row | undefined {
@@ -166,7 +166,7 @@ const rootId = `${platform}-target-chart`
     }
 
     function renderFromPercent(target: number) {
-      percentValue && (percentValue.textContent = `${target}%`)
+      if (percentValue) percentValue.textContent = `${target}%`
       percentInput!.setAttribute('aria-valuenow', String(target))
       const row = newestMeeting(target)
       if (!row) {
@@ -200,13 +200,9 @@ const rootId = `${platform}-target-chart`
       })
     })
 
-    const initialId = root.dataset.defaultId || versionSelect.value
     const initialTarget = Number(root.dataset.defaultTarget || percentInput.value)
     percentInput.value = String(initialTarget)
     renderFromPercent(initialTarget)
-    if (initialId && versionSelect.value !== initialId) {
-      // keep percent-driven default; already applied
-    }
   }
 
   document.querySelectorAll<HTMLElement>('[data-rows]').forEach(initTargetChart)

--- a/apps/web/src/components/DistributionTargetChart.astro
+++ b/apps/web/src/components/DistributionTargetChart.astro
@@ -73,25 +73,44 @@ const rootId = `${platform}-target-chart`
       </div>
 
       <div class="flex flex-col gap-2">
-        <label for={`${rootId}-percent`} class="text-base font-medium text-white sm:text-sm">
-          Target coverage
-          <span id={`${rootId}-percent-value`} class="ml-2 font-mono text-slate-300 tabular-nums">{defaultTarget}%</span>
-        </label>
+        <div class="flex items-end justify-between gap-3">
+          <label for={`${rootId}-percent`} class="text-base font-medium text-white sm:text-sm">Target coverage</label>
+          <div class="flex items-center gap-1">
+            <input
+              id={`${rootId}-percent-number`}
+              name="targetCoverageNumber"
+              type="number"
+              min="50"
+              max="99.9"
+              step="0.1"
+              value={String(defaultTarget)}
+              inputmode="decimal"
+              aria-label="Target coverage percent"
+              class:list={[
+                'w-20 rounded-lg border-0 bg-white/5 px-2 py-1.5 text-right font-mono text-base text-white tabular-nums ring-1 ring-white/15 sm:text-sm',
+                ring,
+                'focus-visible:outline-2 focus-visible:-outline-offset-1',
+              ]}
+            />
+            <span class="text-base text-slate-400 sm:text-sm" aria-hidden="true">%</span>
+          </div>
+        </div>
         <input
           id={`${rootId}-percent`}
           name="targetCoverage"
           type="range"
           min="50"
-          max="99"
-          step="1"
+          max="99.9"
+          step="0.1"
           value={String(defaultTarget)}
           class:list={['w-full accent-current', accentText]}
           aria-valuemin={50}
-          aria-valuemax={99}
+          aria-valuemax={99.9}
           aria-valuenow={defaultTarget}
+          aria-label="Target coverage slider"
         />
         <p class="text-base text-slate-400 sm:text-sm">
-          Finds the newest {versionLabel} that still reaches at least this many users.
+          Finds the newest {versionLabel} that still reaches at least this many users. Use tenths for targets like 99.5% or 99.9%.
         </p>
       </div>
     </div>
@@ -138,7 +157,6 @@ const rootId = `${platform}-target-chart`
     const rows = JSON.parse(root.dataset.rows || '[]') as Row[]
     const versionSelect = root.querySelector<HTMLSelectElement>('select[name="minimumVersion"]')
     const percentInput = root.querySelector<HTMLInputElement>('input[name="targetCoverage"]')
-    const percentValue = root.querySelector<HTMLElement>('[id$="-percent-value"]')
     const resultText = root.querySelector<HTMLElement>('[id$="-result-text"]')
     const targetNoun = root.dataset.targetNoun || 'target'
     if (!versionSelect || !percentInput || !resultText) return
@@ -165,19 +183,38 @@ const rootId = `${platform}-target-chart`
       resultText!.textContent = `If you set ${row.label} as your minimum ${targetNoun}, you cover about ${formatPercent(row.reach)} of active devices.`
     }
 
-    function renderFromPercent(target: number) {
-      if (percentValue) percentValue.textContent = `${target}%`
+    const percentNumber = root.querySelector<HTMLInputElement>('input[name="targetCoverageNumber"]')
+    const minTarget = 50
+    const maxTarget = 99.9
+
+    function clampTarget(value: number) {
+      if (!Number.isFinite(value)) return defaultTargetFallback()
+      return Math.min(maxTarget, Math.max(minTarget, Math.round(value * 10) / 10))
+    }
+
+    function defaultTargetFallback() {
+      return Number(root.dataset.defaultTarget || 95)
+    }
+
+    function formatTarget(value: number) {
+      return Number.isInteger(value) ? String(value) : value.toFixed(1)
+    }
+
+    function renderFromPercent(rawTarget: number) {
+      const target = clampTarget(rawTarget)
+      percentInput!.value = String(target)
+      if (percentNumber) percentNumber.value = formatTarget(target)
       percentInput!.setAttribute('aria-valuenow', String(target))
       const row = newestMeeting(target)
       if (!row) {
-        resultText!.textContent = `No ${targetNoun} in this dataset reaches ${target}%. Lower the coverage target.`
+        resultText!.textContent = `No ${targetNoun} in this dataset reaches ${formatTarget(target)}%. Lower the coverage target.`
         return
       }
       syncing = true
       versionSelect!.value = row.id
       syncing = false
       paintSelection(row.id)
-      resultText!.textContent = `To cover at least ${target}% of users, set your minimum ${targetNoun} to ${row.label} (${formatPercent(row.reach)} covered).`
+      resultText!.textContent = `To cover at least ${formatTarget(target)}% of users, set your minimum ${targetNoun} to ${row.label} (${formatPercent(row.reach)} covered).`
     }
 
     versionSelect.addEventListener('change', () => {
@@ -187,6 +224,14 @@ const rootId = `${platform}-target-chart`
 
     percentInput.addEventListener('input', () => {
       renderFromPercent(Number(percentInput.value))
+    })
+
+    percentNumber?.addEventListener('input', () => {
+      renderFromPercent(Number(percentNumber.value))
+    })
+
+    percentNumber?.addEventListener('change', () => {
+      renderFromPercent(Number(percentNumber.value))
     })
 
     root.querySelectorAll<HTMLButtonElement>('[data-row-id]').forEach((button) => {

--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -49,6 +49,8 @@ const navigation: Record<string, NavigationItem[]> = {
   products: [
     { name: m.live_update({}, { locale: Astro.locals.locale }), href: getRelativeLocaleUrl(Astro.locals.locale, 'live-update') },
     { name: 'Live Update data', href: getRelativeLocaleUrl(Astro.locals.locale, 'data') },
+    { name: 'Android distribution chart', href: getRelativeLocaleUrl(Astro.locals.locale, 'android-distribution-chart') },
+    { name: 'iOS distribution chart', href: getRelativeLocaleUrl(Astro.locals.locale, 'ios-distribution-chart') },
     { name: 'Notifications', href: getRelativeLocaleUrl(Astro.locals.locale, 'notifications') },
     { name: 'Observe', href: getRelativeLocaleUrl(Astro.locals.locale, 'observe') },
     { name: m.native_build({}, { locale: Astro.locals.locale }), href: getRelativeLocaleUrl(Astro.locals.locale, 'native-build') },

--- a/apps/web/src/data/android-distribution.json
+++ b/apps/web/src/data/android-distribution.json
@@ -1,0 +1,160 @@
+{
+  "updatedAt": "2025-11-30T22:00:00.000Z",
+  "source": "Composables Android Distribution Chart",
+  "sourceUrl": "https://composables.com/android-distribution-chart",
+  "fetchedAt": "2026-07-28T17:30:25.635Z",
+  "apiDistribution": [
+    {
+      "version": "Android 5 (Lollipop)",
+      "api": 21,
+      "distribution": 0.1
+    },
+    {
+      "version": "Android 5.1 (Lollipop)",
+      "api": 22,
+      "distribution": 0.3
+    },
+    {
+      "version": "Android 6 (Marshmallow)",
+      "api": 23,
+      "distribution": 0.4
+    },
+    {
+      "version": "Android 7 (Nougat)",
+      "api": 24,
+      "distribution": 0.4
+    },
+    {
+      "version": "Android 7.1 (Nougat)",
+      "api": 25,
+      "distribution": 0.4
+    },
+    {
+      "version": "Android 8 (Oreo)",
+      "api": 26,
+      "distribution": 0.8
+    },
+    {
+      "version": "Android 8.1 (Oreo)",
+      "api": 27,
+      "distribution": 2.3
+    },
+    {
+      "version": "Android 9 (Pie)",
+      "api": 28,
+      "distribution": 4.5
+    },
+    {
+      "version": "Android 10 (Q)",
+      "api": 29,
+      "distribution": 7.8
+    },
+    {
+      "version": "Android 11 (R)",
+      "api": 30,
+      "distribution": 13.7
+    },
+    {
+      "version": "Android 12 (S)",
+      "api": 31,
+      "distribution": 11.4
+    },
+    {
+      "version": "Android 13 (T)",
+      "api": 33,
+      "distribution": 13.9
+    },
+    {
+      "version": "Android 14 (U)",
+      "api": 34,
+      "distribution": 17.2
+    },
+    {
+      "version": "Android 15 (V)",
+      "api": 35,
+      "distribution": 19.3
+    },
+    {
+      "version": "Android 16 (B)",
+      "api": 36,
+      "distribution": 7.4
+    }
+  ],
+  "cumulativeDistribution": [
+    {
+      "version": "Android 5 (Lollipop)",
+      "api": 21,
+      "distribution": 99.9
+    },
+    {
+      "version": "Android 5.1 (Lollipop)",
+      "api": 22,
+      "distribution": 99.8
+    },
+    {
+      "version": "Android 6 (Marshmallow)",
+      "api": 23,
+      "distribution": 99.5
+    },
+    {
+      "version": "Android 7 (Nougat)",
+      "api": 24,
+      "distribution": 99.1
+    },
+    {
+      "version": "Android 7.1 (Nougat)",
+      "api": 25,
+      "distribution": 98.7
+    },
+    {
+      "version": "Android 8 (Oreo)",
+      "api": 26,
+      "distribution": 98.3
+    },
+    {
+      "version": "Android 8.1 (Oreo)",
+      "api": 27,
+      "distribution": 97.5
+    },
+    {
+      "version": "Android 9 (Pie)",
+      "api": 28,
+      "distribution": 95.2
+    },
+    {
+      "version": "Android 10 (Q)",
+      "api": 29,
+      "distribution": 90.7
+    },
+    {
+      "version": "Android 11 (R)",
+      "api": 30,
+      "distribution": 82.9
+    },
+    {
+      "version": "Android 12 (S)",
+      "api": 31,
+      "distribution": 69.2
+    },
+    {
+      "version": "Android 13 (T)",
+      "api": 33,
+      "distribution": 57.8
+    },
+    {
+      "version": "Android 14 (U)",
+      "api": 34,
+      "distribution": 43.9
+    },
+    {
+      "version": "Android 15 (V)",
+      "api": 35,
+      "distribution": 26.7
+    },
+    {
+      "version": "Android 16 (B)",
+      "api": 36,
+      "distribution": 7.4
+    }
+  ]
+}

--- a/apps/web/src/data/ios-distribution.json
+++ b/apps/web/src/data/ios-distribution.json
@@ -1,0 +1,122 @@
+{
+  "updatedAt": "2026-07-27T21:00:00.000Z",
+  "source": "iOS Ref",
+  "sourceUrl": "https://iosref.com/ios-usage",
+  "fetchedAt": "2026-07-28T17:30:25.916Z",
+  "data": [
+    {
+      "version": "iOS 27",
+      "released": "2026",
+      "cumulativeUsage": null,
+      "lastIosFor": "—"
+    },
+    {
+      "version": "iOS 26",
+      "released": "2025",
+      "cumulativeUsage": 67.8,
+      "lastIosFor": "—"
+    },
+    {
+      "version": "iOS 18",
+      "released": "2024",
+      "cumulativeUsage": 87.2,
+      "lastIosFor": "iPhone XS / XS Max , iPhone XR"
+    },
+    {
+      "version": "iOS 17",
+      "released": "2023",
+      "cumulativeUsage": 90.6,
+      "lastIosFor": "—"
+    },
+    {
+      "version": "iOS 16",
+      "released": "2022",
+      "cumulativeUsage": 94,
+      "lastIosFor": "iPhone X , iPhone 8 / 8 Plus"
+    },
+    {
+      "version": "iOS 15",
+      "released": "2021",
+      "cumulativeUsage": 96,
+      "lastIosFor": "iPhone 7 / 7 Plus ,iPhone SE (gen 1) , iPhone 6s / 6s Plus"
+    },
+    {
+      "version": "iOS 14",
+      "released": "2020",
+      "cumulativeUsage": 96.3,
+      "lastIosFor": "—"
+    },
+    {
+      "version": "iOS 13",
+      "released": "2019",
+      "cumulativeUsage": 96.4,
+      "lastIosFor": ""
+    },
+    {
+      "version": "iOS 12",
+      "released": "2018",
+      "cumulativeUsage": 96.8,
+      "lastIosFor": "iPhone 6 / 6 Plus , iPhone 5s"
+    },
+    {
+      "version": "iOS 11",
+      "released": "2017",
+      "cumulativeUsage": 99.2,
+      "lastIosFor": "—"
+    },
+    {
+      "version": "iOS 10",
+      "released": "2016",
+      "cumulativeUsage": 99.3,
+      "lastIosFor": "iPhone 5c , iPhone 5"
+    },
+    {
+      "version": "iOS 9",
+      "released": "2015",
+      "cumulativeUsage": 99.3,
+      "lastIosFor": "iPhone 4s"
+    },
+    {
+      "version": "iOS 8",
+      "released": "2014",
+      "cumulativeUsage": 99.3,
+      "lastIosFor": "—"
+    },
+    {
+      "version": "iOS 7",
+      "released": "2013",
+      "cumulativeUsage": 99.3,
+      "lastIosFor": "iPhone 4"
+    },
+    {
+      "version": "iOS 6",
+      "released": "2012",
+      "cumulativeUsage": 99.3,
+      "lastIosFor": "iPhone 3GS"
+    },
+    {
+      "version": "iOS 5",
+      "released": "2011",
+      "cumulativeUsage": 99.3,
+      "lastIosFor": "—"
+    },
+    {
+      "version": "iOS 4",
+      "released": "2010",
+      "cumulativeUsage": 99.3,
+      "lastIosFor": "iPhone 3G"
+    },
+    {
+      "version": "iOS 3",
+      "released": "2009",
+      "cumulativeUsage": null,
+      "lastIosFor": "iPhone (gen 1)"
+    },
+    {
+      "version": "iOS 2",
+      "released": "2008",
+      "cumulativeUsage": null,
+      "lastIosFor": ""
+    }
+  ]
+}

--- a/apps/web/src/data/ios-distribution.json
+++ b/apps/web/src/data/ios-distribution.json
@@ -1,8 +1,8 @@
 {
-  "updatedAt": "2026-07-27T21:00:00.000Z",
+  "updatedAt": "2026-06-05T21:00:00.000Z",
   "source": "iOS Ref",
   "sourceUrl": "https://iosref.com/ios-usage",
-  "fetchedAt": "2026-07-28T17:30:25.916Z",
+  "fetchedAt": "2026-07-30T21:26:42.269Z",
   "data": [
     {
       "version": "iOS 27",

--- a/apps/web/src/lib/formatPercent.ts
+++ b/apps/web/src/lib/formatPercent.ts
@@ -1,0 +1,4 @@
+export function formatPercent(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—'
+  return `${value.toFixed(value < 1 ? 1 : value % 1 === 0 ? 0 : 1).replace(/\.0$/, '')}%`
+}

--- a/apps/web/src/pages/android-distribution-chart.astro
+++ b/apps/web/src/pages/android-distribution-chart.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '@/layouts/Layout.astro'
+import DistributionRefreshPanel from '@/components/DistributionRefreshPanel.astro'
 import { createLdJsonGraph, createWebPageLdJson } from '@/lib/ldJson'
 import { getRelativeLocaleUrl } from '@/services/links'
 import androidDistribution from '@/data/android-distribution.json'
@@ -58,77 +59,74 @@ function formatPercent(value: number) {
 
 <Layout content={content}>
   <section class="relative overflow-hidden border-b border-white/10 bg-linear-to-b from-slate-950 via-slate-900 to-slate-950 py-16 sm:py-20">
-    <div class="pointer-events-none absolute inset-0">
-      <div class="absolute top-10 -left-16 h-72 w-72 rounded-full bg-green-500/10 blur-3xl"></div>
-      <div class="absolute top-0 right-0 h-80 w-80 rounded-full bg-blue-500/10 blur-3xl"></div>
+    <div class="pointer-events-none absolute inset-0" aria-hidden="true">
+      <div class="absolute top-10 -left-16 size-72 rounded-full bg-green-500/10 blur-3xl"></div>
+      <div class="absolute top-0 right-0 size-80 rounded-full bg-blue-500/10 blur-3xl"></div>
     </div>
 
     <div class="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-      <div class="max-w-4xl">
-        <p class="text-sm font-semibold tracking-[0.3em] text-green-300 uppercase">Android platform data</p>
-        <h1 class="mt-4 text-4xl font-bold tracking-tight text-white sm:text-5xl">{title}</h1>
-        <p class="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
-          Distribution of Android versions across active devices. Use it to decide your minimum SDK when you ship a Capacitor, React Native, Flutter, or native Android app.
-        </p>
+      <p class="font-mono text-sm font-semibold tracking-wide text-green-300 uppercase">Android platform data</p>
+      <h1 class="mt-4 max-w-[30ch] text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl">{title}</h1>
+      <p class="mt-6 max-w-[48ch] text-lg text-pretty text-slate-300">
+        Distribution of Android versions across active devices. Use it to decide your minimum SDK when you ship a Capacitor, React Native, Flutter, or native Android app.
+      </p>
 
-        <div class="mt-8 flex flex-wrap items-center gap-4 text-sm text-slate-400">
-          <span class="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1">
-            Updated {updatedFormatted}
-          </span>
-          <span class="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1">
+      <dl class="mt-8 flex flex-wrap gap-x-6 gap-y-3 text-base text-slate-400 sm:text-sm">
+        <div>
+          <dt class="sr-only">Last updated</dt>
+          <dd>Updated {updatedFormatted}</dd>
+        </div>
+        <div class="min-w-0">
+          <dt class="sr-only">Source</dt>
+          <dd>
             Source:
-            <a href={data.sourceUrl} target="_blank" rel="noopener noreferrer" class="ml-1 text-green-300 underline underline-offset-4 hover:text-green-200">
+            <a href={data.sourceUrl} target="_blank" rel="noopener noreferrer" class="text-green-300 underline underline-offset-4 hover:text-green-200">
               {data.source}
             </a>
-          </span>
-          {
-            topVersion && (
-              <span class="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1">
-                Top version: {topVersion.version.split('(')[0].trim()} ({formatPercent(topVersion.distribution)})
-              </span>
-            )
-          }
+          </dd>
         </div>
+        {
+          topVersion && (
+            <div>
+              <dt class="sr-only">Top version</dt>
+              <dd>
+                Top version: {topVersion.version.split('(')[0].trim()} (<span class="tabular-nums">{formatPercent(topVersion.distribution)}</span>)
+              </dd>
+            </div>
+          )
+        }
+      </dl>
 
-        <div class="mt-8 rounded-2xl border border-white/10 bg-white/5 p-5 sm:flex sm:items-center sm:justify-between">
-          <div>
-            <p class="text-sm font-semibold text-white">Need the iOS version breakdown?</p>
-            <p class="text-sm text-slate-400">Compare cumulative iOS adoption on the companion page.</p>
-          </div>
-          <a
-            href={getRelativeLocaleUrl(locale, 'ios-distribution-chart')}
-            class="mt-4 inline-flex items-center justify-center rounded-xl border border-white/15 px-5 py-2.5 text-sm font-semibold text-white transition hover:border-blue-300/60 hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 focus-visible:outline-none sm:mt-0"
-          >
-            Open iOS distribution chart
-          </a>
-        </div>
-      </div>
+      <p class="mt-8 text-base text-slate-300 sm:text-sm">
+        Need the iOS version breakdown?
+        <a href={getRelativeLocaleUrl(locale, 'ios-distribution-chart')} class="ml-1 font-semibold text-white underline underline-offset-4 hover:text-green-200">
+          Open iOS distribution chart
+        </a>
+      </p>
     </div>
   </section>
 
   <section class="border-b border-white/10 bg-slate-950 py-16 sm:py-20">
     <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-      <div class="mb-10">
-        <p class="text-sm font-semibold tracking-[0.25em] text-green-300 uppercase">Market share</p>
-        <h2 class="mt-3 text-3xl font-bold text-white">Android version share</h2>
-        <p class="mt-3 text-slate-400">Share of devices running each Android version. Total checked versions add up to {formatPercent(Number(totalShare.toFixed(1)))}.</p>
-      </div>
+      <p class="font-mono text-sm font-semibold tracking-wide text-green-300 uppercase">Market share</p>
+      <h2 class="mt-3 max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">Android version share</h2>
+      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">
+        Share of devices running each Android version. Total checked versions add up to{' '}
+        <span class="tabular-nums">{formatPercent(Number(totalShare.toFixed(1)))}</span>.
+      </p>
 
-      <div class="space-y-3">
+      <div class="mt-10 divide-y divide-white/10 border-y border-white/10" role="list">
         {
           data.apiDistribution.map((row) => (
-            <div class="group grid items-center gap-4 rounded-xl border border-white/10 bg-white/[0.03] p-3 sm:grid-cols-[220px_1fr_80px]">
-              <div class="flex items-center justify-between gap-4 sm:block">
+            <div class="grid items-center gap-4 py-4 sm:grid-cols-[220px_1fr_5rem]" role="listitem">
+              <div class="min-w-0">
                 <p class="font-medium text-white">{row.version}</p>
-                <p class="text-xs text-slate-400 sm:mt-1">API {row.api ?? '—'}</p>
+                <p class="mt-1 text-base text-slate-400 sm:text-sm">API {row.api ?? '—'}</p>
               </div>
-              <div class="h-3 w-full overflow-hidden rounded-full bg-white/10">
-                <div
-                  class="h-full rounded-full bg-linear-to-r from-green-400 to-blue-500 transition-all duration-700 ease-out"
-                  style={`width: ${Math.min(100, row.distribution)}%`}
-                />
+              <div class="h-3 w-full overflow-hidden rounded-full bg-white/10" aria-hidden="true">
+                <div class="h-full w-(--bar-width) rounded-full bg-linear-to-r from-green-400 to-blue-500" style={`--bar-width: ${Math.min(100, row.distribution)}%`} />
               </div>
-              <p class="text-right font-mono text-sm font-semibold text-white">{formatPercent(row.distribution)}</p>
+              <p class="text-right font-mono text-base font-semibold text-white tabular-nums sm:text-sm">{formatPercent(row.distribution)}</p>
             </div>
           ))
         }
@@ -138,68 +136,42 @@ function formatPercent(value: number) {
 
   <section class="border-b border-white/10 bg-slate-900 py-16 sm:py-20">
     <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-      <div class="mb-10">
-        <p class="text-sm font-semibold tracking-[0.25em] text-blue-300 uppercase">Cumulative reach</p>
-        <h2 class="mt-3 text-3xl font-bold text-white">Cumulative distribution</h2>
-        <p class="mt-3 text-slate-400">Percentage of devices that can run your app if you target a given API level or higher.</p>
-      </div>
+      <p class="font-mono text-sm font-semibold tracking-wide text-blue-300 uppercase">Cumulative reach</p>
+      <h2 class="mt-3 max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">Cumulative distribution</h2>
+      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">Percentage of devices that can run your app if you target a given API level or higher.</p>
 
-      <div class="overflow-x-auto rounded-2xl border border-white/10">
-        <table class="w-full text-left text-sm">
-          <thead class="border-b border-white/10 bg-white/5 text-slate-400">
-            <tr>
-              <th class="px-4 py-3 font-medium">Version</th>
-              <th class="px-4 py-3 font-medium">API</th>
-              <th class="px-4 py-3 font-medium">Cumulative</th>
-              <th class="px-4 py-3 font-medium">Bar</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-white/10">
-            {
-              data.cumulativeDistribution.map((row) => (
-                <tr class="hover:bg-white/[0.03]">
-                  <td class="px-4 py-3 font-medium text-white">{row.version}</td>
-                  <td class="px-4 py-3 text-slate-400">{row.api ?? '—'}</td>
-                  <td class="px-4 py-3 font-mono font-semibold text-white">{formatPercent(row.distribution)}</td>
-                  <td class="px-4 py-3">
-                    <div class="h-2 w-24 overflow-hidden rounded-full bg-white/10 sm:w-32">
-                      <div class="h-full rounded-full bg-linear-to-r from-blue-500 to-cyan-400" style={`width: ${Math.min(100, row.distribution)}%`} />
-                    </div>
-                  </td>
-                </tr>
-              ))
-            }
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </section>
-
-  <section class="bg-slate-950 py-16 sm:py-20">
-    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-      <div class="rounded-3xl border border-white/10 bg-white/5 p-8 sm:p-10">
-        <h2 class="text-2xl font-bold text-white">How this data is kept current</h2>
-        <p class="mt-4 max-w-3xl text-sm leading-7 text-slate-300">
-          A daily job fetches the latest numbers from the sources above. If the figures changed, the JSON files are committed automatically; if not, the repo stays untouched. The
-          pages read these files at build time, so the charts are always in sync with the latest published data.
-        </p>
-        <div class="mt-6 flex flex-col gap-3 sm:flex-row">
-          <a
-            href={getRelativeLocaleUrl(locale, 'ios-distribution-chart')}
-            class="inline-flex items-center justify-center rounded-xl bg-green-400 px-5 py-2.5 text-sm font-semibold text-slate-950 transition hover:bg-green-300 focus-visible:ring-2 focus-visible:ring-green-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 focus-visible:outline-none"
-          >
-            See iOS distribution chart
-          </a>
-          <a
-            href="https://github.com/Cap-go/landing/tree/main/apps/web/src/data"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex items-center justify-center rounded-xl border border-white/15 px-5 py-2.5 text-sm font-semibold text-white transition hover:border-green-300/60 hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-green-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 focus-visible:outline-none"
-          >
-            View raw data
-          </a>
+      <div class="-mx-4 -my-2 mt-10 overflow-x-auto whitespace-nowrap sm:-mx-6 lg:-mx-8">
+        <div class="inline-block min-w-full px-4 py-2 align-middle sm:px-6 lg:px-8">
+          <table class="w-full text-left text-base sm:text-sm">
+            <thead class="border-b border-white/10 text-slate-400">
+              <tr>
+                <th class="py-3 pr-4 font-medium whitespace-nowrap">Version</th>
+                <th class="py-3 pr-4 font-medium whitespace-nowrap">API</th>
+                <th class="py-3 pr-4 font-medium whitespace-nowrap">Cumulative</th>
+                <th class="py-3 font-medium whitespace-nowrap">Reach</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-white/10">
+              {
+                data.cumulativeDistribution.map((row) => (
+                  <tr>
+                    <td class="py-3 pr-4 font-medium whitespace-nowrap text-white">{row.version}</td>
+                    <td class="py-3 pr-4 text-slate-400 tabular-nums">{row.api ?? '—'}</td>
+                    <td class="py-3 pr-4 font-mono font-semibold text-white tabular-nums">{formatPercent(row.distribution)}</td>
+                    <td class="py-3">
+                      <div class="h-2 w-24 overflow-hidden rounded-full bg-white/10 sm:w-32" aria-hidden="true">
+                        <div class="h-full w-(--bar-width) rounded-full bg-linear-to-r from-blue-500 to-cyan-400" style={`--bar-width: ${Math.min(100, row.distribution)}%`} />
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              }
+            </tbody>
+          </table>
         </div>
       </div>
     </div>
   </section>
+
+  <DistributionRefreshPanel accent="green" companionHref="ios-distribution-chart" companionLabel="See iOS distribution chart" />
 </Layout>

--- a/apps/web/src/pages/android-distribution-chart.astro
+++ b/apps/web/src/pages/android-distribution-chart.astro
@@ -2,8 +2,9 @@
 import Layout from '@/layouts/Layout.astro'
 import DistributionRefreshPanel from '@/components/DistributionRefreshPanel.astro'
 import DistributionTargetChart from '@/components/DistributionTargetChart.astro'
+import ToolFaq from '@/components/tools/ToolFaq.astro'
 import { formatPercent } from '@/lib/formatPercent'
-import { createLdJsonGraph, createWebPageLdJson } from '@/lib/ldJson'
+import { createFAQPageLdJson, createItemListLdJson, createLdJsonGraph, createSoftwareApplicationLdJson, createWebPageLdJson } from '@/lib/ldJson'
 import { getRelativeLocaleUrl } from '@/services/links'
 import androidDistribution from '@/data/android-distribution.json'
 
@@ -23,25 +24,9 @@ interface AndroidData {
 }
 
 const data = androidDistribution as AndroidData
-
 const locale = Astro.locals.locale
-const title = 'Android Version Distribution Chart'
-const description = 'Pick a minimum Android API (or a coverage target like 95%) and see what share of devices your app can reach. Auto-updated market data.'
-
-const content = {
-  title,
-  description,
-  keywords: 'android version distribution, android market share, android api levels, min sdk, capacitor android support',
-  ldJSON: createLdJsonGraph(
-    Astro.locals.runtimeConfig.public,
-    createWebPageLdJson(Astro.locals.runtimeConfig.public, {
-      name: title,
-      description,
-      url: Astro.url.href,
-    }),
-    { includeOrganization: true },
-  ),
-}
+const publicConfig = Astro.locals.runtimeConfig.public
+const toAbsoluteLocaleUrl = (path: string) => new URL(getRelativeLocaleUrl(locale, path), Astro.url.origin).toString()
 
 const updatedFormatted = new Date(data.updatedAt).toLocaleDateString('en-US', {
   year: 'numeric',
@@ -57,8 +42,109 @@ const reachRows = [...data.cumulativeDistribution]
     detail: row.api === null ? undefined : `API ${row.api}+`,
     reach: row.distribution,
   }))
+  .sort((a, b) => b.reach - a.reach)
 
+const newestMeeting = (target: number) => [...reachRows].filter((row) => row.reach >= target).sort((a, b) => a.reach - b.reach)[0]
+
+const cover95 = newestMeeting(95)
+const cover99 = newestMeeting(99)
+const cover999 = newestMeeting(99.9)
+const topShare = [...data.apiDistribution].sort((a, b) => b.distribution - a.distribution)[0]
 const shareRows = [...data.apiDistribution].sort((a, b) => b.distribution - a.distribution)
+
+const title = 'Android Version Distribution Chart | Min SDK Market Share'
+const description = cover95
+  ? `Live Android version distribution chart. As of ${updatedFormatted}, ${cover95.label} (API ${cover95.id}+) covers about ${formatPercent(cover95.reach)} of devices. Pick a min SDK or coverage target for Capacitor, React Native, Flutter, and native Android.`
+  : `Live Android version distribution chart. Pick a minimum SDK or coverage target and see what share of devices your app can reach.`
+
+const faqItems = [
+  {
+    question: 'What is an Android version distribution chart?',
+    answer:
+      'It shows how Android versions are split across active devices. Cumulative reach answers the practical question: if this API level is your minimum SDK, what percentage of the market can install your app.',
+  },
+  {
+    question: 'How do I choose a minSdkVersion from this chart?',
+    answer: cover95
+      ? `Set a coverage goal first (many teams use 95%). Then pick the newest Android version that still meets that goal. On this dataset, ${cover95.label} reaches about ${formatPercent(cover95.reach)}. Raise the target toward 99% if you need broader support, or lower it if you can drop older APIs.`
+      : 'Set a coverage goal first, then pick the newest Android version that still meets that goal. Use the interactive planner above to test targets like 95%, 99%, or 99.9%.',
+  },
+  {
+    question: 'What is the difference between market share and cumulative reach?',
+    answer:
+      'Market share is the percent of devices on one exact Android version. Cumulative reach is the percent of devices on that version or newer. For min SDK decisions, use cumulative reach.',
+  },
+  {
+    question: 'How often is this Android distribution data updated?',
+    answer: `Capgo refreshes the chart from ${data.source} daily. If the published figures change, the JSON in the repo is updated automatically. This page currently reflects data updated ${updatedFormatted}.`,
+  },
+  {
+    question: 'Does this help Capacitor and Ionic apps?',
+    answer:
+      'Yes. Capacitor apps still compile to native Android projects, so minSdkVersion affects which devices can install your release. Use this chart before you raise the floor for a plugin, Live Update baseline, or Play Store build.',
+  },
+]
+
+const softwareApplication = createSoftwareApplicationLdJson(publicConfig, {
+  name: 'Capgo Android Version Distribution Chart',
+  description,
+  url: Astro.url.href,
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Web',
+  offers: {
+    price: '0',
+    priceCurrency: 'USD',
+    availability: 'https://schema.org/InStock',
+  },
+})
+
+const faqLdJson = createFAQPageLdJson(publicConfig, {
+  url: Astro.url.href,
+  questions: faqItems,
+})
+
+const webPage = createWebPageLdJson(publicConfig, {
+  name: title,
+  description,
+  url: Astro.url.href,
+})
+
+const itemList = createItemListLdJson(publicConfig, {
+  url: Astro.url.href,
+  name: 'Android cumulative version reach',
+  description: 'Cumulative share of devices that can run an app for each minimum Android API level.',
+  items: reachRows.slice(0, 12).map((row) => ({
+    name: `${row.label} (${formatPercent(row.reach)} cumulative)`,
+    description: row.detail,
+    url: Astro.url.href,
+  })),
+})
+
+const ldJSON = createLdJsonGraph(publicConfig, softwareApplication, {
+  includeOrganization: true,
+  includeBreadcrumbs: true,
+  breadcrumbs: [
+    { name: 'Home', url: toAbsoluteLocaleUrl('') },
+    { name: 'Android distribution chart', url: Astro.url.href },
+  ],
+  additionalEntities: [faqLdJson, webPage, itemList],
+})
+
+const content = {
+  title,
+  description,
+  keywords:
+    'android version distribution, android version market share, android api distribution, android cumulative distribution, minSdkVersion, min sdk android, android device coverage, capacitor android min sdk, ionic android support',
+  ldJSON,
+  articleModifiedTime: data.updatedAt,
+}
+
+const relatedLinks = [
+  { name: 'iOS version distribution chart', href: getRelativeLocaleUrl(locale, 'ios-distribution-chart') },
+  { name: 'Capgo native build', href: getRelativeLocaleUrl(locale, 'native-build') },
+  { name: 'Android keystore generator', href: getRelativeLocaleUrl(locale, 'tools/android-keystore-generator') },
+  { name: 'Live updates for Capacitor', href: getRelativeLocaleUrl(locale, 'live-update') },
+]
 ---
 
 <Layout content={content}>
@@ -69,12 +155,41 @@ const shareRows = [...data.apiDistribution].sort((a, b) => b.distribution - a.di
     </div>
 
     <div class="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-      <p class="font-mono text-sm font-semibold tracking-wide text-green-300 uppercase">Android support planner</p>
-      <h1 class="mt-4 max-w-[30ch] text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl">Choose a min SDK by the users you need to cover</h1>
-      <p class="mt-6 max-w-[48ch] text-lg text-pretty text-slate-300">
-        Cumulative reach tells you: if this Android version (API) is your floor, what percent of devices can run the app. Use it to set minSdk for Capacitor, React Native, Flutter,
-        or native Android.
+      <p class="font-mono text-sm font-semibold tracking-wide text-green-300 uppercase">Android version distribution</p>
+      <h1 class="mt-4 max-w-[32ch] text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl">Android version distribution chart for min SDK decisions</h1>
+      <p class="mt-6 max-w-[56ch] text-lg text-pretty text-slate-300">
+        Use this Android API market-share chart to choose a minimum SDK by the users you still need to cover. Cumulative reach answers: if this Android version is your floor, what
+        percent of devices can install your Capacitor, React Native, Flutter, or native app.
       </p>
+
+      <div class="mt-8 max-w-3xl rounded-2xl border border-white/10 bg-white/5 px-5 py-4">
+        <p class="text-base text-pretty text-slate-200 sm:text-sm">
+          As of {updatedFormatted}
+          {
+            cover95 && (
+              <>
+                , targeting <strong class="font-semibold text-white">{cover95.label}</strong> covers about{' '}
+                <strong class="font-semibold text-white tabular-nums">{formatPercent(cover95.reach)}</strong> of devices
+              </>
+            )
+          }
+          {
+            cover99 && (
+              <>
+                . A {formatPercent(99)} goal lands near <strong class="font-semibold text-white">{cover99.label}</strong>
+              </>
+            )
+          }
+          {
+            topShare && (
+              <>
+                . The largest single version share today is <strong class="font-semibold text-white">{topShare.version}</strong> at{' '}
+                <strong class="font-semibold text-white tabular-nums">{formatPercent(topShare.distribution)}</strong>.
+              </>
+            )
+          }
+        </p>
+      </div>
 
       <dl class="mt-8 flex flex-wrap gap-x-6 gap-y-3 text-base text-slate-400 sm:text-sm">
         <div>
@@ -90,24 +205,64 @@ const shareRows = [...data.apiDistribution].sort((a, b) => b.distribution - a.di
             </a>
           </dd>
         </div>
+        {
+          cover999 && (
+            <div>
+              <dt class="sr-only">99.9 percent coverage target</dt>
+              <dd>
+                {formatPercent(99.9)} coverage: {cover999.label}
+              </dd>
+            </div>
+          )
+        }
       </dl>
 
       <p class="mt-8 text-base text-slate-300 sm:text-sm">
-        Need the iOS deployment target?
+        Compare with iOS deployment targets on the{' '}
         <a href={getRelativeLocaleUrl(locale, 'ios-distribution-chart')} class="font-semibold text-white underline underline-offset-4 hover:text-green-200">
-          Open iOS distribution chart
+          iOS version distribution chart
         </a>
+        .
       </p>
     </div>
   </section>
 
   <DistributionTargetChart platform="android" rows={reachRows} versionLabel="Android version / API" targetNoun="Android version" />
 
+  <section class="border-b border-white/10 bg-slate-950 py-16 sm:py-20">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+      <p class="font-mono text-sm font-semibold tracking-wide text-green-300 uppercase">How to use the chart</p>
+      <h2 class="mt-3 max-w-[40ch] text-3xl font-semibold tracking-tight text-balance text-white">How to pick an Android min SDK from version distribution data</h2>
+      <div class="mt-8 grid gap-8 lg:grid-cols-3">
+        <div>
+          <h3 class="text-xl font-semibold tracking-tight text-white">1. Set a coverage goal</h3>
+          <p class="mt-3 text-base text-pretty text-slate-400 sm:text-sm">
+            Decide what percent of the Android install base you must keep. Common goals are 95%, 99%, or 99.9% when you still support older phones.
+          </p>
+        </div>
+        <div>
+          <h3 class="text-xl font-semibold tracking-tight text-white">2. Read cumulative reach</h3>
+          <p class="mt-3 text-base text-pretty text-slate-400 sm:text-sm">
+            Cumulative distribution is the right metric for minSdkVersion. It measures devices on that API level or newer, not only devices stuck on one release.
+          </p>
+        </div>
+        <div>
+          <h3 class="text-xl font-semibold tracking-tight text-white">3. Choose the newest safe floor</h3>
+          <p class="mt-3 text-base text-pretty text-slate-400 sm:text-sm">
+            Prefer the newest Android version that still meets your goal. That maximizes modern APIs and Play policy headroom while protecting the users you care about.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <section class="border-b border-white/10 bg-slate-900 py-16 sm:py-20">
     <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
       <p class="font-mono text-sm font-semibold tracking-wide text-green-300 uppercase">Market share</p>
-      <h2 class="mt-3 max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">Share by Android version</h2>
-      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">Individual market share (not cumulative). Sorted from highest share to lowest.</p>
+      <h2 class="mt-3 max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">Android version market share by API level</h2>
+      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">
+        Individual Android version share, sorted highest to lowest. Use this when you need the current mix of OS versions, not the cumulative install floor.
+      </p>
 
       <div class="mt-10 divide-y divide-white/10 border-y border-white/10" role="list">
         {
@@ -125,6 +280,30 @@ const shareRows = [...data.apiDistribution].sort((a, b) => b.distribution - a.di
           ))
         }
       </div>
+    </div>
+  </section>
+
+  <ToolFaq
+    title="Android distribution FAQ"
+    intro="Answers for teams setting minSdkVersion, reviewing Play Store support, or planning Capacitor Android upgrades."
+    items={faqItems}
+  />
+
+  <section class="border-b border-white/10 bg-slate-950 py-16 sm:py-20">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+      <h2 class="max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">Related developer resources</h2>
+      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">Keep going with iOS coverage data, signing tools, and Capgo release workflows.</p>
+      <ul class="mt-8 grid gap-3 sm:grid-cols-2" role="list">
+        {
+          relatedLinks.map((link) => (
+            <li>
+              <a href={link.href} class="flex rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-base font-semibold text-white hover:border-green-300/40 sm:text-sm">
+                {link.name}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
     </div>
   </section>
 

--- a/apps/web/src/pages/android-distribution-chart.astro
+++ b/apps/web/src/pages/android-distribution-chart.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from '@/layouts/Layout.astro'
 import DistributionRefreshPanel from '@/components/DistributionRefreshPanel.astro'
+import DistributionTargetChart from '@/components/DistributionTargetChart.astro'
+import { formatPercent } from '@/lib/formatPercent'
 import { createLdJsonGraph, createWebPageLdJson } from '@/lib/ldJson'
 import { getRelativeLocaleUrl } from '@/services/links'
 import androidDistribution from '@/data/android-distribution.json'
@@ -24,12 +26,12 @@ const data = androidDistribution as AndroidData
 
 const locale = Astro.locals.locale
 const title = 'Android Version Distribution Chart'
-const description = `Market share of every Android version and API level. Data from ${data.source}, refreshed automatically.`
+const description = 'Pick a minimum Android API (or a coverage target like 95%) and see what share of devices your app can reach. Auto-updated market data.'
 
 const content = {
   title,
   description,
-  keywords: 'android version distribution, android market share, android api levels, capacitor android support',
+  keywords: 'android version distribution, android market share, android api levels, min sdk, capacitor android support',
   ldJSON: createLdJsonGraph(
     Astro.locals.runtimeConfig.public,
     createWebPageLdJson(Astro.locals.runtimeConfig.public, {
@@ -41,20 +43,22 @@ const content = {
   ),
 }
 
-const updatedDate = new Date(data.updatedAt)
-const updatedFormatted = updatedDate.toLocaleDateString('en-US', {
+const updatedFormatted = new Date(data.updatedAt).toLocaleDateString('en-US', {
   year: 'numeric',
   month: 'long',
   day: 'numeric',
 })
 
-const sortedByShare = [...data.apiDistribution].sort((a, b) => b.distribution - a.distribution)
-const topVersion = sortedByShare[0]
-const totalShare = data.apiDistribution.reduce((sum, row) => sum + row.distribution, 0)
+const reachRows = [...data.cumulativeDistribution]
+  .filter((row) => typeof row.distribution === 'number')
+  .map((row) => ({
+    id: String(row.api ?? row.version),
+    label: row.version,
+    detail: row.api === null ? undefined : `API ${row.api}+`,
+    reach: row.distribution,
+  }))
 
-function formatPercent(value: number) {
-  return `${value.toFixed(value < 1 ? 1 : value % 1 === 0 ? 0 : 1).replace(/\.0$/, '')}%`
-}
+const shareRows = [...data.apiDistribution].sort((a, b) => b.distribution - a.distribution)
 ---
 
 <Layout content={content}>
@@ -65,10 +69,11 @@ function formatPercent(value: number) {
     </div>
 
     <div class="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-      <p class="font-mono text-sm font-semibold tracking-wide text-green-300 uppercase">Android platform data</p>
-      <h1 class="mt-4 max-w-[30ch] text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl">{title}</h1>
+      <p class="font-mono text-sm font-semibold tracking-wide text-green-300 uppercase">Android support planner</p>
+      <h1 class="mt-4 max-w-[30ch] text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl">Choose a min SDK by the users you need to cover</h1>
       <p class="mt-6 max-w-[48ch] text-lg text-pretty text-slate-300">
-        Distribution of Android versions across active devices. Use it to decide your minimum SDK when you ship a Capacitor, React Native, Flutter, or native Android app.
+        Cumulative reach tells you: if this Android version (API) is your floor, what percent of devices can run the app. Use it to set minSdk for Capacitor, React Native, Flutter,
+        or native Android.
       </p>
 
       <dl class="mt-8 flex flex-wrap gap-x-6 gap-y-3 text-base text-slate-400 sm:text-sm">
@@ -85,39 +90,28 @@ function formatPercent(value: number) {
             </a>
           </dd>
         </div>
-        {
-          topVersion && (
-            <div>
-              <dt class="sr-only">Top version</dt>
-              <dd>
-                Top version: {topVersion.version.split('(')[0].trim()} (<span class="tabular-nums">{formatPercent(topVersion.distribution)}</span>)
-              </dd>
-            </div>
-          )
-        }
       </dl>
 
       <p class="mt-8 text-base text-slate-300 sm:text-sm">
-        Need the iOS version breakdown?
-        <a href={getRelativeLocaleUrl(locale, 'ios-distribution-chart')} class="ml-1 font-semibold text-white underline underline-offset-4 hover:text-green-200">
+        Need the iOS deployment target?
+        <a href={getRelativeLocaleUrl(locale, 'ios-distribution-chart')} class="font-semibold text-white underline underline-offset-4 hover:text-green-200">
           Open iOS distribution chart
         </a>
       </p>
     </div>
   </section>
 
-  <section class="border-b border-white/10 bg-slate-950 py-16 sm:py-20">
+  <DistributionTargetChart platform="android" rows={reachRows} versionLabel="Android version / API" targetNoun="Android version" />
+
+  <section class="border-b border-white/10 bg-slate-900 py-16 sm:py-20">
     <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
       <p class="font-mono text-sm font-semibold tracking-wide text-green-300 uppercase">Market share</p>
-      <h2 class="mt-3 max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">Android version share</h2>
-      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">
-        Share of devices running each Android version. Total checked versions add up to{' '}
-        <span class="tabular-nums">{formatPercent(Number(totalShare.toFixed(1)))}</span>.
-      </p>
+      <h2 class="mt-3 max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">Share by Android version</h2>
+      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">Individual market share (not cumulative). Sorted from highest share to lowest.</p>
 
       <div class="mt-10 divide-y divide-white/10 border-y border-white/10" role="list">
         {
-          data.apiDistribution.map((row) => (
+          shareRows.map((row) => (
             <div class="grid items-center gap-4 py-4 sm:grid-cols-[220px_1fr_5rem]" role="listitem">
               <div class="min-w-0">
                 <p class="font-medium text-white">{row.version}</p>
@@ -130,45 +124,6 @@ function formatPercent(value: number) {
             </div>
           ))
         }
-      </div>
-    </div>
-  </section>
-
-  <section class="border-b border-white/10 bg-slate-900 py-16 sm:py-20">
-    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-      <p class="font-mono text-sm font-semibold tracking-wide text-blue-300 uppercase">Cumulative reach</p>
-      <h2 class="mt-3 max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">Cumulative distribution</h2>
-      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">Percentage of devices that can run your app if you target a given API level or higher.</p>
-
-      <div class="-mx-4 -my-2 mt-10 overflow-x-auto whitespace-nowrap sm:-mx-6 lg:-mx-8">
-        <div class="inline-block min-w-full px-4 py-2 align-middle sm:px-6 lg:px-8">
-          <table class="w-full text-left text-base sm:text-sm">
-            <thead class="border-b border-white/10 text-slate-400">
-              <tr>
-                <th class="py-3 pr-4 font-medium whitespace-nowrap">Version</th>
-                <th class="py-3 pr-4 font-medium whitespace-nowrap">API</th>
-                <th class="py-3 pr-4 font-medium whitespace-nowrap">Cumulative</th>
-                <th class="py-3 font-medium whitespace-nowrap">Reach</th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-white/10">
-              {
-                data.cumulativeDistribution.map((row) => (
-                  <tr>
-                    <td class="py-3 pr-4 font-medium whitespace-nowrap text-white">{row.version}</td>
-                    <td class="py-3 pr-4 text-slate-400 tabular-nums">{row.api ?? '—'}</td>
-                    <td class="py-3 pr-4 font-mono font-semibold text-white tabular-nums">{formatPercent(row.distribution)}</td>
-                    <td class="py-3">
-                      <div class="h-2 w-24 overflow-hidden rounded-full bg-white/10 sm:w-32" aria-hidden="true">
-                        <div class="h-full w-(--bar-width) rounded-full bg-linear-to-r from-blue-500 to-cyan-400" style={`--bar-width: ${Math.min(100, row.distribution)}%`} />
-                      </div>
-                    </td>
-                  </tr>
-                ))
-              }
-            </tbody>
-          </table>
-        </div>
       </div>
     </div>
   </section>

--- a/apps/web/src/pages/android-distribution-chart.astro
+++ b/apps/web/src/pages/android-distribution-chart.astro
@@ -1,0 +1,205 @@
+---
+import Layout from '@/layouts/Layout.astro'
+import { createLdJsonGraph, createWebPageLdJson } from '@/lib/ldJson'
+import { getRelativeLocaleUrl } from '@/services/links'
+import androidDistribution from '@/data/android-distribution.json'
+
+interface DistributionRow {
+  version: string
+  api: number | null
+  distribution: number
+}
+
+interface AndroidData {
+  updatedAt: string
+  source: string
+  sourceUrl: string
+  fetchedAt: string
+  apiDistribution: DistributionRow[]
+  cumulativeDistribution: DistributionRow[]
+}
+
+const data = androidDistribution as AndroidData
+
+const locale = Astro.locals.locale
+const title = 'Android Version Distribution Chart'
+const description = `Market share of every Android version and API level. Data from ${data.source}, refreshed automatically.`
+
+const content = {
+  title,
+  description,
+  keywords: 'android version distribution, android market share, android api levels, capacitor android support',
+  ldJSON: createLdJsonGraph(
+    Astro.locals.runtimeConfig.public,
+    createWebPageLdJson(Astro.locals.runtimeConfig.public, {
+      name: title,
+      description,
+      url: Astro.url.href,
+    }),
+    { includeOrganization: true },
+  ),
+}
+
+const updatedDate = new Date(data.updatedAt)
+const updatedFormatted = updatedDate.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+})
+
+const sortedByShare = [...data.apiDistribution].sort((a, b) => b.distribution - a.distribution)
+const topVersion = sortedByShare[0]
+const totalShare = data.apiDistribution.reduce((sum, row) => sum + row.distribution, 0)
+
+function formatPercent(value: number) {
+  return `${value.toFixed(value < 1 ? 1 : value % 1 === 0 ? 0 : 1).replace(/\.0$/, '')}%`
+}
+---
+
+<Layout content={content}>
+  <section class="relative overflow-hidden border-b border-white/10 bg-linear-to-b from-slate-950 via-slate-900 to-slate-950 py-16 sm:py-20">
+    <div class="pointer-events-none absolute inset-0">
+      <div class="absolute top-10 -left-16 h-72 w-72 rounded-full bg-green-500/10 blur-3xl"></div>
+      <div class="absolute top-0 right-0 h-80 w-80 rounded-full bg-blue-500/10 blur-3xl"></div>
+    </div>
+
+    <div class="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+      <div class="max-w-4xl">
+        <p class="text-sm font-semibold tracking-[0.3em] text-green-300 uppercase">Android platform data</p>
+        <h1 class="mt-4 text-4xl font-bold tracking-tight text-white sm:text-5xl">{title}</h1>
+        <p class="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
+          Distribution of Android versions across active devices. Use it to decide your minimum SDK when you ship a Capacitor, React Native, Flutter, or native Android app.
+        </p>
+
+        <div class="mt-8 flex flex-wrap items-center gap-4 text-sm text-slate-400">
+          <span class="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1">
+            Updated {updatedFormatted}
+          </span>
+          <span class="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1">
+            Source:
+            <a href={data.sourceUrl} target="_blank" rel="noopener noreferrer" class="ml-1 text-green-300 underline underline-offset-4 hover:text-green-200">
+              {data.source}
+            </a>
+          </span>
+          {
+            topVersion && (
+              <span class="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1">
+                Top version: {topVersion.version.split('(')[0].trim()} ({formatPercent(topVersion.distribution)})
+              </span>
+            )
+          }
+        </div>
+
+        <div class="mt-8 rounded-2xl border border-white/10 bg-white/5 p-5 sm:flex sm:items-center sm:justify-between">
+          <div>
+            <p class="text-sm font-semibold text-white">Need the iOS version breakdown?</p>
+            <p class="text-sm text-slate-400">Compare cumulative iOS adoption on the companion page.</p>
+          </div>
+          <a
+            href={getRelativeLocaleUrl(locale, 'ios-distribution-chart')}
+            class="mt-4 inline-flex items-center justify-center rounded-xl border border-white/15 px-5 py-2.5 text-sm font-semibold text-white transition hover:border-blue-300/60 hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 focus-visible:outline-none sm:mt-0"
+          >
+            Open iOS distribution chart
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="border-b border-white/10 bg-slate-950 py-16 sm:py-20">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+      <div class="mb-10">
+        <p class="text-sm font-semibold tracking-[0.25em] text-green-300 uppercase">Market share</p>
+        <h2 class="mt-3 text-3xl font-bold text-white">Android version share</h2>
+        <p class="mt-3 text-slate-400">Share of devices running each Android version. Total checked versions add up to {formatPercent(Number(totalShare.toFixed(1)))}.</p>
+      </div>
+
+      <div class="space-y-3">
+        {
+          data.apiDistribution.map((row) => (
+            <div class="group grid items-center gap-4 rounded-xl border border-white/10 bg-white/[0.03] p-3 sm:grid-cols-[220px_1fr_80px]">
+              <div class="flex items-center justify-between gap-4 sm:block">
+                <p class="font-medium text-white">{row.version}</p>
+                <p class="text-xs text-slate-400 sm:mt-1">API {row.api ?? '—'}</p>
+              </div>
+              <div class="h-3 w-full overflow-hidden rounded-full bg-white/10">
+                <div
+                  class="h-full rounded-full bg-linear-to-r from-green-400 to-blue-500 transition-all duration-700 ease-out"
+                  style={`width: ${Math.min(100, row.distribution)}%`}
+                />
+              </div>
+              <p class="text-right font-mono text-sm font-semibold text-white">{formatPercent(row.distribution)}</p>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <section class="border-b border-white/10 bg-slate-900 py-16 sm:py-20">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+      <div class="mb-10">
+        <p class="text-sm font-semibold tracking-[0.25em] text-blue-300 uppercase">Cumulative reach</p>
+        <h2 class="mt-3 text-3xl font-bold text-white">Cumulative distribution</h2>
+        <p class="mt-3 text-slate-400">Percentage of devices that can run your app if you target a given API level or higher.</p>
+      </div>
+
+      <div class="overflow-x-auto rounded-2xl border border-white/10">
+        <table class="w-full text-left text-sm">
+          <thead class="border-b border-white/10 bg-white/5 text-slate-400">
+            <tr>
+              <th class="px-4 py-3 font-medium">Version</th>
+              <th class="px-4 py-3 font-medium">API</th>
+              <th class="px-4 py-3 font-medium">Cumulative</th>
+              <th class="px-4 py-3 font-medium">Bar</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-white/10">
+            {
+              data.cumulativeDistribution.map((row) => (
+                <tr class="hover:bg-white/[0.03]">
+                  <td class="px-4 py-3 font-medium text-white">{row.version}</td>
+                  <td class="px-4 py-3 text-slate-400">{row.api ?? '—'}</td>
+                  <td class="px-4 py-3 font-mono font-semibold text-white">{formatPercent(row.distribution)}</td>
+                  <td class="px-4 py-3">
+                    <div class="h-2 w-24 overflow-hidden rounded-full bg-white/10 sm:w-32">
+                      <div class="h-full rounded-full bg-linear-to-r from-blue-500 to-cyan-400" style={`width: ${Math.min(100, row.distribution)}%`} />
+                    </div>
+                  </td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <section class="bg-slate-950 py-16 sm:py-20">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+      <div class="rounded-3xl border border-white/10 bg-white/5 p-8 sm:p-10">
+        <h2 class="text-2xl font-bold text-white">How this data is kept current</h2>
+        <p class="mt-4 max-w-3xl text-sm leading-7 text-slate-300">
+          A daily job fetches the latest numbers from the sources above. If the figures changed, the JSON files are committed automatically; if not, the repo stays untouched. The
+          pages read these files at build time, so the charts are always in sync with the latest published data.
+        </p>
+        <div class="mt-6 flex flex-col gap-3 sm:flex-row">
+          <a
+            href={getRelativeLocaleUrl(locale, 'ios-distribution-chart')}
+            class="inline-flex items-center justify-center rounded-xl bg-green-400 px-5 py-2.5 text-sm font-semibold text-slate-950 transition hover:bg-green-300 focus-visible:ring-2 focus-visible:ring-green-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 focus-visible:outline-none"
+          >
+            See iOS distribution chart
+          </a>
+          <a
+            href="https://github.com/Cap-go/landing/tree/main/apps/web/src/data"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center justify-center rounded-xl border border-white/15 px-5 py-2.5 text-sm font-semibold text-white transition hover:border-green-300/60 hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-green-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 focus-visible:outline-none"
+          >
+            View raw data
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Layout>

--- a/apps/web/src/pages/ios-distribution-chart.astro
+++ b/apps/web/src/pages/ios-distribution-chart.astro
@@ -2,8 +2,9 @@
 import Layout from '@/layouts/Layout.astro'
 import DistributionRefreshPanel from '@/components/DistributionRefreshPanel.astro'
 import DistributionTargetChart from '@/components/DistributionTargetChart.astro'
+import ToolFaq from '@/components/tools/ToolFaq.astro'
 import { formatPercent } from '@/lib/formatPercent'
-import { createLdJsonGraph, createWebPageLdJson } from '@/lib/ldJson'
+import { createFAQPageLdJson, createItemListLdJson, createLdJsonGraph, createSoftwareApplicationLdJson, createWebPageLdJson } from '@/lib/ldJson'
 import { getRelativeLocaleUrl } from '@/services/links'
 import iosDistribution from '@/data/ios-distribution.json'
 
@@ -23,25 +24,9 @@ interface IosData {
 }
 
 const data = iosDistribution as IosData
-
 const locale = Astro.locals.locale
-const title = 'iOS Version Distribution Chart'
-const description = 'Pick a minimum iOS version (or a coverage target like 95%) and see what share of devices your app can reach. Auto-updated usage data.'
-
-const content = {
-  title,
-  description,
-  keywords: 'ios version distribution, ios deployment target, ios usage, capacitor ios support, min ios version',
-  ldJSON: createLdJsonGraph(
-    Astro.locals.runtimeConfig.public,
-    createWebPageLdJson(Astro.locals.runtimeConfig.public, {
-      name: title,
-      description,
-      url: Astro.url.href,
-    }),
-    { includeOrganization: true },
-  ),
-}
+const publicConfig = Astro.locals.runtimeConfig.public
+const toAbsoluteLocaleUrl = (path: string) => new URL(getRelativeLocaleUrl(locale, path), Astro.url.origin).toString()
 
 const updatedFormatted = new Date(data.updatedAt).toLocaleDateString('en-US', {
   year: 'numeric',
@@ -57,12 +42,113 @@ const reachRows = data.data
     detail: `Released ${row.released}`,
     reach: row.cumulativeUsage,
   }))
+  .sort((a, b) => b.reach - a.reach)
+
+const newestMeeting = (target: number) => [...reachRows].filter((row) => row.reach >= target).sort((a, b) => a.reach - b.reach)[0]
+
+const cover95 = newestMeeting(95)
+const cover99 = newestMeeting(99)
+const cover999 = newestMeeting(99.9)
+const latestTracked = reachRows[reachRows.length - 1]
 
 const deviceRows = [...data.data].sort((a, b) => {
   const aReach = typeof a.cumulativeUsage === 'number' ? a.cumulativeUsage : -1
   const bReach = typeof b.cumulativeUsage === 'number' ? b.cumulativeUsage : -1
   return bReach - aReach
 })
+
+const title = 'iOS Version Distribution Chart | Deployment Target Usage'
+const description = cover95
+  ? `Live iOS version usage chart. As of ${updatedFormatted}, ${cover95.label} covers about ${formatPercent(cover95.reach)} of devices. Pick a deployment target or coverage goal for Capacitor, React Native, Flutter, and native iOS.`
+  : `Live iOS version usage chart. Pick a minimum iOS version or coverage target and see what share of devices your app can reach.`
+
+const faqItems = [
+  {
+    question: 'What is an iOS version distribution chart?',
+    answer:
+      'It shows cumulative iOS usage: the share of devices running at least a given major iOS version. That is the figure to use when you choose IPHONEOS_DEPLOYMENT_TARGET or a minimum supported iOS release.',
+  },
+  {
+    question: 'How do I choose an iOS deployment target from this data?',
+    answer: cover95
+      ? `Pick the coverage you need, then take the newest iOS version that still meets it. On this dataset, ${cover95.label} covers about ${formatPercent(cover95.reach)}. Move toward 99% or 99.9% if you must keep older iPhones, or accept a lower floor to use newer APIs sooner.`
+      : 'Pick the coverage you need, then take the newest iOS version that still meets it. Use the interactive planner above to test 95%, 99%, or 99.9% goals.',
+  },
+  {
+    question: 'Why is cumulative usage more useful than raw version share?',
+    answer: 'A deployment target means “this iOS version or newer.” Cumulative usage matches that rule. Raw share for one release understates how many devices can run the build.',
+  },
+  {
+    question: 'How often is this iOS usage data updated?',
+    answer: `Capgo refreshes the chart from ${data.source} daily. When the published numbers change, the JSON in the repo updates automatically. This page currently reflects data updated ${updatedFormatted}.`,
+  },
+  {
+    question: 'Does this help Capacitor and Ionic iOS apps?',
+    answer:
+      'Yes. Capacitor apps ship as native iOS binaries, so the deployment target controls App Store eligibility and device reach. Check this chart before raising the floor for plugins, Xcode upgrades, or cloud builds.',
+  },
+]
+
+const softwareApplication = createSoftwareApplicationLdJson(publicConfig, {
+  name: 'Capgo iOS Version Distribution Chart',
+  description,
+  url: Astro.url.href,
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Web',
+  offers: {
+    price: '0',
+    priceCurrency: 'USD',
+    availability: 'https://schema.org/InStock',
+  },
+})
+
+const faqLdJson = createFAQPageLdJson(publicConfig, {
+  url: Astro.url.href,
+  questions: faqItems,
+})
+
+const webPage = createWebPageLdJson(publicConfig, {
+  name: title,
+  description,
+  url: Astro.url.href,
+})
+
+const itemList = createItemListLdJson(publicConfig, {
+  url: Astro.url.href,
+  name: 'iOS cumulative version usage',
+  description: 'Cumulative share of devices that can run an app for each minimum iOS version.',
+  items: reachRows.slice(0, 12).map((row) => ({
+    name: `${row.label} (${formatPercent(row.reach)} cumulative)`,
+    description: row.detail,
+    url: Astro.url.href,
+  })),
+})
+
+const ldJSON = createLdJsonGraph(publicConfig, softwareApplication, {
+  includeOrganization: true,
+  includeBreadcrumbs: true,
+  breadcrumbs: [
+    { name: 'Home', url: toAbsoluteLocaleUrl('') },
+    { name: 'iOS distribution chart', url: Astro.url.href },
+  ],
+  additionalEntities: [faqLdJson, webPage, itemList],
+})
+
+const content = {
+  title,
+  description,
+  keywords:
+    'ios version distribution, ios version usage, ios market share, ios deployment target, iphoneos deployment target, ios cumulative usage, capacitor ios support, ionic ios version',
+  ldJSON,
+  articleModifiedTime: data.updatedAt,
+}
+
+const relatedLinks = [
+  { name: 'Android version distribution chart', href: getRelativeLocaleUrl(locale, 'android-distribution-chart') },
+  { name: 'iOS certificate generator', href: getRelativeLocaleUrl(locale, 'tools/ios-certificate-generator') },
+  { name: 'iOS UDID finder', href: getRelativeLocaleUrl(locale, 'tools/ios-udid-finder') },
+  { name: 'Capgo native build', href: getRelativeLocaleUrl(locale, 'native-build') },
+]
 ---
 
 <Layout content={content}>
@@ -73,12 +159,41 @@ const deviceRows = [...data.data].sort((a, b) => {
     </div>
 
     <div class="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-      <p class="font-mono text-sm font-semibold tracking-wide text-blue-300 uppercase">iOS support planner</p>
-      <h1 class="mt-4 max-w-[30ch] text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl">Choose a deployment target by the users you need to cover</h1>
-      <p class="mt-6 max-w-[48ch] text-lg text-pretty text-slate-300">
-        Cumulative usage tells you: if this iOS version is your floor, what percent of devices can run the app. Use it to set IPHONEOS_DEPLOYMENT_TARGET for Capacitor, React
-        Native, Flutter, or native iOS.
+      <p class="font-mono text-sm font-semibold tracking-wide text-blue-300 uppercase">iOS version distribution</p>
+      <h1 class="mt-4 max-w-[32ch] text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl">iOS version distribution chart for deployment target decisions</h1>
+      <p class="mt-6 max-w-[56ch] text-lg text-pretty text-slate-300">
+        Use this iOS usage chart to choose a deployment target by the users you still need to cover. Cumulative usage answers: if this iOS version is your floor, what percent of
+        iPhone and iPad devices can run your Capacitor, React Native, Flutter, or native app.
       </p>
+
+      <div class="mt-8 max-w-3xl rounded-2xl border border-white/10 bg-white/5 px-5 py-4">
+        <p class="text-base text-pretty text-slate-200 sm:text-sm">
+          As of {updatedFormatted}
+          {
+            cover95 && (
+              <>
+                , targeting <strong class="font-semibold text-white">{cover95.label}</strong> covers about{' '}
+                <strong class="font-semibold text-white tabular-nums">{formatPercent(cover95.reach)}</strong> of devices
+              </>
+            )
+          }
+          {
+            cover99 && (
+              <>
+                . A {formatPercent(99)} goal lands near <strong class="font-semibold text-white">{cover99.label}</strong>
+              </>
+            )
+          }
+          {
+            latestTracked && (
+              <>
+                . The newest tracked release with data is <strong class="font-semibold text-white">{latestTracked.label}</strong> at{' '}
+                <strong class="font-semibold text-white tabular-nums">{formatPercent(latestTracked.reach)}</strong>.
+              </>
+            )
+          }
+        </p>
+      </div>
 
       <dl class="mt-8 flex flex-wrap gap-x-6 gap-y-3 text-base text-slate-400 sm:text-sm">
         <div>
@@ -94,24 +209,64 @@ const deviceRows = [...data.data].sort((a, b) => {
             </a>
           </dd>
         </div>
+        {
+          cover999 && (
+            <div>
+              <dt class="sr-only">99.9 percent coverage target</dt>
+              <dd>
+                {formatPercent(99.9)} coverage: {cover999.label}
+              </dd>
+            </div>
+          )
+        }
       </dl>
 
       <p class="mt-8 text-base text-slate-300 sm:text-sm">
-        Need the Android min SDK?
+        Compare with Android min SDK coverage on the{' '}
         <a href={getRelativeLocaleUrl(locale, 'android-distribution-chart')} class="font-semibold text-white underline underline-offset-4 hover:text-blue-200">
-          Open Android distribution chart
+          Android version distribution chart
         </a>
+        .
       </p>
     </div>
   </section>
 
   <DistributionTargetChart platform="ios" rows={reachRows} versionLabel="iOS version" targetNoun="iOS version" />
 
+  <section class="border-b border-white/10 bg-slate-950 py-16 sm:py-20">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+      <p class="font-mono text-sm font-semibold tracking-wide text-blue-300 uppercase">How to use the chart</p>
+      <h2 class="mt-3 max-w-[40ch] text-3xl font-semibold tracking-tight text-balance text-white">How to pick an iOS deployment target from version usage data</h2>
+      <div class="mt-8 grid gap-8 lg:grid-cols-3">
+        <div>
+          <h3 class="text-xl font-semibold tracking-tight text-white">1. Set a coverage goal</h3>
+          <p class="mt-3 text-base text-pretty text-slate-400 sm:text-sm">
+            Decide how much of the iOS install base you must keep. Teams often start at 95% and only climb to 99% or 99.9% when older iPhones still matter.
+          </p>
+        </div>
+        <div>
+          <h3 class="text-xl font-semibold tracking-tight text-white">2. Use cumulative usage</h3>
+          <p class="mt-3 text-base text-pretty text-slate-400 sm:text-sm">
+            A deployment target means that iOS version or newer. Cumulative usage matches that definition and is the number to trust for App Store reach estimates.
+          </p>
+        </div>
+        <div>
+          <h3 class="text-xl font-semibold tracking-tight text-white">3. Take the newest safe floor</h3>
+          <p class="mt-3 text-base text-pretty text-slate-400 sm:text-sm">
+            Prefer the newest iOS version that still hits your goal. That unlocks newer APIs and Xcode defaults while protecting the users behind your coverage target.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <section class="border-b border-white/10 bg-slate-900 py-16 sm:py-20">
     <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
       <p class="font-mono text-sm font-semibold tracking-wide text-cyan-300 uppercase">Device coverage</p>
-      <h2 class="mt-3 max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">Last iOS version for devices</h2>
-      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">Which devices stop at each iOS version. Sorted by cumulative coverage, highest first.</p>
+      <h2 class="mt-3 max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">Last iOS version by device and cumulative usage</h2>
+      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">
+        See which devices stop at each major iOS release, sorted by cumulative coverage from highest to lowest.
+      </p>
 
       <div class="-mx-4 -my-2 mt-10 overflow-x-auto whitespace-nowrap sm:-mx-6 lg:-mx-8">
         <div class="inline-block min-w-full px-4 py-2 align-middle sm:px-6 lg:px-8">
@@ -139,6 +294,30 @@ const deviceRows = [...data.data].sort((a, b) => {
           </table>
         </div>
       </div>
+    </div>
+  </section>
+
+  <ToolFaq
+    title="iOS distribution FAQ"
+    intro="Answers for teams setting IPHONEOS_DEPLOYMENT_TARGET, planning Xcode upgrades, or reviewing Capacitor iOS support."
+    items={faqItems}
+  />
+
+  <section class="border-b border-white/10 bg-slate-950 py-16 sm:py-20">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+      <h2 class="max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">Related developer resources</h2>
+      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">Keep going with Android coverage data, Apple signing tools, and Capgo release workflows.</p>
+      <ul class="mt-8 grid gap-3 sm:grid-cols-2" role="list">
+        {
+          relatedLinks.map((link) => (
+            <li>
+              <a href={link.href} class="flex rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-base font-semibold text-white hover:border-blue-300/40 sm:text-sm">
+                {link.name}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
     </div>
   </section>
 

--- a/apps/web/src/pages/ios-distribution-chart.astro
+++ b/apps/web/src/pages/ios-distribution-chart.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from '@/layouts/Layout.astro'
 import DistributionRefreshPanel from '@/components/DistributionRefreshPanel.astro'
+import DistributionTargetChart from '@/components/DistributionTargetChart.astro'
+import { formatPercent } from '@/lib/formatPercent'
 import { createLdJsonGraph, createWebPageLdJson } from '@/lib/ldJson'
 import { getRelativeLocaleUrl } from '@/services/links'
 import iosDistribution from '@/data/ios-distribution.json'
@@ -24,12 +26,12 @@ const data = iosDistribution as IosData
 
 const locale = Astro.locals.locale
 const title = 'iOS Version Distribution Chart'
-const description = `Cumulative usage of each major iOS version. Data from ${data.source}, refreshed automatically.`
+const description = 'Pick a minimum iOS version (or a coverage target like 95%) and see what share of devices your app can reach. Auto-updated usage data.'
 
 const content = {
   title,
   description,
-  keywords: 'ios version distribution, ios version market share, ios usage, capacitor ios support',
+  keywords: 'ios version distribution, ios deployment target, ios usage, capacitor ios support, min ios version',
   ldJSON: createLdJsonGraph(
     Astro.locals.runtimeConfig.public,
     createWebPageLdJson(Astro.locals.runtimeConfig.public, {
@@ -41,20 +43,26 @@ const content = {
   ),
 }
 
-const updatedDate = new Date(data.updatedAt)
-const updatedFormatted = updatedDate.toLocaleDateString('en-US', {
+const updatedFormatted = new Date(data.updatedAt).toLocaleDateString('en-US', {
   year: 'numeric',
   month: 'long',
   day: 'numeric',
 })
 
-const rowsWithData = data.data.filter((row) => typeof row.cumulativeUsage === 'number')
-const latestVersion = rowsWithData[0]
+const reachRows = data.data
+  .filter((row): row is IosRow & { cumulativeUsage: number } => typeof row.cumulativeUsage === 'number')
+  .map((row) => ({
+    id: row.version,
+    label: row.version,
+    detail: `Released ${row.released}`,
+    reach: row.cumulativeUsage,
+  }))
 
-function formatPercent(value: number | null) {
-  if (value === null) return '—'
-  return `${value.toFixed(value < 1 ? 1 : value % 1 === 0 ? 0 : 1).replace(/\.0$/, '')}%`
-}
+const deviceRows = [...data.data].sort((a, b) => {
+  const aReach = typeof a.cumulativeUsage === 'number' ? a.cumulativeUsage : -1
+  const bReach = typeof b.cumulativeUsage === 'number' ? b.cumulativeUsage : -1
+  return bReach - aReach
+})
 ---
 
 <Layout content={content}>
@@ -65,10 +73,11 @@ function formatPercent(value: number | null) {
     </div>
 
     <div class="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-      <p class="font-mono text-sm font-semibold tracking-wide text-blue-300 uppercase">iOS platform data</p>
-      <h1 class="mt-4 max-w-[30ch] text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl">{title}</h1>
+      <p class="font-mono text-sm font-semibold tracking-wide text-blue-300 uppercase">iOS support planner</p>
+      <h1 class="mt-4 max-w-[30ch] text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl">Choose a deployment target by the users you need to cover</h1>
       <p class="mt-6 max-w-[48ch] text-lg text-pretty text-slate-300">
-        Cumulative usage of each major iOS version. Use it to pick a deployment target for your Capacitor, React Native, Flutter, or native iOS app.
+        Cumulative usage tells you: if this iOS version is your floor, what percent of devices can run the app. Use it to set IPHONEOS_DEPLOYMENT_TARGET for Capacitor, React
+        Native, Flutter, or native iOS.
       </p>
 
       <dl class="mt-8 flex flex-wrap gap-x-6 gap-y-3 text-base text-slate-400 sm:text-sm">
@@ -85,59 +94,24 @@ function formatPercent(value: number | null) {
             </a>
           </dd>
         </div>
-        {
-          latestVersion && (
-            <div>
-              <dt class="sr-only">Latest tracked version</dt>
-              <dd>
-                Latest tracked: {latestVersion.version} (<span class="tabular-nums">{formatPercent(latestVersion.cumulativeUsage)}</span>)
-              </dd>
-            </div>
-          )
-        }
       </dl>
 
       <p class="mt-8 text-base text-slate-300 sm:text-sm">
-        Need the Android version breakdown?
-        <a href={getRelativeLocaleUrl(locale, 'android-distribution-chart')} class="ml-1 font-semibold text-white underline underline-offset-4 hover:text-blue-200">
+        Need the Android min SDK?
+        <a href={getRelativeLocaleUrl(locale, 'android-distribution-chart')} class="font-semibold text-white underline underline-offset-4 hover:text-blue-200">
           Open Android distribution chart
         </a>
       </p>
     </div>
   </section>
 
-  <section class="border-b border-white/10 bg-slate-950 py-16 sm:py-20">
-    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-      <p class="font-mono text-sm font-semibold tracking-wide text-blue-300 uppercase">Cumulative usage</p>
-      <h2 class="mt-3 max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">iOS version cumulative usage</h2>
-      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">
-        Percentage of devices running at least a given iOS version. Higher is better for dropping older releases.
-      </p>
-
-      <div class="mt-10 divide-y divide-white/10 border-y border-white/10" role="list">
-        {
-          rowsWithData.map((row) => (
-            <div class="grid items-center gap-4 py-4 sm:grid-cols-[140px_1fr_5rem]" role="listitem">
-              <div class="min-w-0">
-                <p class="font-medium text-white">{row.version}</p>
-                <p class="mt-1 text-base text-slate-400 sm:text-sm">Released {row.released}</p>
-              </div>
-              <div class="h-3 w-full overflow-hidden rounded-full bg-white/10" aria-hidden="true">
-                <div class="h-full w-(--bar-width) rounded-full bg-linear-to-r from-blue-400 to-cyan-400" style={`--bar-width: ${Math.min(100, row.cumulativeUsage ?? 0)}%`} />
-              </div>
-              <p class="text-right font-mono text-base font-semibold text-white tabular-nums sm:text-sm">{formatPercent(row.cumulativeUsage)}</p>
-            </div>
-          ))
-        }
-      </div>
-    </div>
-  </section>
+  <DistributionTargetChart platform="ios" rows={reachRows} versionLabel="iOS version" targetNoun="iOS version" />
 
   <section class="border-b border-white/10 bg-slate-900 py-16 sm:py-20">
     <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
       <p class="font-mono text-sm font-semibold tracking-wide text-cyan-300 uppercase">Device coverage</p>
       <h2 class="mt-3 max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">Last iOS version for devices</h2>
-      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">Which devices are capped at each iOS version. Useful when you plan minimum OS support.</p>
+      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">Which devices stop at each iOS version. Sorted by cumulative coverage, highest first.</p>
 
       <div class="-mx-4 -my-2 mt-10 overflow-x-auto whitespace-nowrap sm:-mx-6 lg:-mx-8">
         <div class="inline-block min-w-full px-4 py-2 align-middle sm:px-6 lg:px-8">
@@ -152,23 +126,11 @@ function formatPercent(value: number | null) {
             </thead>
             <tbody class="divide-y divide-white/10">
               {
-                data.data.map((row) => (
+                deviceRows.map((row) => (
                   <tr>
                     <td class="py-3 pr-4 font-medium whitespace-nowrap text-white">{row.version}</td>
                     <td class="py-3 pr-4 text-slate-400 tabular-nums">{row.released}</td>
-                    <td class="py-3 pr-4">
-                      <div class="flex items-center gap-3">
-                        <span class="font-mono font-semibold text-white tabular-nums">{formatPercent(row.cumulativeUsage)}</span>
-                        {typeof row.cumulativeUsage === 'number' && (
-                          <div class="hidden h-2 w-24 overflow-hidden rounded-full bg-white/10 sm:block sm:w-32" aria-hidden="true">
-                            <div
-                              class="h-full w-(--bar-width) rounded-full bg-linear-to-r from-cyan-400 to-blue-500"
-                              style={`--bar-width: ${Math.min(100, row.cumulativeUsage)}%`}
-                            />
-                          </div>
-                        )}
-                      </div>
-                    </td>
+                    <td class="py-3 pr-4 font-mono font-semibold text-white tabular-nums">{formatPercent(row.cumulativeUsage)}</td>
                     <td class="max-w-xs py-3 whitespace-normal text-slate-400">{row.lastIosFor || '—'}</td>
                   </tr>
                 ))

--- a/apps/web/src/pages/ios-distribution-chart.astro
+++ b/apps/web/src/pages/ios-distribution-chart.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '@/layouts/Layout.astro'
+import DistributionRefreshPanel from '@/components/DistributionRefreshPanel.astro'
 import { createLdJsonGraph, createWebPageLdJson } from '@/lib/ldJson'
 import { getRelativeLocaleUrl } from '@/services/links'
 import iosDistribution from '@/data/ios-distribution.json'
@@ -58,77 +59,73 @@ function formatPercent(value: number | null) {
 
 <Layout content={content}>
   <section class="relative overflow-hidden border-b border-white/10 bg-linear-to-b from-slate-950 via-slate-900 to-slate-950 py-16 sm:py-20">
-    <div class="pointer-events-none absolute inset-0">
-      <div class="absolute top-10 -left-16 h-72 w-72 rounded-full bg-blue-500/10 blur-3xl"></div>
-      <div class="absolute top-0 right-0 h-80 w-80 rounded-full bg-cyan-500/10 blur-3xl"></div>
+    <div class="pointer-events-none absolute inset-0" aria-hidden="true">
+      <div class="absolute top-10 -left-16 size-72 rounded-full bg-blue-500/10 blur-3xl"></div>
+      <div class="absolute top-0 right-0 size-80 rounded-full bg-cyan-500/10 blur-3xl"></div>
     </div>
 
     <div class="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-      <div class="max-w-4xl">
-        <p class="text-sm font-semibold tracking-[0.3em] text-blue-300 uppercase">iOS platform data</p>
-        <h1 class="mt-4 text-4xl font-bold tracking-tight text-white sm:text-5xl">{title}</h1>
-        <p class="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
-          Cumulative usage of each major iOS version. Use it to pick a deployment target for your Capacitor, React Native, Flutter, or native iOS app.
-        </p>
+      <p class="font-mono text-sm font-semibold tracking-wide text-blue-300 uppercase">iOS platform data</p>
+      <h1 class="mt-4 max-w-[30ch] text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl">{title}</h1>
+      <p class="mt-6 max-w-[48ch] text-lg text-pretty text-slate-300">
+        Cumulative usage of each major iOS version. Use it to pick a deployment target for your Capacitor, React Native, Flutter, or native iOS app.
+      </p>
 
-        <div class="mt-8 flex flex-wrap items-center gap-4 text-sm text-slate-400">
-          <span class="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1">
-            Updated {updatedFormatted}
-          </span>
-          <span class="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1">
+      <dl class="mt-8 flex flex-wrap gap-x-6 gap-y-3 text-base text-slate-400 sm:text-sm">
+        <div>
+          <dt class="sr-only">Last updated</dt>
+          <dd>Updated {updatedFormatted}</dd>
+        </div>
+        <div class="min-w-0">
+          <dt class="sr-only">Source</dt>
+          <dd>
             Source:
-            <a href={data.sourceUrl} target="_blank" rel="noopener noreferrer" class="ml-1 text-blue-300 underline underline-offset-4 hover:text-blue-200">
+            <a href={data.sourceUrl} target="_blank" rel="noopener noreferrer" class="text-blue-300 underline underline-offset-4 hover:text-blue-200">
               {data.source}
             </a>
-          </span>
-          {
-            latestVersion && (
-              <span class="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1">
-                Latest tracked: {latestVersion.version} ({formatPercent(latestVersion.cumulativeUsage)})
-              </span>
-            )
-          }
+          </dd>
         </div>
+        {
+          latestVersion && (
+            <div>
+              <dt class="sr-only">Latest tracked version</dt>
+              <dd>
+                Latest tracked: {latestVersion.version} (<span class="tabular-nums">{formatPercent(latestVersion.cumulativeUsage)}</span>)
+              </dd>
+            </div>
+          )
+        }
+      </dl>
 
-        <div class="mt-8 rounded-2xl border border-white/10 bg-white/5 p-5 sm:flex sm:items-center sm:justify-between">
-          <div>
-            <p class="text-sm font-semibold text-white">Need the Android version breakdown?</p>
-            <p class="text-sm text-slate-400">Compare Android version market share on the companion page.</p>
-          </div>
-          <a
-            href={getRelativeLocaleUrl(locale, 'android-distribution-chart')}
-            class="mt-4 inline-flex items-center justify-center rounded-xl border border-white/15 px-5 py-2.5 text-sm font-semibold text-white transition hover:border-green-300/60 hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-green-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 focus-visible:outline-none sm:mt-0"
-          >
-            Open Android distribution chart
-          </a>
-        </div>
-      </div>
+      <p class="mt-8 text-base text-slate-300 sm:text-sm">
+        Need the Android version breakdown?
+        <a href={getRelativeLocaleUrl(locale, 'android-distribution-chart')} class="ml-1 font-semibold text-white underline underline-offset-4 hover:text-blue-200">
+          Open Android distribution chart
+        </a>
+      </p>
     </div>
   </section>
 
   <section class="border-b border-white/10 bg-slate-950 py-16 sm:py-20">
     <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-      <div class="mb-10">
-        <p class="text-sm font-semibold tracking-[0.25em] text-blue-300 uppercase">Cumulative usage</p>
-        <h2 class="mt-3 text-3xl font-bold text-white">iOS version cumulative usage</h2>
-        <p class="mt-3 text-slate-400">Percentage of devices running at least a given iOS version. Higher is better for dropping older releases.</p>
-      </div>
+      <p class="font-mono text-sm font-semibold tracking-wide text-blue-300 uppercase">Cumulative usage</p>
+      <h2 class="mt-3 max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">iOS version cumulative usage</h2>
+      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">
+        Percentage of devices running at least a given iOS version. Higher is better for dropping older releases.
+      </p>
 
-      <div class="space-y-3">
+      <div class="mt-10 divide-y divide-white/10 border-y border-white/10" role="list">
         {
           rowsWithData.map((row) => (
-            <div class="group grid items-center gap-4 rounded-xl border border-white/10 bg-white/[0.03] p-3 sm:grid-cols-[140px_1fr_80px]">
-              <div>
+            <div class="grid items-center gap-4 py-4 sm:grid-cols-[140px_1fr_5rem]" role="listitem">
+              <div class="min-w-0">
                 <p class="font-medium text-white">{row.version}</p>
-                <p class="text-xs text-slate-400">Released {row.released}</p>
+                <p class="mt-1 text-base text-slate-400 sm:text-sm">Released {row.released}</p>
               </div>
-              <div class="h-3 w-full overflow-hidden rounded-full bg-white/10">
-                <div
-                  class="h-full rounded-full bg-linear-to-r from-blue-400 to-cyan-400 transition-all duration-700 ease-out"
-                  style={`width: ${Math.min(100, row.cumulativeUsage ?? 0)}%`}
-                />
+              <div class="h-3 w-full overflow-hidden rounded-full bg-white/10" aria-hidden="true">
+                <div class="h-full w-(--bar-width) rounded-full bg-linear-to-r from-blue-400 to-cyan-400" style={`--bar-width: ${Math.min(100, row.cumulativeUsage ?? 0)}%`} />
               </div>
-              <p class="text-right font-mono text-sm font-semibold text-white">{formatPercent(row.cumulativeUsage)}</p>
+              <p class="text-right font-mono text-base font-semibold text-white tabular-nums sm:text-sm">{formatPercent(row.cumulativeUsage)}</p>
             </div>
           ))
         }
@@ -138,73 +135,50 @@ function formatPercent(value: number | null) {
 
   <section class="border-b border-white/10 bg-slate-900 py-16 sm:py-20">
     <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-      <div class="mb-10">
-        <p class="text-sm font-semibold tracking-[0.25em] text-cyan-300 uppercase">Device coverage</p>
-        <h2 class="mt-3 text-3xl font-bold text-white">Last iOS version for devices</h2>
-        <p class="mt-3 text-slate-400">Which devices are capped at each iOS version. Useful when you plan minimum OS support.</p>
-      </div>
+      <p class="font-mono text-sm font-semibold tracking-wide text-cyan-300 uppercase">Device coverage</p>
+      <h2 class="mt-3 max-w-[35ch] text-3xl font-semibold tracking-tight text-balance text-white">Last iOS version for devices</h2>
+      <p class="mt-3 max-w-[56ch] text-base text-pretty text-slate-400 sm:text-sm">Which devices are capped at each iOS version. Useful when you plan minimum OS support.</p>
 
-      <div class="overflow-x-auto rounded-2xl border border-white/10">
-        <table class="w-full text-left text-sm">
-          <thead class="border-b border-white/10 bg-white/5 text-slate-400">
-            <tr>
-              <th class="px-4 py-3 font-medium">Version</th>
-              <th class="px-4 py-3 font-medium">Released</th>
-              <th class="px-4 py-3 font-medium">Cumulative usage</th>
-              <th class="px-4 py-3 font-medium">Last iOS for</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-white/10">
-            {
-              data.data.map((row) => (
-                <tr class="hover:bg-white/[0.03]">
-                  <td class="px-4 py-3 font-medium text-white">{row.version}</td>
-                  <td class="px-4 py-3 text-slate-400">{row.released}</td>
-                  <td class="px-4 py-3">
-                    <div class="flex items-center gap-3">
-                      <span class="font-mono font-semibold text-white">{formatPercent(row.cumulativeUsage)}</span>
-                      {typeof row.cumulativeUsage === 'number' && (
-                        <div class="hidden h-2 w-24 overflow-hidden rounded-full bg-white/10 sm:block sm:w-32">
-                          <div class="h-full rounded-full bg-linear-to-r from-cyan-400 to-blue-500" style={`width: ${Math.min(100, row.cumulativeUsage)}%`} />
-                        </div>
-                      )}
-                    </div>
-                  </td>
-                  <td class="max-w-xs px-4 py-3 text-slate-400">{row.lastIosFor || '—'}</td>
-                </tr>
-              ))
-            }
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </section>
-
-  <section class="bg-slate-950 py-16 sm:py-20">
-    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-      <div class="rounded-3xl border border-white/10 bg-white/5 p-8 sm:p-10">
-        <h2 class="text-2xl font-bold text-white">How this data is kept current</h2>
-        <p class="mt-4 max-w-3xl text-sm leading-7 text-slate-300">
-          A daily job fetches the latest numbers from the sources above. If the figures changed, the JSON files are committed automatically; if not, the repo stays untouched. The
-          pages read these files at build time, so the charts are always in sync with the latest published data.
-        </p>
-        <div class="mt-6 flex flex-col gap-3 sm:flex-row">
-          <a
-            href={getRelativeLocaleUrl(locale, 'android-distribution-chart')}
-            class="inline-flex items-center justify-center rounded-xl bg-blue-400 px-5 py-2.5 text-sm font-semibold text-slate-950 transition hover:bg-blue-300 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 focus-visible:outline-none"
-          >
-            See Android distribution chart
-          </a>
-          <a
-            href="https://github.com/Cap-go/landing/tree/main/apps/web/src/data"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex items-center justify-center rounded-xl border border-white/15 px-5 py-2.5 text-sm font-semibold text-white transition hover:border-blue-300/60 hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 focus-visible:outline-none"
-          >
-            View raw data
-          </a>
+      <div class="-mx-4 -my-2 mt-10 overflow-x-auto whitespace-nowrap sm:-mx-6 lg:-mx-8">
+        <div class="inline-block min-w-full px-4 py-2 align-middle sm:px-6 lg:px-8">
+          <table class="w-full text-left text-base sm:text-sm">
+            <thead class="border-b border-white/10 text-slate-400">
+              <tr>
+                <th class="py-3 pr-4 font-medium whitespace-nowrap">Version</th>
+                <th class="py-3 pr-4 font-medium whitespace-nowrap">Released</th>
+                <th class="py-3 pr-4 font-medium whitespace-nowrap">Cumulative usage</th>
+                <th class="py-3 font-medium whitespace-nowrap">Last iOS for</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-white/10">
+              {
+                data.data.map((row) => (
+                  <tr>
+                    <td class="py-3 pr-4 font-medium whitespace-nowrap text-white">{row.version}</td>
+                    <td class="py-3 pr-4 text-slate-400 tabular-nums">{row.released}</td>
+                    <td class="py-3 pr-4">
+                      <div class="flex items-center gap-3">
+                        <span class="font-mono font-semibold text-white tabular-nums">{formatPercent(row.cumulativeUsage)}</span>
+                        {typeof row.cumulativeUsage === 'number' && (
+                          <div class="hidden h-2 w-24 overflow-hidden rounded-full bg-white/10 sm:block sm:w-32" aria-hidden="true">
+                            <div
+                              class="h-full w-(--bar-width) rounded-full bg-linear-to-r from-cyan-400 to-blue-500"
+                              style={`--bar-width: ${Math.min(100, row.cumulativeUsage)}%`}
+                            />
+                          </div>
+                        )}
+                      </div>
+                    </td>
+                    <td class="max-w-xs py-3 whitespace-normal text-slate-400">{row.lastIosFor || '—'}</td>
+                  </tr>
+                ))
+              }
+            </tbody>
+          </table>
         </div>
       </div>
     </div>
   </section>
+
+  <DistributionRefreshPanel accent="blue" companionHref="android-distribution-chart" companionLabel="See Android distribution chart" />
 </Layout>

--- a/apps/web/src/pages/ios-distribution-chart.astro
+++ b/apps/web/src/pages/ios-distribution-chart.astro
@@ -1,0 +1,210 @@
+---
+import Layout from '@/layouts/Layout.astro'
+import { createLdJsonGraph, createWebPageLdJson } from '@/lib/ldJson'
+import { getRelativeLocaleUrl } from '@/services/links'
+import iosDistribution from '@/data/ios-distribution.json'
+
+interface IosRow {
+  version: string
+  released: string
+  cumulativeUsage: number | null
+  lastIosFor: string
+}
+
+interface IosData {
+  updatedAt: string
+  source: string
+  sourceUrl: string
+  fetchedAt: string
+  data: IosRow[]
+}
+
+const data = iosDistribution as IosData
+
+const locale = Astro.locals.locale
+const title = 'iOS Version Distribution Chart'
+const description = `Cumulative usage of each major iOS version. Data from ${data.source}, refreshed automatically.`
+
+const content = {
+  title,
+  description,
+  keywords: 'ios version distribution, ios version market share, ios usage, capacitor ios support',
+  ldJSON: createLdJsonGraph(
+    Astro.locals.runtimeConfig.public,
+    createWebPageLdJson(Astro.locals.runtimeConfig.public, {
+      name: title,
+      description,
+      url: Astro.url.href,
+    }),
+    { includeOrganization: true },
+  ),
+}
+
+const updatedDate = new Date(data.updatedAt)
+const updatedFormatted = updatedDate.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+})
+
+const rowsWithData = data.data.filter((row) => typeof row.cumulativeUsage === 'number')
+const latestVersion = rowsWithData[0]
+
+function formatPercent(value: number | null) {
+  if (value === null) return '—'
+  return `${value.toFixed(value < 1 ? 1 : value % 1 === 0 ? 0 : 1).replace(/\.0$/, '')}%`
+}
+---
+
+<Layout content={content}>
+  <section class="relative overflow-hidden border-b border-white/10 bg-linear-to-b from-slate-950 via-slate-900 to-slate-950 py-16 sm:py-20">
+    <div class="pointer-events-none absolute inset-0">
+      <div class="absolute top-10 -left-16 h-72 w-72 rounded-full bg-blue-500/10 blur-3xl"></div>
+      <div class="absolute top-0 right-0 h-80 w-80 rounded-full bg-cyan-500/10 blur-3xl"></div>
+    </div>
+
+    <div class="relative mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+      <div class="max-w-4xl">
+        <p class="text-sm font-semibold tracking-[0.3em] text-blue-300 uppercase">iOS platform data</p>
+        <h1 class="mt-4 text-4xl font-bold tracking-tight text-white sm:text-5xl">{title}</h1>
+        <p class="mt-6 max-w-3xl text-lg leading-8 text-slate-300">
+          Cumulative usage of each major iOS version. Use it to pick a deployment target for your Capacitor, React Native, Flutter, or native iOS app.
+        </p>
+
+        <div class="mt-8 flex flex-wrap items-center gap-4 text-sm text-slate-400">
+          <span class="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1">
+            Updated {updatedFormatted}
+          </span>
+          <span class="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1">
+            Source:
+            <a href={data.sourceUrl} target="_blank" rel="noopener noreferrer" class="ml-1 text-blue-300 underline underline-offset-4 hover:text-blue-200">
+              {data.source}
+            </a>
+          </span>
+          {
+            latestVersion && (
+              <span class="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-3 py-1">
+                Latest tracked: {latestVersion.version} ({formatPercent(latestVersion.cumulativeUsage)})
+              </span>
+            )
+          }
+        </div>
+
+        <div class="mt-8 rounded-2xl border border-white/10 bg-white/5 p-5 sm:flex sm:items-center sm:justify-between">
+          <div>
+            <p class="text-sm font-semibold text-white">Need the Android version breakdown?</p>
+            <p class="text-sm text-slate-400">Compare Android version market share on the companion page.</p>
+          </div>
+          <a
+            href={getRelativeLocaleUrl(locale, 'android-distribution-chart')}
+            class="mt-4 inline-flex items-center justify-center rounded-xl border border-white/15 px-5 py-2.5 text-sm font-semibold text-white transition hover:border-green-300/60 hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-green-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 focus-visible:outline-none sm:mt-0"
+          >
+            Open Android distribution chart
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="border-b border-white/10 bg-slate-950 py-16 sm:py-20">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+      <div class="mb-10">
+        <p class="text-sm font-semibold tracking-[0.25em] text-blue-300 uppercase">Cumulative usage</p>
+        <h2 class="mt-3 text-3xl font-bold text-white">iOS version cumulative usage</h2>
+        <p class="mt-3 text-slate-400">Percentage of devices running at least a given iOS version. Higher is better for dropping older releases.</p>
+      </div>
+
+      <div class="space-y-3">
+        {
+          rowsWithData.map((row) => (
+            <div class="group grid items-center gap-4 rounded-xl border border-white/10 bg-white/[0.03] p-3 sm:grid-cols-[140px_1fr_80px]">
+              <div>
+                <p class="font-medium text-white">{row.version}</p>
+                <p class="text-xs text-slate-400">Released {row.released}</p>
+              </div>
+              <div class="h-3 w-full overflow-hidden rounded-full bg-white/10">
+                <div
+                  class="h-full rounded-full bg-linear-to-r from-blue-400 to-cyan-400 transition-all duration-700 ease-out"
+                  style={`width: ${Math.min(100, row.cumulativeUsage ?? 0)}%`}
+                />
+              </div>
+              <p class="text-right font-mono text-sm font-semibold text-white">{formatPercent(row.cumulativeUsage)}</p>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <section class="border-b border-white/10 bg-slate-900 py-16 sm:py-20">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+      <div class="mb-10">
+        <p class="text-sm font-semibold tracking-[0.25em] text-cyan-300 uppercase">Device coverage</p>
+        <h2 class="mt-3 text-3xl font-bold text-white">Last iOS version for devices</h2>
+        <p class="mt-3 text-slate-400">Which devices are capped at each iOS version. Useful when you plan minimum OS support.</p>
+      </div>
+
+      <div class="overflow-x-auto rounded-2xl border border-white/10">
+        <table class="w-full text-left text-sm">
+          <thead class="border-b border-white/10 bg-white/5 text-slate-400">
+            <tr>
+              <th class="px-4 py-3 font-medium">Version</th>
+              <th class="px-4 py-3 font-medium">Released</th>
+              <th class="px-4 py-3 font-medium">Cumulative usage</th>
+              <th class="px-4 py-3 font-medium">Last iOS for</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-white/10">
+            {
+              data.data.map((row) => (
+                <tr class="hover:bg-white/[0.03]">
+                  <td class="px-4 py-3 font-medium text-white">{row.version}</td>
+                  <td class="px-4 py-3 text-slate-400">{row.released}</td>
+                  <td class="px-4 py-3">
+                    <div class="flex items-center gap-3">
+                      <span class="font-mono font-semibold text-white">{formatPercent(row.cumulativeUsage)}</span>
+                      {typeof row.cumulativeUsage === 'number' && (
+                        <div class="hidden h-2 w-24 overflow-hidden rounded-full bg-white/10 sm:block sm:w-32">
+                          <div class="h-full rounded-full bg-linear-to-r from-cyan-400 to-blue-500" style={`width: ${Math.min(100, row.cumulativeUsage)}%`} />
+                        </div>
+                      )}
+                    </div>
+                  </td>
+                  <td class="max-w-xs px-4 py-3 text-slate-400">{row.lastIosFor || '—'}</td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <section class="bg-slate-950 py-16 sm:py-20">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+      <div class="rounded-3xl border border-white/10 bg-white/5 p-8 sm:p-10">
+        <h2 class="text-2xl font-bold text-white">How this data is kept current</h2>
+        <p class="mt-4 max-w-3xl text-sm leading-7 text-slate-300">
+          A daily job fetches the latest numbers from the sources above. If the figures changed, the JSON files are committed automatically; if not, the repo stays untouched. The
+          pages read these files at build time, so the charts are always in sync with the latest published data.
+        </p>
+        <div class="mt-6 flex flex-col gap-3 sm:flex-row">
+          <a
+            href={getRelativeLocaleUrl(locale, 'android-distribution-chart')}
+            class="inline-flex items-center justify-center rounded-xl bg-blue-400 px-5 py-2.5 text-sm font-semibold text-slate-950 transition hover:bg-blue-300 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 focus-visible:outline-none"
+          >
+            See Android distribution chart
+          </a>
+          <a
+            href="https://github.com/Cap-go/landing/tree/main/apps/web/src/data"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center justify-center rounded-xl border border-white/15 px-5 py-2.5 text-sm font-semibold text-white transition hover:border-blue-300/60 hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 focus-visible:outline-none"
+          >
+            View raw data
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</Layout>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "refresh:website-stats": "WEBSITE_STATS_REFRESH=true bun run scripts/fetch-website-stats.ts",
     "refresh:stars": "GITHUB_STATS_REFRESH=true bun run scripts/fetch-github-stars.ts",
     "refresh:downloads": "NPM_DOWNLOADS_REFRESH=true bun run scripts/fetch-npm-downloads.ts",
+    "scrape:distribution-charts": "bun run scripts/scrape-distribution-charts.ts",
     "generate:social-images": "bun run scripts/generate-social-images.ts",
     "just:build": "bun run build",
     "build:web": "cd apps/web && bun run build",

--- a/scripts/scrape-distribution-charts.ts
+++ b/scripts/scrape-distribution-charts.ts
@@ -45,10 +45,12 @@ function parsePercent(text: string): number | null {
   return Number.isFinite(value) ? value : null
 }
 
-function parseDate(text: string): string {
-  const date = new Date(text)
-  if (!Number.isNaN(date.getTime())) return date.toISOString()
-  return new Date().toISOString()
+function parseRequiredDate(text: string, label: string): string {
+  const trimmed = text.trim()
+  if (!trimmed) throw new Error(`Missing ${label} update date in source HTML`)
+  const date = new Date(trimmed)
+  if (Number.isNaN(date.getTime())) throw new Error(`Unparseable ${label} update date: ${trimmed}`)
+  return date.toISOString()
 }
 
 async function fetchHtml(url: string): Promise<string> {
@@ -68,6 +70,9 @@ async function scrapeAndroid(): Promise<AndroidData> {
 
   const updatedText = $('.distribution-updated time').text().trim()
   const tables = $('.distribution-table')
+  if (tables.length < 2) {
+    throw new Error(`Expected 2 Android distribution tables, found ${tables.length}`)
+  }
 
   const parseTable = (index: number): AndroidApiRow[] => {
     const rows: AndroidApiRow[] = []
@@ -82,20 +87,26 @@ async function scrapeAndroid(): Promise<AndroidData> {
         const api = /^\d+$/.test(apiText) ? Number(apiText) : null
         const distributionText = cells.eq(2).find('.titleSmall').last().text().trim() || cells.eq(2).text().trim()
         const distribution = parsePercent(distributionText)
-        if (distribution !== null) {
+        if (version && distribution !== null) {
           rows.push({ version, api, distribution })
         }
       })
     return rows
   }
 
+  const apiDistribution = parseTable(0)
+  const cumulativeDistribution = parseTable(1)
+  if (apiDistribution.length === 0 || cumulativeDistribution.length === 0) {
+    throw new Error(`Android tables parsed empty (api=${apiDistribution.length}, cumulative=${cumulativeDistribution.length})`)
+  }
+
   return {
-    updatedAt: parseDate(updatedText || new Date().toDateString()),
+    updatedAt: parseRequiredDate(updatedText, 'Android'),
     source: 'Composables Android Distribution Chart',
     sourceUrl: ANDROID_URL,
     fetchedAt: new Date().toISOString(),
-    apiDistribution: parseTable(0),
-    cumulativeDistribution: parseTable(1),
+    apiDistribution,
+    cumulativeDistribution,
   }
 }
 
@@ -103,7 +114,6 @@ async function scrapeIos(): Promise<IosData> {
   const html = await fetchHtml(IOS_URL)
   const $ = cheerio.load(html)
 
-  // cheerio .text() strips tags, so match plain text like "last updated on June 6, 2026"
   const sourceText = $('#page-content p')
     .filter((_, el) => $(el).text().includes('last updated'))
     .text()
@@ -119,11 +129,17 @@ async function scrapeIos(): Promise<IosData> {
     const usageText = cells.eq(2).find('.titleSmall').last().text().trim() || cells.eq(2).text().trim()
     const cumulativeUsage = parsePercent(usageText)
     const lastIosFor = cells.length >= 4 ? cells.eq(3).text().trim().replace(/\s+/g, ' ') : ''
+    if (!version) return
     rows.push({ version, released, cumulativeUsage, lastIosFor })
   })
 
+  const rowsWithUsage = rows.filter((row) => typeof row.cumulativeUsage === 'number')
+  if (rows.length === 0 || rowsWithUsage.length === 0) {
+    throw new Error(`iOS table parsed empty (rows=${rows.length}, withUsage=${rowsWithUsage.length})`)
+  }
+
   return {
-    updatedAt: parseDate(updatedText || new Date().toDateString()),
+    updatedAt: parseRequiredDate(updatedText, 'iOS'),
     source: 'iOS Ref',
     sourceUrl: IOS_URL,
     fetchedAt: new Date().toISOString(),
@@ -152,15 +168,32 @@ function writeIfChanged(filePath: string, data: { fetchedAt: string }): boolean 
   return true
 }
 
-const changed: string[] = []
+async function scrapeAndWrite(label: string, repoPath: string, filePath: string, scrape: () => Promise<{ fetchedAt: string }>): Promise<{ changed: boolean; ok: boolean }> {
+  try {
+    const data = await scrape()
+    const changed = writeIfChanged(filePath, data)
+    return { changed, ok: true }
+  } catch (err) {
+    console.error(`${label} scrape failed:`, err)
+    return { changed: false, ok: false }
+  }
+}
 
 async function main() {
-  const android = await scrapeAndroid()
-  const ios = await scrapeIos()
-  if (writeIfChanged(ANDROID_FILE, android)) changed.push('apps/web/src/data/android-distribution.json')
-  if (writeIfChanged(IOS_FILE, ios)) changed.push('apps/web/src/data/ios-distribution.json')
+  const [android, ios] = await Promise.all([
+    scrapeAndWrite('Android', 'apps/web/src/data/android-distribution.json', ANDROID_FILE, scrapeAndroid),
+    scrapeAndWrite('iOS', 'apps/web/src/data/ios-distribution.json', IOS_FILE, scrapeIos),
+  ])
 
-  console.log(JSON.stringify({ changed }, null, 2))
+  const changed: string[] = []
+  if (android.changed) changed.push('apps/web/src/data/android-distribution.json')
+  if (ios.changed) changed.push('apps/web/src/data/ios-distribution.json')
+
+  console.log(JSON.stringify({ changed, androidOk: android.ok, iosOk: ios.ok }, null, 2))
+
+  if (!android.ok && !ios.ok) {
+    process.exit(1)
+  }
 }
 
 main().catch((err) => {

--- a/scripts/scrape-distribution-charts.ts
+++ b/scripts/scrape-distribution-charts.ts
@@ -1,0 +1,162 @@
+import * as cheerio from 'cheerio'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ANDROID_URL = 'https://composables.com/android-distribution-chart'
+const IOS_URL = 'https://iosref.com/ios-usage'
+
+const DATA_DIR = path.join(import.meta.dir, '..', 'apps', 'web', 'src', 'data')
+const ANDROID_FILE = path.join(DATA_DIR, 'android-distribution.json')
+const IOS_FILE = path.join(DATA_DIR, 'ios-distribution.json')
+
+interface AndroidApiRow {
+  version: string
+  api: number | null
+  distribution: number
+}
+
+interface AndroidData {
+  updatedAt: string
+  source: string
+  sourceUrl: string
+  fetchedAt: string
+  apiDistribution: AndroidApiRow[]
+  cumulativeDistribution: AndroidApiRow[]
+}
+
+interface IosRow {
+  version: string
+  released: string
+  cumulativeUsage: number | null
+  lastIosFor: string
+}
+
+interface IosData {
+  updatedAt: string
+  source: string
+  sourceUrl: string
+  fetchedAt: string
+  data: IosRow[]
+}
+
+function parsePercent(text: string): number | null {
+  const clean = text.replace(/,/g, '').replace(/%/g, '').trim()
+  const value = parseFloat(clean)
+  return Number.isFinite(value) ? value : null
+}
+
+function parseDate(text: string): string {
+  const date = new Date(text)
+  if (!Number.isNaN(date.getTime())) return date.toISOString()
+  return new Date().toISOString()
+}
+
+async function fetchHtml(url: string): Promise<string> {
+  const res = await fetch(url, {
+    headers: {
+      Accept: 'text/html',
+      'User-Agent': 'Mozilla/5.0 (compatible; CapgoBot/1.0; +https://capgo.app)',
+    },
+  })
+  if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`)
+  return res.text()
+}
+
+async function scrapeAndroid(): Promise<AndroidData> {
+  const html = await fetchHtml(ANDROID_URL)
+  const $ = cheerio.load(html)
+
+  const updatedText = $('.distribution-updated time').text().trim()
+  const tables = $('.distribution-table')
+
+  const parseTable = (index: number): AndroidApiRow[] => {
+    const rows: AndroidApiRow[] = []
+    tables
+      .eq(index)
+      .find('tbody tr')
+      .each((_, tr) => {
+        const cells = $(tr).find('td')
+        if (cells.length < 3) return
+        const version = cells.eq(0).text().trim()
+        const apiText = cells.eq(1).text().trim()
+        const api = /^\d+$/.test(apiText) ? Number(apiText) : null
+        const distributionText = cells.eq(2).find('.titleSmall').last().text().trim() || cells.eq(2).text().trim()
+        const distribution = parsePercent(distributionText)
+        if (distribution !== null) {
+          rows.push({ version, api, distribution })
+        }
+      })
+    return rows
+  }
+
+  return {
+    updatedAt: parseDate(updatedText || new Date().toDateString()),
+    source: 'Composables Android Distribution Chart',
+    sourceUrl: ANDROID_URL,
+    fetchedAt: new Date().toISOString(),
+    apiDistribution: parseTable(0),
+    cumulativeDistribution: parseTable(1),
+  }
+}
+
+async function scrapeIos(): Promise<IosData> {
+  const html = await fetchHtml(IOS_URL)
+  const $ = cheerio.load(html)
+
+  const sourceText = $('#page-content p')
+    .filter((_, el) => $(el).text().includes('last updated'))
+    .text()
+  const updatedMatch = sourceText.match(/last updated on\s*<b>([^<]+)<\/b>/i)
+  const updatedText = updatedMatch ? updatedMatch[1].trim() : ''
+
+  const rows: IosRow[] = []
+  $('.table.table-bordered tbody tr').each((_, tr) => {
+    const cells = $(tr).find('td')
+    if (cells.length < 3) return
+    const version = cells.eq(0).text().replace(/BETA/g, '').trim()
+    const released = cells.eq(1).text().trim()
+    const usageText = cells.eq(2).find('.titleSmall').last().text().trim() || cells.eq(2).text().trim()
+    const cumulativeUsage = parsePercent(usageText)
+    const lastIosFor = cells.length >= 4 ? cells.eq(3).text().trim().replace(/\s+/g, ' ') : ''
+    rows.push({ version, released, cumulativeUsage, lastIosFor })
+  })
+
+  return {
+    updatedAt: parseDate(updatedText || new Date().toDateString()),
+    source: 'iOS Ref',
+    sourceUrl: IOS_URL,
+    fetchedAt: new Date().toISOString(),
+    data: rows,
+  }
+}
+
+function writeIfChanged(filePath: string, data: unknown): boolean {
+  const next = JSON.stringify(data, null, 2) + '\n'
+  if (fs.existsSync(filePath)) {
+    const current = fs.readFileSync(filePath, 'utf8')
+    if (current === next) {
+      console.log(`No change for ${path.basename(filePath)}`)
+      return false
+    }
+  }
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, next)
+  console.log(`Updated ${path.basename(filePath)}`)
+  return true
+}
+
+const changed: string[] = []
+
+async function main() {
+  const android = await scrapeAndroid()
+  const ios = await scrapeIos()
+  if (writeIfChanged(ANDROID_FILE, android)) changed.push('apps/web/src/data/android-distribution.json')
+  if (writeIfChanged(IOS_FILE, ios)) changed.push('apps/web/src/data/ios-distribution.json')
+
+  console.log(JSON.stringify({ changed }, null, 2))
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/scrape-distribution-charts.ts
+++ b/scripts/scrape-distribution-charts.ts
@@ -103,10 +103,11 @@ async function scrapeIos(): Promise<IosData> {
   const html = await fetchHtml(IOS_URL)
   const $ = cheerio.load(html)
 
+  // cheerio .text() strips tags, so match plain text like "last updated on June 6, 2026"
   const sourceText = $('#page-content p')
     .filter((_, el) => $(el).text().includes('last updated'))
     .text()
-  const updatedMatch = sourceText.match(/last updated on\s*<b>([^<]+)<\/b>/i)
+  const updatedMatch = sourceText.match(/last updated on\s+([^.]+?)(?:\s+using|\.|$)/i)
   const updatedText = updatedMatch ? updatedMatch[1].trim() : ''
 
   const rows: IosRow[] = []
@@ -130,15 +131,21 @@ async function scrapeIos(): Promise<IosData> {
   }
 }
 
-function writeIfChanged(filePath: string, data: unknown): boolean {
-  const next = JSON.stringify(data, null, 2) + '\n'
+function withoutFetchedAt(data: { fetchedAt?: string }): unknown {
+  const { fetchedAt: _fetchedAt, ...rest } = data
+  return rest
+}
+
+function writeIfChanged(filePath: string, data: { fetchedAt: string }): boolean {
+  const nextSemantic = JSON.stringify(withoutFetchedAt(data), null, 2)
   if (fs.existsSync(filePath)) {
-    const current = fs.readFileSync(filePath, 'utf8')
-    if (current === next) {
+    const current = JSON.parse(fs.readFileSync(filePath, 'utf8')) as { fetchedAt?: string }
+    if (JSON.stringify(withoutFetchedAt(current), null, 2) === nextSemantic) {
       console.log(`No change for ${path.basename(filePath)}`)
       return false
     }
   }
+  const next = JSON.stringify(data, null, 2) + '\n'
   fs.mkdirSync(path.dirname(filePath), { recursive: true })
   fs.writeFileSync(filePath, next)
   console.log(`Updated ${path.basename(filePath)}`)

--- a/scripts/scrape-distribution-charts.ts
+++ b/scripts/scrape-distribution-charts.ts
@@ -49,7 +49,7 @@ function parseRequiredDate(text: string, label: string): string {
   const trimmed = text.trim()
   if (!trimmed) throw new Error(`Missing ${label} update date in source HTML`)
   const date = new Date(trimmed)
-  if (Number.isNaN(date.getTime())) throw new Error(`Unparseable ${label} update date: ${trimmed}`)
+  if (Number.isNaN(date.getTime())) throw new Error(`Unparsable ${label} update date: ${trimmed}`)
   return date.toISOString()
 }
 

--- a/scripts/scrape-distribution-charts.ts
+++ b/scripts/scrape-distribution-charts.ts
@@ -59,6 +59,7 @@ async function fetchHtml(url: string): Promise<string> {
       Accept: 'text/html',
       'User-Agent': 'Mozilla/5.0 (compatible; CapgoBot/1.0; +https://capgo.app)',
     },
+    signal: AbortSignal.timeout(30_000),
   })
   if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`)
   return res.text()
@@ -191,7 +192,7 @@ async function main() {
 
   console.log(JSON.stringify({ changed, androidOk: android.ok, iosOk: ios.ok }, null, 2))
 
-  if (!android.ok && !ios.ok) {
+  if (!android.ok || !ios.ok) {
     process.exit(1)
   }
 }


### PR DESCRIPTION
## Summary
- Interactive Android + iOS **support planners**: pick a minimum version **or** a coverage target (default 95%) and see which users you reach
- Charts sorted by cumulative coverage high → low (what % you support if that version is your floor)
- Daily scraper only commits when distribution data changes; hardened validation + independent Android/iOS scrapes
- Footer links + cross-links between the two pages

## Screenshots

### Android — pick min SDK / coverage
![Android support planner](https://litter.catbox.moe/klfkpf.webp)

### iOS — pick deployment target / coverage
![iOS support planner](https://litter.catbox.moe/hbsif1.webp)

## Test plan
- [ ] Open `/android-distribution-chart/` — change version select and coverage slider; result text + highlight update
- [ ] Open `/ios-distribution-chart/` — same interactions
- [ ] Confirm lists are ordered highest cumulative coverage first
- [ ] Run `bun run scrape:distribution-charts` twice — second run no changes; invalid HTML would fail that platform only
- [ ] Footer + cross-page links work both ways

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android and iOS distribution charts with version reach, market share, and device coverage details.
  * Added interactive controls to select minimum app versions and coverage targets.
  * Added links between the Android and iOS charts, source data, and data-refresh information.
  * Added distribution chart navigation links to the site footer.

* **Data Updates**
  * Added current Android and iOS distribution datasets with source and update metadata.
  * Added automated data refreshes for distribution information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public pages and a scheduled workflow with `contents: write` that auto-commits; scrapers depend on third-party HTML selectors, so source layout changes could fail CI until the script is updated.
> 
> **Overview**
> Adds **Android** and **iOS version distribution** marketing pages that read committed JSON at build time and help teams pick min SDK / deployment targets from cumulative device reach.
> 
> Each page wires in a shared **`DistributionTargetChart`** (version select, coverage slider/number, bar list, client-side sync) plus **`DistributionRefreshPanel`**, FAQ/SEO structured data, platform-specific static sections (Android per-version market share; iOS device table), and cross-links. **Footer** product nav gains links to both routes.
> 
> **Data pipeline:** initial `android-distribution.json` / `ios-distribution.json`, a **`scrape:distribution-charts`** Bun script (Cheerio HTML scrape from Composables + iOS Ref, semantic diff before write, per-platform failure isolation), and a **daily GitHub Actions** workflow that runs the scraper and auto-commits only when figures change. Adds **`formatPercent`** for display consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44c4a055a650bb4290ed08e789e1f4f705a48677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->