### PR TITLE
docs(builder): list all Cloud Build prescan checks

### DIFF
--- a/apps/docs/src/content/docs/docs/builder/index.mdx
+++ b/apps/docs/src/content/docs/docs/builder/index.mdx
@@ -154,6 +154,11 @@ Build time is the only cost:
     href="/docs/builder/webhooks/"
   />
   <LinkCard 
+    title="Prescan checks" 
+    description="Full list of pre-build checks and how to skip or warn on specific rules."
+    href="/docs/builder/prescan/"
+  />
+  <LinkCard 
     title="GitHub Actions" 
     description="Full Capgo Build CI setup with secrets and release workflows."
     href="/docs/builder/github-actions/"

--- a/apps/docs/src/content/docs/docs/builder/prescan.mdx
+++ b/apps/docs/src/content/docs/docs/builder/prescan.mdx
@@ -1,0 +1,199 @@
+---
+title: Build prescan checks
+description: Full list of Capgo Cloud Build prescan checks and how to skip or warn on specific rules.
+sidebar:
+  order: 12
+  label: Prescan checks
+---
+
+import { Aside, LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+Before Capgo Cloud Build uploads your project, the CLI runs a **prescan** that catches credential, project, and store-config problems locally.
+
+It also runs standalone:
+
+```bash
+npx @capgo/cli@latest build prescan <appId> --platform ios
+```
+
+There are **80** checks today. Prefer ignoring individual check ids over turning the whole scan off.
+
+## Ignore specific checks
+
+```bash
+# Skip one check entirely (example: intentional Capacitor server.url / Next.js shell)
+npx @capgo/cli@latest build request <appId> --platform ios \
+  --prescan-skip ios/capacitor-server-url-shipped
+
+# Run the check but never block on it (error becomes warning)
+npx @capgo/cli@latest build request <appId> --platform ios \
+  --prescan-warn ios/capacitor-server-url-shipped
+
+# Repeatable or comma-separated
+npx @capgo/cli@latest build request <appId> --platform ios \
+  --prescan-skip ios/capacitor-server-url-shipped \
+  --prescan-warn ios/capacitor-allow-navigation-wildcard,ios/plist-ats-arbitrary-loads
+```
+
+Standalone aliases on `build prescan`:
+
+```bash
+npx @capgo/cli@latest build prescan <appId> --platform ios \
+  --skip ios/capacitor-server-url-shipped \
+  --warn ios/capacitor-server-cleartext
+```
+
+Unknown check ids fail fast with a clear error.
+
+<Aside type="tip">
+Requires `@capgo/cli@latest` with per-check override support. Prefer `--prescan-skip` / `--prescan-warn` so every other check still protects your build.
+</Aside>
+
+## Global escapes (use sparingly)
+
+| Flag | Effect |
+| --- | --- |
+| `--no-prescan` | Skip the entire scan |
+| `--prescan-ignore-fatal` (or `--ignore-fatal` on `build prescan`) | Run scan, print report, never block |
+| `--fail-on-warnings` | Treat warnings as fatal (CI) |
+
+`--no-prescan` and `--prescan-ignore-fatal` hide or bypass **all** remaining checks. Use per-check overrides instead when you only disagree with one rule.
+
+## Check catalog
+
+Use the exact id in `--prescan-skip` / `--prescan-warn`.
+
+**Gradual enforce** means the finding is information-only until `2026-08-14`, then it can block builds.
+
+### Shared
+
+| Id | Platforms | What it checks | Gradual enforce |
+| --- | --- | --- | --- |
+| `shared/apikey-permission` | ios, android | API key can request native builds | — |
+| `shared/app-exists` | ios, android | App id exists and is visible to the API key | — |
+| `shared/credentials-saved` | ios, android | Required iOS/Android credentials are saved locally | — |
+| `shared/cap-sync-stale` | ios, android | Web assets built and Capacitor plugins synced | — |
+| `shared/node-linker-layout` | ios, android | node_modules layout works with Capacitor native paths | — |
+| `shared/bundle-id-consistency` | ios, android | Capacitor appId matches native bundle id / applicationId | — |
+
+### iOS
+
+| Id | Platforms | What it checks | Gradual enforce |
+| --- | --- | --- | --- |
+| `ios/p12-opens` | ios | iOS .p12 opens with the provided password | — |
+| `ios/p12-expiry` | ios | iOS signing certificate is not expired | — |
+| `ios/profile-expiry` | ios | Provisioning profile is not expired | — |
+| `ios/profile-bundle-match` | ios | Provisioning profile bundle id matches the app | — |
+| `ios/profile-type-vs-mode` | ios | Profile type matches app_store / ad_hoc mode | — |
+| `ios/cert-profile-pairing` | ios | Certificate is embedded in the provisioning profile | — |
+| `ios/targets-covered` | ios | All iOS targets have a provisioning profile | — |
+| `ios/infoplist-sanity` | ios | Info.plist has required version / identity keys | — |
+| `ios/asc-key-valid` | ios | App Store Connect API key fields look valid | — |
+| `ios/asc-key-access` | ios | ASC API key can access the app (remote) | — |
+| `ios/plist-bundle-id-format` | ios | CFBundleIdentifier format is valid | Yes |
+| `ios/plist-version-short-format` | ios | CFBundleShortVersionString format is valid | Yes |
+| `ios/plist-version-build-format` | ios | CFBundleVersion format is valid | Yes |
+| `ios/plist-encryption-compliance` | ios | ITSAppUsesNonExemptEncryption is declared | Yes |
+| `ios/plist-ats-arbitrary-loads` | ios | NSAllowsArbitraryLoads is not enabled for production | Yes |
+| `ios/plist-launch-storyboard` | ios | Launch screen is declared | Yes |
+| `ios/plist-orientations-multitasking` | ios | Orientation / multitasking settings are consistent | Yes |
+| `ios/plist-orientations-present` | ios | UISupportedInterfaceOrientations is declared | Yes |
+| `ios/plist-display-name` | ios | Display name is set | Yes |
+| `ios/plist-background-modes-sanity` | ios | UIBackgroundModes values look valid | Yes |
+| `ios/xcode-deployment-target-capacitor` | ios | iOS deployment target meets Capacitor requirements | Yes |
+| `ios/xcode-signing-team` | ios | Signing team is set | Yes |
+| `ios/xcode-bundle-id-mismatch-across-configs` | ios | Bundle id is consistent across Xcode configs | Yes |
+| `ios/xcode-enable-bitcode-leftover` | ios | ENABLE_BITCODE leftover is removed | Yes |
+| `ios/xcode-swift-version-sanity` | ios | Swift version setting looks sane | Yes |
+| `ios/xcode-no-app-target` | ios | Xcode project has an application target | Yes |
+| `ios/xcode-multiple-app-targets` | ios | Multiple app targets are handled intentionally | Yes |
+| `ios/entitlements-vs-profile-capability` | ios | Entitlements match profile capabilities | Yes |
+| `ios/entitlements-aps-environment-vs-mode` | ios | aps-environment matches distribution mode | Yes |
+| `ios/entitlements-associated-domains-format` | ios | Associated Domains format is valid | Yes |
+| `ios/entitlements-app-groups-format` | ios | App Groups format is valid | Yes |
+| `ios/capacitor-server-url-shipped` | ios | server.url is not left as a live-reload / remote shell endpoint for store builds | Yes |
+| `ios/capacitor-server-cleartext` | ios | server.cleartext is not enabled for production | Yes |
+| `ios/capacitor-allow-navigation-wildcard` | ios | server.allowNavigation is not a blanket wildcard | Yes |
+| `ios/pods-not-installed` | ios | CocoaPods Pods / workspace are present when using Pods | Yes |
+| `ios/pods-lock-missing` | ios | Podfile.lock pins pod versions | Yes |
+| `ios/pods-capacitor-missing` | ios | Podfile wires Capacitor | Yes |
+| `ios/spm-package-resolved-missing` | ios | SPM Package.resolved is present | Yes |
+| `ios/spm-capacitor-dependency-missing` | ios | Package.swift declares Capacitor | Yes |
+| `ios/appicon-empty-or-placeholder` | ios | AppIcon.appiconset exists and is not empty | Yes |
+| `ios/appicon-referenced-file-missing` | ios | Contents.json icon files exist on disk | Yes |
+| `ios/appicon-marketing-missing` | ios | 1024×1024 marketing icon exists | Yes |
+| `ios/spm-deployment-target-consistency` | ios | SPM deployment target is consistent | Yes |
+
+### Android
+
+| Id | Platforms | What it checks | Gradual enforce |
+| --- | --- | --- | --- |
+| `android/keystore-opens` | android | Android keystore opens with provided passwords | — |
+| `android/keystore-expiry` | android | Android signing cert is not expired | — |
+| `android/cordova-vars-present` | android | cordova.variables.gradle is present after cap sync | — |
+| `android/gradle-props-heuristics` | android | gradle.properties heuristics for common build breaks | — |
+| `android/play-sa-json` | android | Play service-account JSON is present when configured | — |
+| `android/flavor-exists` | android | Requested product flavor exists | — |
+| `android/agp8-package-attr` | android | Manifest package= attribute removed for AGP 8+ | — |
+| `android/manifest-well-formed` | android | AndroidManifest.xml parses | — |
+| `android/manifest-tag-typo` | android | Common manifest tag typos | — |
+| `android/manifest-namespace-uri` | android | xmlns:android namespace URI is correct | — |
+| `android/manifest-missing-prefix` | android | Android attributes use the android: prefix | — |
+| `android/manifest-exported-missing` | android | android:exported is set where required | — |
+| `android/manifest-multiple-uses-sdk` | android | Only one uses-sdk element | — |
+| `android/manifest-duplicate-component` | android | No duplicate components | — |
+| `android/manifest-unique-permission` | android | Custom permissions are unique | — |
+| `android/manifest-hardcoded-debuggable` | android | debuggable=true not shipped | — |
+| `android/manifest-mock-location` | android | ACCESS_MOCK_LOCATION not shipped | — |
+| `android/manifest-exported-unprotected` | android | Exported components are protected | — |
+| `android/manifest-query-all-packages` | android | QUERY_ALL_PACKAGES justification | — |
+| `android/manifest-deeplink-valid` | android | Deeplink intent-filters look valid | — |
+| `android/applicationid-present` | android | applicationId is declared in app/build.gradle | — |
+| `android/capacitor-build-gradle-applied` | android | capacitor.build.gradle exists when applied | — |
+| `android/gradle-wrapper-present` | android | Gradle wrapper files are present | — |
+| `android/flavor-dimensions` | android | Flavor dimensions are declared when flavors exist | — |
+| `android/google-services-file` | android | google-services.json present when plugin applied | — |
+| `android/local-properties-committed` | android | local.properties is not committed with secrets | — |
+| `android/sdk-floors` | android | min/compile/target SDK floors look valid | — |
+| `android/target-sdk-play` | android | targetSdk meets Play requirements | — |
+| `android/min-sdk-capacitor` | android | minSdk meets Capacitor requirements | — |
+| `android/version-fields` | android | versionCode / versionName are present | — |
+| `android/play-sa-access` | android | Play service account can access the app (remote) | — |
+
+## Example: remote Next.js / server.url shell
+
+Shipping a native shell that loads a production `server.url` is a supported Capacitor pattern. Prescan flags `ios/capacitor-server-url-shipped` because it is often a live-reload leftover.
+
+Acknowledge it without disabling other checks:
+
+```bash
+npx @capgo/cli@latest build request <appId> --platform ios \
+  --prescan-skip ios/capacitor-server-url-shipped
+```
+
+Or keep visibility as a warning:
+
+```bash
+npx @capgo/cli@latest build request <appId> --platform ios \
+  --prescan-warn ios/capacitor-server-url-shipped
+```
+
+## Related
+
+<CardGrid>
+  <LinkCard
+    title="Getting Started"
+    description="Create your first Capgo Cloud Build."
+    href="/docs/builder/getting-started/"
+  />
+  <LinkCard
+    title="Troubleshooting"
+    description="Common Cloud Build failures and fixes."
+    href="/docs/builder/troubleshooting/"
+  />
+  <LinkCard
+    title="CLI build reference"
+    description="Full build request / prescan command options."
+    href="/docs/cli/reference/build/"
+  />
+</CardGrid>

--- a/apps/docs/src/content/docs/docs/builder/troubleshooting.mdx
+++ b/apps/docs/src/content/docs/docs/builder/troubleshooting.mdx
@@ -513,9 +513,21 @@ Current limitations:
 
 These limitations may be adjusted based on feedback.
 
+## Prescan blocked my build
+
+Capgo runs a local **prescan** before upload. Fix the reported finding, or ignore only that check id:
+
+```bash
+npx @capgo/cli@latest build request <appId> --platform ios \
+  --prescan-skip ios/capacitor-server-url-shipped
+```
+
+See the full catalog: [Prescan checks](/docs/builder/prescan/).
+
 ## Additional Resources
 
 - [Getting Started](/docs/builder/getting-started/) - Initial setup guide
 - [iOS Builds](/docs/builder/ios/) - iOS-specific configuration
 - [Android Builds](/docs/builder/android/) - Android-specific configuration
+- [Prescan checks](/docs/builder/prescan/) - Full list of pre-build checks and ignore flags
 - [CLI Reference](/docs/cli/reference/build/) - Complete command documentation

--- a/apps/docs/src/content/docs/docs/cli/reference/build.mdx
+++ b/apps/docs/src/content/docs/docs/cli/reference/build.mdx
@@ -139,6 +139,8 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--ai-analytics** | <code>boolean</code> | On build failure, send logs to Capgo AI for diagnosis. In interactive terminals this skips the upfront confirmation; in CI this auto-uploads and prints the analysis to stderr. |
 | **--no-prescan** | <code>boolean</code> | Skip the automatic pre-build scan |
 | **--prescan-ignore-fatal** | <code>boolean</code> | Run the pre-build scan but never block the build (report only) |
+| **--prescan-skip** | <code>string</code> | Skip specific prescan check(s) by id (repeatable or comma-separated). Other checks still run. |
+| **--prescan-warn** | <code>string</code> | Downgrade specific prescan check(s) to warning by id (repeatable or comma-separated). Check still runs. |
 | **--fail-on-warnings** | <code>boolean</code> | Treat prescan warnings as fatal |
 | **--send-logs-to-support** | <code>boolean</code> | On a CI/CD build failure, automatically upload the build logs to Capgo support (no email required). Capgo support is notified and will follow up by email. Additive to --ai-analytics. |
 | **--send-logs** | <code>boolean</code> | Deprecated alias for --send-logs-to-support |
@@ -176,6 +178,7 @@ npx @capgo/cli@latest build prescan
 
 Scan your project and saved credentials for problems that would fail a cloud build — before uploading anything.
 Checks credentials (expiry, passwords, profile pairing), project state (cap sync, node_modules layout), and platform config. Runs automatically inside `build request`; this command runs it standalone (e.g. in CI).
+See [Prescan checks](/docs/builder/prescan/) for the full check catalog and how to `--skip` / `--warn` individual rules.
 
 **Options:**
 
@@ -189,6 +192,8 @@ Checks credentials (expiry, passwords, profile pairing), project state (cap sync
 | **--json** | <code>boolean</code> | Output a machine-readable JSON report |
 | **--fail-on-warnings** | <code>boolean</code> | Exit non-zero when warnings are found (CI) |
 | **--ignore-fatal** | <code>boolean</code> | Diagnostic mode: report everything but always exit 0 |
+| **--skip** | <code>string</code> | Skip specific check(s) by id (repeatable or comma-separated) |
+| **--warn** | <code>string</code> | Downgrade specific check(s) to warning by id (repeatable or comma-separated) |
 | **--verbose** | <code>boolean</code> | Enable verbose output with detailed logging |
 | **--supa-host** | <code>string</code> | Custom Supabase host URL (for self-hosting or Capgo development) |
 | **--supa-anon** | <code>string</code> | Custom Supabase anon key (for self-hosting) |


### PR DESCRIPTION
## Summary (AI generated)

- Add `/docs/builder/prescan/` with the full catalog of 80 Capgo Cloud Build prescan check ids
- Document `--prescan-skip` / `--prescan-warn` (and standalone `--skip` / `--warn`) plus global escape flags
- Link the page from Builder intro, Troubleshooting, and the CLI `build` reference

## Motivation (AI generated)

Customers need a public list of every prescan rule and a way to ignore specific ones (for example intentional `server.url` / Next.js shells) without disabling the whole scan.

## Business Impact (AI generated)

Cuts support load around the Aug 14 gradual-enforce rollout and unblocks legitimate remote-web Capacitor architectures.

## Test Plan (AI generated)

- [ ] Preview `/docs/builder/prescan/` renders tables for shared / iOS / Android
- [ ] Links from `/docs/builder/`, troubleshooting, and CLI build reference resolve
- [ ] Example commands use `npx @capgo/cli@latest`

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788629980&installation_model_id=430928&pr_number=930&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F930&signature=cba60100c0d93a272cc6deebceb482b30dea96c41d345d6ded52bcaea035d140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

