### PR TITLE
feat: Distrib webhook for blog article imports

### DIFF
--- a/.github/workflows/deploy-distrib-worker.yml
+++ b/.github/workflows/deploy-distrib-worker.yml
@@ -1,0 +1,66 @@
+name: Deploy Distrib Worker
+
+concurrency:
+  group: deploy-distrib-worker
+  cancel-in-progress: false
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/distrib-worker/**'
+      - 'package.json'
+      - 'bun.lock'
+      - '.github/workflows/deploy-distrib-worker.yml'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.14
+
+      - name: Cache bun modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - run: bun install --frozen-lockfile
+      - run: bun run ci:verify:distrib
+
+      - name: Write Worker secrets
+        env:
+          DISTRIB_ACCESS_TOKEN: ${{ secrets.DISTRIB_ACCESS_TOKEN }}
+          DISTRIB_SECRETS_FILE: ${{ runner.temp }}/distrib-worker-secrets.json
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: |
+          bun --eval 'const secrets = {
+            DISTRIB_ACCESS_TOKEN: process.env.DISTRIB_ACCESS_TOKEN,
+            PERSONAL_ACCESS_TOKEN: process.env.PERSONAL_ACCESS_TOKEN,
+          }
+
+          for (const [key, value] of Object.entries(secrets)) {
+            if (!value) throw new Error(`${key} is required`)
+          }
+
+          await Bun.write(process.env.DISTRIB_SECRETS_FILE, JSON.stringify(secrets))'
+
+      - run: cd apps/distrib-worker && bunx wrangler deploy --secrets-file "$DISTRIB_SECRETS_FILE"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DISTRIB_SECRETS_FILE: ${{ runner.temp }}/distrib-worker-secrets.json

--- a/.github/workflows/import-distrib.yml
+++ b/.github/workflows/import-distrib.yml
@@ -1,0 +1,103 @@
+name: Import Distrib Articles
+
+on:
+  repository_dispatch:
+    types:
+      - distrib_publish_articles
+  workflow_dispatch:
+    inputs:
+      payload:
+        description: Raw Distrib publish_articles or update_articles payload JSON for testing.
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: distrib-import-${{ github.event.client_payload.timestamp || github.run_id }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  NODE_OPTIONS: '--max-old-space-size=16384'
+  UV_THREADPOOL_SIZE: '32'
+
+jobs:
+  import:
+    name: Import articles
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN || github.token }}
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.14
+
+      - name: Cache bun modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - run: bun install --frozen-lockfile
+
+      - name: Write manual payload
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          DISTRIB_MANUAL_PAYLOAD: ${{ inputs.payload }}
+        run: printf '%s' "$DISTRIB_MANUAL_PAYLOAD" > "$RUNNER_TEMP/distrib-payload.json"
+
+      - name: Import Distrib articles
+        id: import
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            bun run scripts/blogs/import_distrib.ts "$RUNNER_TEMP/distrib-payload.json"
+          else
+            bun run scripts/blogs/import_distrib.ts
+          fi
+
+      - name: Format imported articles
+        if: steps.import.outputs.files != ''
+        run: xargs bunx prettier --write < .distrib-imported-files
+
+      - name: Verify website
+        if: steps.import.outputs.files != ''
+        run: bun run ci:verify:web
+        env:
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          ORAMA_CLOUD_API_KEY: ${{ secrets.ORAMA_CLOUD_API_KEY }}
+          ORAMA_CLOUD_ENDPOINT: ${{ secrets.ORAMA_CLOUD_ENDPOINT }}
+          CLOUDFLARE_TURNSTILE_SITE_KEY: ${{ secrets.CLOUDFLARE_TURNSTILE_SITE_KEY }}
+
+      - name: Push imported articles to main
+        if: steps.import.outputs.files != ''
+        shell: bash
+        run: |
+          rm -f .distrib-imported-files
+
+          if [[ -z "$(git status --porcelain apps/web/src/content/blog/en)" ]]; then
+            echo "No blog changes to publish."
+            exit 0
+          fi
+
+          default_branch="${{ github.event.repository.default_branch }}"
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git add apps/web/src/content/blog/en
+          git commit -m "chore: import Distrib articles"
+          git pull --rebase origin "$default_branch"
+          git push origin "HEAD:$default_branch"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       translation: ${{ steps.filter.outputs.translation }}
       outrank: ${{ steps.filter.outputs.outrank }}
+      distrib: ${{ steps.filter.outputs.distrib }}
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -46,6 +47,7 @@ jobs:
               echo "docs=true"
               echo "translation=true"
               echo "outrank=true"
+              echo "distrib=true"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -72,6 +74,7 @@ jobs:
           docs=false
           translation=false
           outrank=false
+          distrib=false
 
           if matches '^(apps/web/|apps/shared/|scripts/|configs\.json$|package\.json$|bun\.lock$|\.github/workflows/test\.yml$|\.github/workflows/deploy-web\.yml$)'; then
             web=true
@@ -89,11 +92,16 @@ jobs:
             outrank=true
           fi
 
+          if matches '^(apps/distrib-worker/|package\.json$|bun\.lock$|\.github/workflows/test\.yml$|\.github/workflows/deploy-distrib-worker\.yml$)'; then
+            distrib=true
+          fi
+
           {
             echo "web=$web"
             echo "docs=$docs"
             echo "translation=$translation"
             echo "outrank=$outrank"
+            echo "distrib=$distrib"
           } >> "$GITHUB_OUTPUT"
 
   web:
@@ -229,3 +237,28 @@ jobs:
             ${{ runner.os }}-bun-
       - run: bun install --frozen-lockfile
       - run: bun run ci:verify:outrank
+
+  distrib:
+    name: Distrib Worker Check
+    needs: changes
+    if: needs.changes.outputs.distrib == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.14
+      - name: Cache bun modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+      - run: bun install --frozen-lockfile
+      - run: bun run ci:verify:distrib
+

--- a/apps/distrib-worker/package.json
+++ b/apps/distrib-worker/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@capgo/distrib-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "tsc --noEmit",
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  }
+}

--- a/apps/distrib-worker/src/index.ts
+++ b/apps/distrib-worker/src/index.ts
@@ -1,0 +1,208 @@
+interface Env {
+  DISTRIB_ACCESS_TOKEN?: string
+  PERSONAL_ACCESS_TOKEN?: string
+  GITHUB_OWNER: string
+  GITHUB_REPO: string
+  GITHUB_EVENT_TYPE?: string
+}
+
+interface DistribArticle {
+  id?: string
+  title?: string
+  slug?: string
+  content_html?: string
+  content_markdown?: string
+  meta_description?: string
+  created_at?: string
+  image_url?: string
+  alt_text?: string
+  tags?: unknown
+  author?: string
+  status?: string
+  is_update?: boolean
+}
+
+interface DistribPayload {
+  event_type?: string
+  timestamp?: string
+  data?: {
+    articles?: DistribArticle[]
+  }
+}
+
+const DEFAULT_GITHUB_EVENT_TYPE = 'distrib_publish_articles'
+const MAX_REPOSITORY_DISPATCH_BYTES = 65_000
+const SUPPORTED_DISTRIB_EVENT_TYPES = new Set(['publish_articles', 'update_articles'])
+const JSON_HEADERS = {
+  'content-type': 'application/json; charset=utf-8',
+}
+
+function jsonResponse(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: JSON_HEADERS,
+  })
+}
+
+function requestAccessToken(request: Request): string {
+  const authorization = request.headers.get('authorization') || ''
+  const bearerMatch = /^Bearer\s+(.+)$/i.exec(authorization)
+  if (bearerMatch?.[1]?.trim()) return bearerMatch[1].trim()
+
+  const apiKey = request.headers.get('x-api-key')
+  if (apiKey?.trim()) return apiKey.trim()
+
+  const makeApiKey = request.headers.get('x-make-apikey')
+  if (makeApiKey?.trim()) return makeApiKey.trim()
+
+  return ''
+}
+
+async function secureEqual(left: string, right: string): Promise<boolean> {
+  const encoder = new TextEncoder()
+  const [leftHash, rightHash] = await Promise.all([
+    crypto.subtle.digest('SHA-256', encoder.encode(left)),
+    crypto.subtle.digest('SHA-256', encoder.encode(right)),
+  ])
+  const leftBytes = new Uint8Array(leftHash)
+  const rightBytes = new Uint8Array(rightHash)
+  let difference = 0
+
+  for (let index = 0; index < leftBytes.length; index += 1) {
+    difference |= leftBytes[index] ^ rightBytes[index]
+  }
+
+  return difference === 0
+}
+
+function isSupportedEventType(eventType: string | undefined): boolean {
+  return typeof eventType === 'string' && SUPPORTED_DISTRIB_EVENT_TYPES.has(eventType)
+}
+
+function payloadArticles(payload: DistribPayload): DistribArticle[] {
+  if (Array.isArray(payload.data?.articles)) return payload.data.articles
+  return []
+}
+
+function validatePayload(payload: unknown): payload is DistribPayload {
+  if (!payload || typeof payload !== 'object') return false
+
+  const candidate = payload as DistribPayload
+  if (!isSupportedEventType(candidate.event_type)) return false
+
+  const articles = payloadArticles(candidate)
+  if (articles.length === 0) return false
+
+  return articles.every(
+    (article) =>
+      typeof article?.title === 'string' &&
+      article.title.trim().length > 0 &&
+      typeof article?.content_markdown === 'string' &&
+      article.content_markdown.trim().length > 0,
+  )
+}
+
+function normalizePayload(payload: DistribPayload): DistribPayload {
+  return {
+    event_type: payload.event_type,
+    timestamp: payload.timestamp,
+    data: {
+      articles: payloadArticles(payload).map((article) => ({
+        id: article.id,
+        title: article.title,
+        slug: article.slug,
+        content_html: article.content_html,
+        content_markdown: article.content_markdown,
+        meta_description: article.meta_description,
+        created_at: article.created_at,
+        image_url: article.image_url,
+        alt_text: article.alt_text,
+        tags: Array.isArray(article.tags) ? article.tags.filter((tag) => typeof tag === 'string') : undefined,
+        author: article.author,
+        status: article.status,
+        is_update: article.is_update,
+      })),
+    },
+  }
+}
+
+async function parsePayload(request: Request): Promise<DistribPayload | undefined> {
+  try {
+    const payload = await request.json()
+    if (!validatePayload(payload)) return undefined
+    return normalizePayload(payload)
+  } catch {
+    return undefined
+  }
+}
+
+async function dispatchToGithub(env: Env, payload: DistribPayload): Promise<Response> {
+  if (!env.PERSONAL_ACCESS_TOKEN) return jsonResponse({ error: 'missing_personal_access_token' }, 500)
+
+  const dispatchBody = JSON.stringify({
+    event_type: env.GITHUB_EVENT_TYPE || DEFAULT_GITHUB_EVENT_TYPE,
+    client_payload: payload,
+  })
+
+  if (new TextEncoder().encode(dispatchBody).byteLength > MAX_REPOSITORY_DISPATCH_BYTES) {
+    return jsonResponse({ error: 'payload_too_large_for_repository_dispatch' }, 413)
+  }
+
+  try {
+    const response = await fetch(`https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/dispatches`, {
+      method: 'POST',
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${env.PERSONAL_ACCESS_TOKEN}`,
+        'content-type': 'application/json',
+        'user-agent': 'capgo-distrib-webhook',
+        'x-github-api-version': '2022-11-28',
+      },
+      body: dispatchBody,
+    })
+
+    if (response.ok) return jsonResponse({ message: 'Distrib payload dispatched' }, 202)
+
+    const details = await response.text()
+    return jsonResponse(
+      {
+        error: 'github_dispatch_failed',
+        status: response.status,
+        details: details.slice(0, 500),
+      },
+      502,
+    )
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error)
+    console.error('GitHub repository_dispatch request failed', details)
+    return jsonResponse(
+      {
+        error: 'github_dispatch_network_failure',
+        details: details.slice(0, 500),
+      },
+      502,
+    )
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url)
+
+    if (request.method === 'GET' && (url.pathname === '/' || url.pathname === '/health')) {
+      return jsonResponse({ status: 'ok' })
+    }
+
+    if (url.pathname !== '/webhook') return jsonResponse({ error: 'not_found' }, 404)
+    if (request.method !== 'POST') return jsonResponse({ error: 'method_not_allowed' }, 405)
+    if (!env.DISTRIB_ACCESS_TOKEN) return jsonResponse({ error: 'missing_distrib_access_token' }, 500)
+
+    const tokenIsValid = await secureEqual(requestAccessToken(request), env.DISTRIB_ACCESS_TOKEN)
+    if (!tokenIsValid) return jsonResponse({ error: 'invalid_access_token' }, 401)
+
+    const payload = await parsePayload(request)
+    if (!payload) return jsonResponse({ error: 'invalid_distrib_payload' }, 400)
+
+    return dispatchToGithub(env, payload)
+  },
+}

--- a/apps/distrib-worker/tsconfig.json
+++ b/apps/distrib-worker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "allowJs": false,
+    "lib": ["ES2022", "WebWorker"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": []
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/distrib-worker/wrangler.jsonc
+++ b/apps/distrib-worker/wrangler.jsonc
@@ -1,0 +1,43 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "capgo-distrib-webhook",
+  "account_id": "9ee3d7479a3c359681e3fab2c8cb22c0",
+  "main": "./src/index.ts",
+  "compatibility_date": "2026-05-12",
+  "compatibility_flags": ["nodejs_compat"],
+  "dependencies_instrumentation": {
+    "enabled": true,
+  },
+  "workers_dev": false,
+  "vars": {
+    "GITHUB_OWNER": "Cap-go",
+    "GITHUB_REPO": "website",
+    "GITHUB_EVENT_TYPE": "distrib_publish_articles",
+  },
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+  },
+  "routes": [
+    {
+      "pattern": "distrib.capgo.app",
+      "custom_domain": true,
+    },
+  ],
+  "env": {
+    "development": {
+      "name": "capgo-distrib-webhook-development",
+      "vars": {
+        "GITHUB_OWNER": "Cap-go",
+        "GITHUB_REPO": "website",
+        "GITHUB_EVENT_TYPE": "distrib_publish_articles",
+      },
+      "routes": [
+        {
+          "pattern": "distrib-development.capgo.app",
+          "custom_domain": true,
+        },
+      ],
+    },
+  },
+}

--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,9 @@
         "zod": "^4.4.3",
       },
     },
+    "apps/distrib-worker": {
+      "name": "@capgo/distrib-worker",
+    },
     "apps/docs": {
       "name": "@capgo/docs",
       "dependencies": {
@@ -90,7 +93,7 @@
         "@astrojs/check": "0.9.9",
         "@types/node": "^26.1.1",
         "vite-plugin-static-copy": "^4.1.1",
-        "wrangler": "^4.111.0",
+        "wrangler": "4.111.0",
         "zod": "^4.4.3",
       },
     },
@@ -233,6 +236,8 @@
     "@bruits/satteri-win32-arm64-msvc": ["@bruits/satteri-win32-arm64-msvc@0.9.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-VnwjBHiAra/PNNEza8eSZdQiG4A3PtTJJwUDtOPAc6iTs0BWZwZX8+OPUZE7//yQCBhgvEMcI8vpwsAwCb6qGQ=="],
 
     "@bruits/satteri-win32-x64-msvc": ["@bruits/satteri-win32-x64-msvc@0.9.3", "", { "os": "win32", "cpu": "x64" }, "sha512-Dsoe4reWe69MyILmMwU6iISIceTW7YIFqbyym7haf9DhUvqkYfMAyp7GMM21JzV0SpG9A2BwzFVP7iq9mmxrpA=="],
+
+    "@capgo/distrib-worker": ["@capgo/distrib-worker@workspace:apps/distrib-worker"],
 
     "@capgo/docs": ["@capgo/docs@workspace:apps/docs"],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ci:verify:outrank": "cd apps/outrank-worker && bun run check",
     "verify:real-translation": "cd apps/translation-worker && bun run test:real",
     "check:docs-mirror": "bun run scripts/check-plugin-doc-mirrors.ts",
-    "check": "bun run check:docs-mirror && cd apps/web && bun run check && cd ../docs && bun run check && cd ../translation-worker && bun run check && cd ../outrank-worker && bun run check",
+    "check": "bun run check:docs-mirror && cd apps/web && bun run check && cd ../docs && bun run check && cd ../translation-worker && bun run check && cd ../outrank-worker && bun run check && cd ../distrib-worker && bun run check",
     "seo:check": "seo-checker --output github",
     "seo:check:json": "seo-checker --output json",
     "seo:check:report": "seo-checker --report seo-report.txt",
@@ -58,7 +58,9 @@
     "visual-diff:capture:after": "bun run scripts/visual-diff.mjs capture after",
     "visual-diff:compare": "bun run scripts/visual-diff.mjs compare",
     "visual-diff:report": "bun run scripts/visual-diff.mjs report",
-    "visual-diff": "bun run scripts/visual-diff.mjs"
+    "visual-diff": "bun run scripts/visual-diff.mjs",
+    "ci:verify:distrib": "cd apps/distrib-worker && bun run check",
+    "deploy:distrib": "cd apps/distrib-worker && bun run deploy"
   },
   "dependencies": {
     "@astrojs/cloudflare": "14.1.2",

--- a/scripts/blogs/import_distrib.ts
+++ b/scripts/blogs/import_distrib.ts
@@ -1,0 +1,232 @@
+import matter from 'gray-matter'
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join, resolve, sep } from 'node:path'
+import { commonReplacements } from '../commonReplacements'
+import { normalizeBlogTags } from '../../apps/web/src/constants/blogTags'
+
+const DEFAULT_BLOG_DIR = 'apps/web/src/content/blog/en'
+const DEFAULT_AUTHOR = 'Martin Donadieu'
+const DEFAULT_AUTHOR_IMAGE_URL = 'https://avatars.githubusercontent.com/u/4084527?v=4'
+const DEFAULT_AUTHOR_URL = 'https://github.com/riderx'
+const DEFAULT_HEAD_IMAGE = '/capgo_banner.png'
+const IMPORTED_FILES_PATH = '.distrib-imported-files'
+
+interface DistribArticle {
+  id?: string
+  title?: string
+  slug?: string
+  content_html?: string
+  content_markdown?: string
+  meta_description?: string
+  created_at?: string
+  image_url?: string
+  alt_text?: string
+  tags?: unknown[]
+  author?: string
+  status?: string
+  is_update?: boolean
+}
+
+interface DistribPayload {
+  event_type?: string
+  timestamp?: string
+  data?: {
+    articles?: DistribArticle[]
+  }
+}
+
+const SUPPORTED_DISTRIB_EVENT_TYPES = new Set(['publish_articles', 'update_articles'])
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+function payloadFromGithubEvent(event: any): DistribPayload {
+  if (typeof event?.inputs?.payload === 'string') return JSON.parse(event.inputs.payload)
+  if (event?.client_payload?.event_type) return event.client_payload
+  if (event?.event_type) return event
+  throw new Error('No Distrib payload found. Pass a payload file or dispatch client_payload.')
+}
+
+function loadPayload(): DistribPayload {
+  const inputPath = process.argv[2]
+  if (inputPath) return readJson(inputPath) as DistribPayload
+
+  if (!process.env.GITHUB_EVENT_PATH) {
+    throw new Error('GITHUB_EVENT_PATH is missing. Pass the Distrib payload file path as the first argument.')
+  }
+
+  return payloadFromGithubEvent(readJson(process.env.GITHUB_EVENT_PATH))
+}
+
+function toSlug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/['"]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function assertInsideDirectory(directory: string, filePath: string): void {
+  const resolvedDirectory = resolve(directory)
+  const resolvedFilePath = resolve(filePath)
+
+  if (resolvedFilePath !== resolvedDirectory && !resolvedFilePath.startsWith(`${resolvedDirectory}${sep}`)) {
+    throw new Error(`Refusing to write outside blog directory: ${filePath}`)
+  }
+}
+
+function isSupportedEventType(eventType: string | undefined): boolean {
+  return typeof eventType === 'string' && SUPPORTED_DISTRIB_EVENT_TYPES.has(eventType)
+}
+
+function payloadArticles(payload: DistribPayload): DistribArticle[] {
+  if (Array.isArray(payload.data?.articles)) return payload.data.articles
+  return []
+}
+
+function frontmatterString(frontmatter: Record<string, unknown>, key: string): string {
+  const value = frontmatter[key]
+  return typeof value === 'string' ? value : ''
+}
+
+function toDate(value: Date | string | undefined, fallback: Date): Date {
+  const date = value ? new Date(value) : new Date(fallback)
+  if (Number.isNaN(date.getTime())) return new Date(fallback)
+  return date
+}
+
+function firstText(content: string, maxLength = 155): string {
+  const text = content
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[#*_`[\]()]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (text.length <= maxLength) return text
+  return `${text.slice(0, maxLength).replace(/\s+\S*$/, '')}...`
+}
+
+function removeLeadingFrontmatter(content: string): string {
+  return content.replace(/^\s*---\n[\s\S]*?\n---\n+/, '')
+}
+
+function removeDuplicateTitle(content: string, title: string): string {
+  const escapedTitle = title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return content.replace(new RegExp(`^\\s*#\\s+${escapedTitle}\\s*\\n+`, 'i'), '')
+}
+
+function normalizeMarkdown(content: string, title: string): string {
+  const normalized = removeDuplicateTitle(removeLeadingFrontmatter(content.replace(/\r\n?/g, '\n')), title)
+    .replace(/https:\/\/capgo\.app\/(de|en|es|fr|id|it|ja|ko)\/(.*?)\//g, 'https://capgo.app/$2/')
+    .trim()
+
+  return `${commonReplacements(normalized)}\n`
+}
+
+function normalizeHeadImage(imageUrl: string | undefined): string {
+  if (!imageUrl) return DEFAULT_HEAD_IMAGE
+
+  const imagePath = imageUrl.split(/[?#]/)[0]?.toLowerCase() || ''
+  if (imagePath.endsWith('.webp')) return DEFAULT_HEAD_IMAGE
+
+  return imageUrl
+}
+
+function isPublished(status: string | undefined): boolean {
+  if (!status) return true
+  return status.trim().toLowerCase() === 'published'
+}
+
+function writeGithubOutput(files: string[], articleCount: number): void {
+  if (!process.env.GITHUB_OUTPUT) return
+
+  appendFileSync(process.env.GITHUB_OUTPUT, `article_count=${articleCount}\n`)
+  appendFileSync(process.env.GITHUB_OUTPUT, 'files<<EOF\n')
+  appendFileSync(process.env.GITHUB_OUTPUT, `${files.join('\n')}\n`)
+  appendFileSync(process.env.GITHUB_OUTPUT, 'EOF\n')
+}
+
+function writeArticle(article: DistribArticle, payloadTimestamp: Date, blogDirectory: string): string {
+  const title = article.title?.trim()
+  if (!title) throw new Error(`Distrib article is missing title: ${JSON.stringify(article)}`)
+  if (!article.content_markdown?.trim()) throw new Error(`Distrib article "${title}" is missing content_markdown.`)
+
+  const slug = toSlug(article.slug || title || article.id || '')
+  if (!slug) throw new Error(`Distrib article "${title}" does not have a usable slug.`)
+
+  const filePath = join(blogDirectory, `${slug}.md`)
+  assertInsideDirectory(blogDirectory, filePath)
+
+  const existingContent = existsSync(filePath) ? readFileSync(filePath, 'utf8') : ''
+  const existingFrontmatter = existingContent ? (matter(existingContent).data as Record<string, unknown>) : {}
+  const existingTag = frontmatterString(existingFrontmatter, 'tag')
+  const existingKeywords = frontmatterString(existingFrontmatter, 'keywords')
+  const tags = Array.isArray(article.tags)
+    ? article.tags
+        .filter((tag): tag is string => typeof tag === 'string')
+        .map((tag) => tag.trim())
+        .filter(Boolean)
+    : existingTag
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter(Boolean)
+  const markdown = normalizeMarkdown(article.content_markdown, title)
+  const createdAt = toDate(article.created_at, toDate(existingFrontmatter.created_at as Date | string | undefined, payloadTimestamp))
+  const updatedAt = article.is_update || existsSync(filePath) ? new Date(payloadTimestamp) : createdAt
+  const keywords = Array.isArray(article.tags) ? tags.join(', ') : existingKeywords || tags.join(', ')
+  const tag = normalizeBlogTags(tags, title, keywords || article.meta_description?.trim() || '')
+  const headImage = article.image_url ? normalizeHeadImage(article.image_url) : frontmatterString(existingFrontmatter, 'head_image') || DEFAULT_HEAD_IMAGE
+  const headImageAlt = article.alt_text?.trim() || frontmatterString(existingFrontmatter, 'head_image_alt') || title
+  const authorName = article.author?.trim() || process.env.DISTRIB_BLOG_AUTHOR || frontmatterString(existingFrontmatter, 'author') || DEFAULT_AUTHOR
+
+  const frontmatter = {
+    slug,
+    title,
+    description: article.meta_description?.trim() || firstText(markdown),
+    author: authorName,
+    author_image_url: process.env.DISTRIB_BLOG_AUTHOR_IMAGE_URL || frontmatterString(existingFrontmatter, 'author_image_url') || DEFAULT_AUTHOR_IMAGE_URL,
+    author_url: process.env.DISTRIB_BLOG_AUTHOR_URL || frontmatterString(existingFrontmatter, 'author_url') || DEFAULT_AUTHOR_URL,
+    created_at: createdAt,
+    updated_at: updatedAt,
+    head_image: headImage,
+    head_image_alt: headImageAlt,
+    keywords,
+    tag,
+    published: isPublished(article.status),
+    locale: 'en',
+    next_blog: '',
+  }
+
+  const content = matter.stringify(markdown, frontmatter, { lineWidth: -1 })
+  if (existingContent === content) return ''
+
+  writeFileSync(filePath, content, 'utf8')
+  return filePath
+}
+
+function main(): void {
+  const payload = loadPayload()
+  if (!isSupportedEventType(payload.event_type)) {
+    throw new Error(`Unsupported Distrib event_type "${payload.event_type}". Expected one of: ${Array.from(SUPPORTED_DISTRIB_EVENT_TYPES).join(', ')}.`)
+  }
+
+  const articles = payloadArticles(payload)
+  if (articles.length === 0) throw new Error('Distrib payload does not contain any articles.')
+
+  const payloadTimestamp = toDate(payload.timestamp, new Date())
+  const blogDirectory = process.env.DISTRIB_BLOG_DIR || DEFAULT_BLOG_DIR
+
+  if (!existsSync(blogDirectory)) mkdirSync(blogDirectory, { recursive: true })
+
+  const writtenFiles = articles.map((article) => writeArticle(article, payloadTimestamp, blogDirectory)).filter(Boolean)
+  writeFileSync(IMPORTED_FILES_PATH, writtenFiles.join('\n') + (writtenFiles.length ? '\n' : ''), 'utf8')
+  writeGithubOutput(writtenFiles, articles.length)
+
+  console.log(`Processed ${articles.length} Distrib article(s).`)
+  console.log(`Changed ${writtenFiles.length} file(s).`)
+}
+
+main()


### PR DESCRIPTION
## Summary
- Add `apps/distrib-worker` Cloudflare Worker at `https://distrib.capgo.app/webhook/` accepting Distrib `publish_articles` and `update_articles` payloads
- Validate access token from `Authorization: Bearer`, `X-API-Key`, or `x-make-apikey` headers
- Dispatch to GitHub `repository_dispatch` (`distrib_publish_articles`) and import articles via `scripts/blogs/import_distrib.ts`
- CI: deploy workflow, import workflow, and test job for the distrib worker

## Distrib configuration
- **Webhook URL:** `https://distrib.capgo.app/webhook/`
- **Access token:** set `DISTRIB_ACCESS_TOKEN` in GitHub secrets (same value you configure in Distrib)

## Test plan
- [ ] Merge and let `Deploy Distrib Worker` run (needs `DISTRIB_ACCESS_TOKEN` secret)
- [ ] Configure Distrib webhook URL + token
- [ ] Run Distrib webhook test (or `workflow_dispatch` on Import Distrib Articles with sample payload)
- [ ] Confirm article lands in `apps/web/src/content/blog/en/`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788597136&installation_model_id=430928&pr_number=927&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F927&signature=1207316cb87847c679518705a76f39a4cbcc050cd46fef51ae91bdc63d3db1df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Distrib webhook that securely receives, validates, and forwards article events.
  - Added automated importing of Distrib articles into the blog, including metadata, images, tags, publication status, and updates.
  - Added health-check and structured error responses for webhook requests.

- **Deployment & Reliability**
  - Added automated validation and deployment workflows for the Distrib service.
  - Added safeguards for invalid content, unsupported events, unsafe paths, missing configuration, and authentication failures.
  - Updated continuous integration to verify Distrib changes automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->