### PR TITLE
feat(landing): highlight human support in hero

### DIFF
--- a/apps/shared/copy/messages.ts
+++ b/apps/shared/copy/messages.ts
@@ -1686,6 +1686,7 @@ const messages = {
     'Build as usual, upload changed JavaScript and assets with the CLI or API, and target the channels that should receive them. Start automatic in 5 minutes or go manual for advanced release logic.',
   home_global_infrastructure_desc: 'Powered by serverless edge computing and distributed databases across 300+ cities and 13,000+ networks for ultra-fast global delivery.',
   home_global_network_label: 'Global Network',
+  home_hero_human_support: 'human support from Martin',
   home_hero_outcome_compliance_desc:
     'Update JavaScript, CSS, copy, runtime flags, and assets while native code and Capacitor config keep going through normal App Store and Play review.',
   home_hero_outcome_compliance_title: 'Keep store review for native changes',

--- a/apps/web/src/components/AppflowShutdown.astro
+++ b/apps/web/src/components/AppflowShutdown.astro
@@ -1,6 +1,7 @@
 ---
 import m from '@/copy/messages'
 import { getRelativeLocaleUrl } from '@/services/links'
+import HumanSupport from '@/components/HumanSupport.astro'
 ---
 
 <!-- Ionic Appflow Shutdown Notice Section -->
@@ -202,7 +203,9 @@ import { getRelativeLocaleUrl } from '@/services/links'
         <div class="flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-sm font-bold text-white ring-2 ring-white">1k+</div>
       </div>
 
-      <div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
+      <div class="flex flex-col items-center justify-center gap-4">
+        <HumanSupport tone="light" size="sm" />
+        <div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
         <a
           href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
           class="inline-flex items-center justify-center rounded-xl bg-blue-600 px-8 py-4 text-base font-semibold text-white transition-all duration-200 hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
@@ -215,6 +218,7 @@ import { getRelativeLocaleUrl } from '@/services/links'
         >
           {m.migration_guide({}, { locale: Astro.locals.locale })}
         </a>
+        </div>
       </div>
     </div>
   </div>

--- a/apps/web/src/components/BuiltForDevelopers.astro
+++ b/apps/web/src/components/BuiltForDevelopers.astro
@@ -1,6 +1,7 @@
 ---
 import m from '@/copy/messages'
 import { getRelativeLocaleUrl } from '@/services/links'
+import HumanSupport from '@/components/HumanSupport.astro'
 ---
 
 <section class="bg-[#1a1a1a] py-24 sm:py-32">
@@ -343,7 +344,8 @@ import { getRelativeLocaleUrl } from '@/services/links'
       </dl>
     </div>
 
-    <div class="mt-16 flex justify-center">
+    <div class="mt-16 flex flex-col items-center gap-3">
+      <HumanSupport size="sm" />
       <a
         href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
         class="rounded-md bg-[#44BCFF] px-8 py-3 text-base font-semibold text-white shadow-sm hover:bg-[#3a9fd6] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#44BCFF]"

--- a/apps/web/src/components/CompetitorComparison.astro
+++ b/apps/web/src/components/CompetitorComparison.astro
@@ -1,5 +1,6 @@
 ---
 import { getRelativeLocaleUrl } from '@/services/links'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 interface Difference {
   label: string
@@ -106,7 +107,9 @@ const fitCards = [
           </p>
           <h1 class="mt-6 text-4xl leading-tight font-black text-white sm:text-5xl lg:text-6xl">{page.title}</h1>
           <p class="mt-5 max-w-2xl text-lg leading-8 text-slate-300">{page.subtitle}</p>
-          <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+          <div class="mt-8 flex flex-col gap-3">
+            <HumanSupport size="sm" align="start" />
+            <div class="flex flex-col gap-3 sm:flex-row">
             <a
               href={registerUrl}
               class="inline-flex min-h-12 items-center justify-center rounded-lg bg-sky-500 px-5 py-3 text-sm font-bold text-white shadow-lg shadow-sky-950/35 transition hover:bg-sky-400 focus:ring-2 focus:ring-sky-300 focus:outline-none"
@@ -119,6 +122,7 @@ const fitCards = [
             >
               See live updates
             </a>
+            </div>
           </div>
         </div>
 
@@ -290,7 +294,9 @@ const fitCards = [
         <p class="mt-4 max-w-2xl text-base leading-7 text-slate-300">
           Use Capgo for live updates, rollback, channels, device logs, plugin maintenance, and native builds when your app is built on Capacitor.
         </p>
-        <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+        <div class="mt-8 flex flex-col gap-3">
+          <HumanSupport size="sm" align="start" />
+          <div class="flex flex-col gap-3 sm:flex-row">
           <a
             href={registerUrl}
             class="inline-flex min-h-12 items-center justify-center rounded-lg bg-white px-5 py-3 text-sm font-bold text-gray-950 transition hover:bg-slate-200 focus:ring-2 focus:ring-white focus:outline-none"
@@ -303,6 +309,7 @@ const fitCards = [
           >
             Read live update guide
           </a>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/GetStarted.astro
+++ b/apps/web/src/components/GetStarted.astro
@@ -1,6 +1,7 @@
 ---
 import m from '@/copy/messages'
 import { getRelativeLocaleUrl } from '@/services/links'
+import HumanSupport from '@/components/HumanSupport.astro'
 ---
 
 <div>
@@ -17,12 +18,15 @@ import { getRelativeLocaleUrl } from '@/services/links'
         {m.instant_updates_for_capacitor_apps_description({}, { locale: Astro.locals.locale })}
       </p>
 
-      <a
-        href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
-        class="inline-flex w-full items-center justify-center rounded-lg bg-black px-6 py-3 text-lg text-white transition-colors duration-200 hover:bg-gray-800 sm:w-auto sm:px-10 sm:py-4 sm:text-xl"
-      >
-        {m.get_started_now({}, { locale: Astro.locals.locale })}
-      </a>
+      <div class="flex flex-col items-start gap-3">
+        <HumanSupport size="sm" align="start" />
+        <a
+          href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
+          class="inline-flex w-full items-center justify-center rounded-lg bg-black px-6 py-3 text-lg text-white transition-colors duration-200 hover:bg-gray-800 sm:w-auto sm:px-10 sm:py-4 sm:text-xl"
+        >
+          {m.get_started_now({}, { locale: Astro.locals.locale })}
+        </a>
+      </div>
     </div>
   </div>
 </div>

--- a/apps/web/src/components/GlobalInfrastructure.astro
+++ b/apps/web/src/components/GlobalInfrastructure.astro
@@ -1,6 +1,7 @@
 ---
 import m from '@/copy/messages'
 import { getRelativeLocaleUrl } from '@/services/links'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. ${m.no_credit_card_required({}, { locale: Astro.locals.locale })}`
 ---
@@ -153,6 +154,7 @@ const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. $
     </div>
 
     <div class="mt-16 flex flex-col items-center gap-3">
+      <HumanSupport size="sm" />
       <a
         href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
         class="rounded-md bg-[#44BCFF] px-8 py-3 text-base font-semibold text-white shadow-sm hover:bg-[#3a9fd6] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#44BCFF]"

--- a/apps/web/src/components/Hero.astro
+++ b/apps/web/src/components/Hero.astro
@@ -2,7 +2,6 @@
 import m from '@/copy/messages'
 import { getRelativeLocaleUrl } from '@/services/links'
 import TeamAvatars from '@/components/TeamAvatars.astro'
-import HumanSupport from '@/components/HumanSupport.astro'
 
 const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. ${m.no_credit_card_required({}, { locale: Astro.locals.locale })}`
 const nativeBuildUrl = getRelativeLocaleUrl(Astro.locals.locale, 'native-build')
@@ -204,7 +203,6 @@ const teamUrl = 'https://book.capgo.app/demo/'
         <p class="font-inter mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-400 sm:text-xl">
           Live updates, native builds, channels, rollback, and release automation for CapacitorJS apps.
         </p>
-        <HumanSupport class="mt-5" />
         <div class="mt-10 flex flex-col items-center gap-4">
           <div class="flex flex-col items-center gap-4 sm:flex-row">
             <div class="group relative inline-flex">

--- a/apps/web/src/components/Hero.astro
+++ b/apps/web/src/components/Hero.astro
@@ -2,6 +2,7 @@
 import m from '@/copy/messages'
 import { getRelativeLocaleUrl } from '@/services/links'
 import TeamAvatars from '@/components/TeamAvatars.astro'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. ${m.no_credit_card_required({}, { locale: Astro.locals.locale })}`
 const nativeBuildUrl = getRelativeLocaleUrl(Astro.locals.locale, 'native-build')
@@ -203,19 +204,7 @@ const teamUrl = 'https://book.capgo.app/demo/'
         <p class="font-inter mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-400 sm:text-xl">
           Live updates, native builds, channels, rollback, and release automation for CapacitorJS apps.
         </p>
-        <p class="font-inter mt-5 inline-flex items-center justify-center gap-2 text-base text-gray-400 sm:text-lg">
-          <span>{m.home_hero_human_support({}, { locale: Astro.locals.locale })}</span>
-          <img
-            src="/martin-avatar.png"
-            alt=""
-            width="28"
-            height="28"
-            class="h-7 w-7 rounded-full object-cover ring-2 ring-white/15"
-            loading="eager"
-            decoding="async"
-            aria-hidden="true"
-          />
-        </p>
+        <HumanSupport class="mt-5" />
         <div class="mt-10 flex flex-col items-center gap-4">
           <div class="flex flex-col items-center gap-4 sm:flex-row">
             <div class="group relative inline-flex">

--- a/apps/web/src/components/Hero.astro
+++ b/apps/web/src/components/Hero.astro
@@ -203,6 +203,19 @@ const teamUrl = 'https://book.capgo.app/demo/'
         <p class="font-inter mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-400 sm:text-xl">
           Live updates, native builds, channels, rollback, and release automation for CapacitorJS apps.
         </p>
+        <p class="font-inter mt-5 inline-flex items-center justify-center gap-2 text-base text-gray-400 sm:text-lg">
+          <span>{m.home_hero_human_support({}, { locale: Astro.locals.locale })}</span>
+          <img
+            src="/martin-avatar.png"
+            alt=""
+            width="28"
+            height="28"
+            class="h-7 w-7 rounded-full object-cover ring-2 ring-white/15"
+            loading="eager"
+            decoding="async"
+            aria-hidden="true"
+          />
+        </p>
         <div class="mt-10 flex flex-col items-center gap-4">
           <div class="flex flex-col items-center gap-4 sm:flex-row">
             <div class="group relative inline-flex">

--- a/apps/web/src/components/HowItWorks.astro
+++ b/apps/web/src/components/HowItWorks.astro
@@ -1,6 +1,7 @@
 ---
 import m from '@/copy/messages'
 import { getRelativeLocaleUrl } from '@/services/links'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. ${m.no_credit_card_required({}, { locale: Astro.locals.locale })}`
 ---
@@ -400,6 +401,7 @@ const ctaSubtext = `${m.days_free_trial({}, { locale: Astro.locals.locale })}. $
     </div>
 
     <div class="mt-16 flex flex-col items-center gap-3">
+      <HumanSupport size="sm" />
       <a
         href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
         class="rounded-md bg-[#44BCFF] px-8 py-3 text-base font-semibold text-white shadow-sm hover:bg-[#3a9fd6] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#44BCFF]"

--- a/apps/web/src/components/HumanSupport.astro
+++ b/apps/web/src/components/HumanSupport.astro
@@ -1,0 +1,32 @@
+---
+import m from '@/copy/messages'
+
+interface Props {
+  class?: string
+  tone?: 'dark' | 'light' | 'muted'
+  size?: 'sm' | 'md'
+  align?: 'center' | 'start'
+}
+
+const { class: className = '', tone = 'dark', size = 'md', align = 'center' } = Astro.props
+
+const toneClass = tone === 'light' ? 'text-gray-600' : tone === 'muted' ? 'text-gray-500' : 'text-gray-400'
+const sizeClass = size === 'sm' ? 'text-sm gap-1.5' : 'text-base sm:text-lg gap-2'
+const alignClass = align === 'start' ? 'justify-start' : 'justify-center'
+const avatarClass = size === 'sm' ? 'h-5 w-5' : 'h-7 w-7'
+const avatarPx = size === 'sm' ? 20 : 28
+---
+
+<p class:list={['font-inter inline-flex items-center', sizeClass, toneClass, alignClass, className]}>
+  <span>{m.home_hero_human_support({}, { locale: Astro.locals.locale })}</span>
+  <img
+    src="/martin-avatar.png"
+    alt=""
+    width={avatarPx}
+    height={avatarPx}
+    class:list={[avatarClass, 'rounded-full object-cover ring-2 ring-white/15']}
+    loading="lazy"
+    decoding="async"
+    aria-hidden="true"
+  />
+</p>

--- a/apps/web/src/components/Orgs.astro
+++ b/apps/web/src/components/Orgs.astro
@@ -3,6 +3,7 @@ import m from '@/copy/messages'
 import { getRelativeLocaleUrl } from '@/services/links'
 import { Image } from 'astro:assets'
 import orgsGraphic from '@/assets/orgs-graphic.svg'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const features = [
   {
@@ -183,7 +184,8 @@ const features = [
     </div>
 
     <!-- CTA Button -->
-    <div class="mt-20 text-center">
+    <div class="mt-20 flex flex-col items-center gap-3 text-center">
+      <HumanSupport size="sm" />
       <a
         href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
         class="inline-flex items-center justify-center rounded-xl bg-[#5B7FE8] px-12 py-4 text-lg font-semibold text-white shadow-lg shadow-blue-500/20 transition-all duration-200 hover:bg-[#4a6ed4] hover:shadow-blue-500/30 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] focus:outline-none"

--- a/apps/web/src/components/enterprise.astro
+++ b/apps/web/src/components/enterprise.astro
@@ -1,5 +1,6 @@
 ---
 import m from '@/copy/messages'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const featureGroups = [
   {
@@ -44,7 +45,9 @@ const stats = [
         {m.enterprise_description()}
       </p>
 
-      <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+      <div class="mt-8 flex flex-col gap-3">
+        <HumanSupport tone="light" size="sm" align="start" />
+        <div class="flex flex-col gap-3 sm:flex-row">
         <a
           href="https://book.capgo.app/enterprise-inquiry/"
           target="_blank"
@@ -59,6 +62,7 @@ const stats = [
         >
           View enterprise features
         </a>
+        </div>
       </div>
 
       <div class="mt-8 flex flex-wrap gap-x-6 gap-y-3 text-sm text-gray-600">

--- a/apps/web/src/components/landing/DeviceLogs.astro
+++ b/apps/web/src/components/landing/DeviceLogs.astro
@@ -1,5 +1,6 @@
 ---
 import m from '@/copy/messages'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 ---
@@ -35,13 +36,16 @@ const locale = Astro.locals.locale
             {m.live_update_logs_bullet4({}, { locale })}
           </li>
         </ul>
-        <div class="mt-8 flex flex-wrap gap-3">
+        <div class="mt-8 flex flex-col items-start gap-3">
+          <HumanSupport size="sm" align="start" />
+          <div class="flex flex-wrap gap-3">
           <a href="/register/" class="rounded-lg bg-blue-600 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-blue-600/30 transition hover:bg-blue-700">
             {m.live_update_logs_cta_primary({}, { locale })}
           </a>
           <a href="/live-update/" class="rounded-lg border border-white/10 px-5 py-3 text-sm font-semibold text-blue-100 transition hover:border-blue-400/60">
             {m.live_update_logs_cta_secondary({}, { locale })}
           </a>
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/components/pricing/Plans.astro
+++ b/apps/web/src/components/pricing/Plans.astro
@@ -4,6 +4,7 @@ import type { Database } from '@/services/supabase.types'
 import { getRelativeLocaleUrl } from '@/services/links'
 import m from '@/copy/messages'
 import TeamAvatars from '@/components/TeamAvatars.astro'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 interface Props {
   pricing: Database['public']['Tables']['plans']['Row'][]
@@ -109,6 +110,7 @@ function buildTimeDisplay(buildTimeSeconds: number) {
           </div>
 
           <div class="mt-6 space-y-3">
+            <HumanSupport tone="light" size="sm" align="start" class="mb-1" />
             <a
               href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
               target="_blank"

--- a/apps/web/src/components/pricing/Plans.astro
+++ b/apps/web/src/components/pricing/Plans.astro
@@ -4,7 +4,6 @@ import type { Database } from '@/services/supabase.types'
 import { getRelativeLocaleUrl } from '@/services/links'
 import m from '@/copy/messages'
 import TeamAvatars from '@/components/TeamAvatars.astro'
-import HumanSupport from '@/components/HumanSupport.astro'
 
 interface Props {
   pricing: Database['public']['Tables']['plans']['Row'][]
@@ -110,7 +109,6 @@ function buildTimeDisplay(buildTimeSeconds: number) {
           </div>
 
           <div class="mt-6 space-y-3">
-            <HumanSupport tone="light" size="sm" align="start" class="mb-1" />
             <a
               href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
               target="_blank"
@@ -155,6 +153,32 @@ function buildTimeDisplay(buildTimeSeconds: number) {
                   <span>{highlight}</span>
                 </li>
               ))}
+              <li class="flex items-start gap-3">
+                <svg
+                  class="mt-1 h-4 w-4 shrink-0 text-gray-500"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="2.5"
+                  aria-hidden="true"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                </svg>
+                <span class="inline-flex items-center gap-1.5">
+                  {m.home_hero_human_support({}, { locale: Astro.locals.locale })}
+                  <img
+                    src="/martin-avatar.png"
+                    alt=""
+                    width="20"
+                    height="20"
+                    class="h-5 w-5 rounded-full object-cover ring-1 ring-gray-200"
+                    loading="lazy"
+                    decoding="async"
+                    aria-hidden="true"
+                  />
+                </span>
+              </li>
             </ul>
           </div>
 

--- a/apps/web/src/components/solutions/SolutionAppExample.astro
+++ b/apps/web/src/components/solutions/SolutionAppExample.astro
@@ -5,6 +5,7 @@ import { solutionStoreApps } from '@/config/solutionStoreApps'
 import { renameCat, shortNumber } from '@/services/misc'
 import { getRelativeLocaleUrl } from '@/services/links'
 import TeamAvatars from '@/components/TeamAvatars.astro'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 interface Props {
   solution: SolutionAppExampleKey
@@ -39,7 +40,9 @@ const showExampleCtas = solution === 'enterprise'
             <h2 class="mt-4 max-w-2xl text-3xl leading-tight font-semibold tracking-tight text-balance text-white sm:text-4xl">{copy(example.headlineKey)}</h2>
             <p class="mt-4 max-w-3xl text-base leading-7 text-pretty text-slate-300 sm:text-lg">{copy(example.useCaseKey)}</p>
             {showExampleCtas && (
-              <div class="solution-app-examples-actions mt-6 flex flex-col gap-3 sm:flex-row">
+              <div class="solution-app-examples-actions mt-6 flex flex-col gap-3">
+                <HumanSupport size="sm" align="start" />
+                <div class="flex flex-col gap-3 sm:flex-row">
                 <a
                   href={registerUrl}
                   class="solution-app-examples-primary inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-cyan-300 px-5 py-3 text-sm font-bold text-slate-950 shadow-lg shadow-cyan-950/30 transition hover:bg-cyan-200 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-cyan-300"
@@ -63,6 +66,7 @@ const showExampleCtas = solution === 'enterprise'
                   <TeamAvatars />
                   <span>{copy('solutions_talk_to_team')}</span>
                 </a>
+                </div>
               </div>
             )}
           </div>
@@ -165,14 +169,15 @@ const showExampleCtas = solution === 'enterprise'
               </div>
             </div>
 
-            <div class="mt-6">
+            <div class="mt-6 flex flex-col gap-3">
+              <HumanSupport size="sm" align="start" />
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="solution-app-examples-cta-link inline-flex min-h-12 w-full items-center justify-center rounded-lg bg-cyan-300 px-5 py-3 text-sm font-bold text-slate-950 shadow-lg shadow-cyan-950/30 transition hover:bg-cyan-200 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-cyan-300"
               >
                 {copy('solution_app_examples_cta_button')}
               </a>
-              <p class="mt-4 text-xs leading-5 text-slate-400">{copy('solution_app_examples_disclaimer')}</p>
+              <p class="mt-1 text-xs leading-5 text-slate-400">{copy('solution_app_examples_disclaimer')}</p>
             </div>
           </aside>
         </div>

--- a/apps/web/src/pages/about.astro
+++ b/apps/web/src/pages/about.astro
@@ -2,6 +2,7 @@
 import Layout from '@/layouts/Layout.astro'
 import m from '@/copy/messages'
 import { getRelativeLocaleUrl } from '@/services/links'
+import HumanSupport from '@/components/HumanSupport.astro'
 import { createLdJsonGraph, createPersonLdJson, createWebPageLdJson } from '@/lib/ldJson'
 import { pluginCountLabel } from '@/config/plugins'
 import type { Thing } from 'schema-dts'
@@ -196,7 +197,9 @@ const timeline = [
             hands-on, and focused on the release path between your code and your users.
           </p>
 
-          <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+          <div class="mt-8 flex flex-col gap-3">
+            <HumanSupport tone="light" size="sm" align="start" />
+            <div class="flex flex-col gap-3 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
               class="inline-flex min-h-11 items-center justify-center rounded-full bg-gray-950 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-gray-800 focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:outline-none"
@@ -209,6 +212,7 @@ const timeline = [
             >
               Read the docs
             </a>
+            </div>
           </div>
         </div>
 
@@ -338,7 +342,9 @@ const timeline = [
             </div>
           </div>
 
-          <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+          <div class="mt-8 flex flex-col gap-3">
+            <HumanSupport tone="light" size="sm" align="start" />
+            <div class="flex flex-col gap-3 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
               class="inline-flex min-h-11 items-center justify-center rounded-full bg-gray-950 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-gray-800 focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:outline-none"
@@ -351,6 +357,7 @@ const timeline = [
             >
               Read the full story
             </a>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/src/pages/alternatives.astro
+++ b/apps/web/src/pages/alternatives.astro
@@ -4,6 +4,7 @@ import { getRelativeLocaleUrl } from '@/services/links'
 import m from '@/copy/messages'
 import { pluginCountLabel } from '@/config/plugins'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const title = m.alternatives_title({}, { locale })
@@ -309,7 +310,8 @@ const content = {
       <p class="mb-8 text-gray-300">
         {m.alternatives_cta_subtitle({}, { locale })}
       </p>
-      <a href={getRelativeLocaleUrl(locale, 'register')} class="inline-block rounded-lg bg-emerald-600 px-8 py-3 text-lg font-medium text-white hover:bg-emerald-700">
+      <HumanSupport class="mb-4" size="sm" />
+      <a href={getRelativeLocaleUrl(locale, 'register')} class="inline-block rounded-lg bg-emerald-600 px-8 py-3 text-lg font-medium text-white hover:bg-emerald-700">      <a href={getRelativeLocaleUrl(locale, 'register')} class="inline-block rounded-lg bg-emerald-600 px-8 py-3 text-lg font-medium text-white hover:bg-emerald-700">
         {m.alternatives_cta_button({}, { locale })}
       </a>
       <p class="mt-4 text-sm text-gray-400" set:html={m.alternatives_cta_questions({}, { locale })} />

--- a/apps/web/src/pages/alternatives.astro
+++ b/apps/web/src/pages/alternatives.astro
@@ -311,7 +311,7 @@ const content = {
         {m.alternatives_cta_subtitle({}, { locale })}
       </p>
       <HumanSupport class="mb-4" size="sm" />
-      <a href={getRelativeLocaleUrl(locale, 'register')} class="inline-block rounded-lg bg-emerald-600 px-8 py-3 text-lg font-medium text-white hover:bg-emerald-700">      <a href={getRelativeLocaleUrl(locale, 'register')} class="inline-block rounded-lg bg-emerald-600 px-8 py-3 text-lg font-medium text-white hover:bg-emerald-700">
+      <a href={getRelativeLocaleUrl(locale, 'register')} class="inline-block rounded-lg bg-emerald-600 px-8 py-3 text-lg font-medium text-white hover:bg-emerald-700">
         {m.alternatives_cta_button({}, { locale })}
       </a>
       <p class="mt-4 text-sm text-gray-400" set:html={m.alternatives_cta_questions({}, { locale })} />

--- a/apps/web/src/pages/app-store-refusal-horror-story.astro
+++ b/apps/web/src/pages/app-store-refusal-horror-story.astro
@@ -2,6 +2,7 @@
 import Layout from '@/layouts/Layout.astro'
 import { createLdJsonGraph, createWebPageLdJson } from '@/lib/ldJson'
 import { refusalStories, storySubmissionFilePath } from '@/data/appStoreRefusalStories'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const config = Astro.locals.runtimeConfig.public
 const title = 'App Store Refusal Horror Story | Capgo'
@@ -173,6 +174,7 @@ const severityStyles = {
             </p>
           </div>
           <div class="lg:col-span-5">
+            <HumanSupport class="mb-3" size="sm" align="start" />
             <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
               <a
                 href="/register/"

--- a/apps/web/src/pages/app_mobile.astro
+++ b/apps/web/src/pages/app_mobile.astro
@@ -9,6 +9,7 @@ import type { SolutionStoreAppId } from '@/config/solutionStoreApps'
 import Layout from '@/layouts/Layout.astro'
 import m from '@/copy/messages'
 import { getRelativeLocaleUrl } from '@/services/links'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const title = 'Capgo mobile app | Preview builds and manage live updates on the go'
 const description =
@@ -283,7 +284,10 @@ const appExampleIds: SolutionStoreAppId[] = ['com.windyty.android', 'com.studysm
             </a>
           ))
         }
+        <HumanSupport class="mb-3" size="sm" />
         <a
+          href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
+          class="inline-flex min-h-12 items-center justify-center rounded-lg bg-white px-5 py-3 text-sm font-semibold text-slate-950        <a
           href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
           class="inline-flex min-h-12 items-center justify-center rounded-lg bg-white px-5 py-3 text-sm font-semibold text-slate-950 transition-colors hover:bg-slate-200 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white"
         >

--- a/apps/web/src/pages/capacitor-app.astro
+++ b/apps/web/src/pages/capacitor-app.astro
@@ -2,6 +2,7 @@
 import Layout from '@/layouts/Layout.astro'
 import { createFAQPageLdJson, createLdJsonGraph, createWebPageLdJson } from '@/lib/ldJson'
 import { getRelativeLocaleUrl } from '@/services/links'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const config = Astro.locals.runtimeConfig.public
@@ -169,7 +170,8 @@ const content = {
             plugins bridge that web code to native device APIs like camera, storage, push notifications, biometrics, files, and location. Capgo turns that architecture into a
             release advantage with live updates, maintained plugins, and native cloud builds.
           </p>
-          <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+          <HumanSupport class="mt-6" size="sm" />
+          <div class="mt-4 flex flex-col gap-3 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'plugins')}
               class="inline-flex items-center justify-center rounded-lg bg-sky-500 px-5 py-3 text-sm font-semibold text-white transition hover:bg-sky-400"
@@ -309,7 +311,8 @@ const content = {
           ))
         }
       </div>
-      <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+      <HumanSupport class="mt-6" size="sm" />
+      <div class="mt-4 flex flex-col gap-3 sm:flex-row">
         <a
           href={getRelativeLocaleUrl(locale, 'live-update')}
           class="inline-flex items-center justify-center rounded-lg bg-sky-500 px-5 py-3 text-sm font-semibold text-white transition hover:bg-sky-400"

--- a/apps/web/src/pages/capwesome.astro
+++ b/apps/web/src/pages/capwesome.astro
@@ -360,8 +360,6 @@ const migrationGuideUrl = getRelativeLocaleUrl(locale, 'docs/upgrade/from-capawe
             <HumanSupport class="mb-4" size="sm" />
             <div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
-                href={getRelativeLocaleUrl(locale, 'register')}            <div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
-              <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-8 py-4 text-lg font-bold text-white transition-all hover:bg-emerald-700"
               >

--- a/apps/web/src/pages/capwesome.astro
+++ b/apps/web/src/pages/capwesome.astro
@@ -3,6 +3,7 @@ import Layout from '@/layouts/Layout.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import m from '@/copy/messages'
 import { pluginCountLabel } from '@/config/plugins'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const title = m.capwesome_title({}, { locale })
@@ -356,7 +357,10 @@ const migrationGuideUrl = getRelativeLocaleUrl(locale, 'docs/upgrade/from-capawe
             <p class="mx-auto mb-8 max-w-2xl text-gray-300">
               {m.capwesome_cta_subtitle({}, { locale })}
             </p>
+            <HumanSupport class="mb-4" size="sm" />
             <div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
+              <a
+                href={getRelativeLocaleUrl(locale, 'register')}            <div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-8 py-4 text-lg font-bold text-white transition-all hover:bg-emerald-700"

--- a/apps/web/src/pages/consulting.astro
+++ b/apps/web/src/pages/consulting.astro
@@ -202,8 +202,6 @@ const useCases = [
       <HumanSupport class="mb-4" size="sm" />
       <div class="flex flex-col justify-center gap-4 sm:flex-row">
         <a
-          href="https://book.capgo.app/capacitor-plugin/"      <div class="flex flex-col justify-center gap-4 sm:flex-row">
-        <a
           href="https://book.capgo.app/capacitor-plugin/"
           target="_blank"
           rel="noopener noreferrer"
@@ -654,8 +652,6 @@ const useCases = [
 
         <HumanSupport class="mb-4" size="sm" />
         <div class="flex flex-col justify-center gap-4 sm:flex-row">
-          <a
-            href="https://book.capgo.app/capacitor-plugin/"        <div class="flex flex-col justify-center gap-4 sm:flex-row">
           <a
             href="https://book.capgo.app/capacitor-plugin/"
             target="_blank"

--- a/apps/web/src/pages/consulting.astro
+++ b/apps/web/src/pages/consulting.astro
@@ -3,6 +3,7 @@ import Layout from '@/layouts/Layout.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import m from '@/copy/messages'
 import { createServiceLdJson, createLdJsonGraph, createFAQPageLdJson } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const title = [Astro.locals.runtimeConfig.public.brand, m.consulting({}, { locale })].join(' | ')
@@ -198,7 +199,10 @@ const useCases = [
         Need a native feature that doesn't exist? We build custom Capacitor plugins and provide expert consulting to bring any native functionality to your app.
       </p>
 
+      <HumanSupport class="mb-4" size="sm" />
       <div class="flex flex-col justify-center gap-4 sm:flex-row">
+        <a
+          href="https://book.capgo.app/capacitor-plugin/"      <div class="flex flex-col justify-center gap-4 sm:flex-row">
         <a
           href="https://book.capgo.app/capacitor-plugin/"
           target="_blank"
@@ -648,7 +652,10 @@ const useCases = [
           Whether you need a custom plugin built or expert consulting for your Capacitor app, we're here to make it happen.
         </p>
 
+        <HumanSupport class="mb-4" size="sm" />
         <div class="flex flex-col justify-center gap-4 sm:flex-row">
+          <a
+            href="https://book.capgo.app/capacitor-plugin/"        <div class="flex flex-col justify-center gap-4 sm:flex-row">
           <a
             href="https://book.capgo.app/capacitor-plugin/"
             target="_blank"

--- a/apps/web/src/pages/cost/cost-to-publish-app-on-app-store.astro
+++ b/apps/web/src/pages/cost/cost-to-publish-app-on-app-store.astro
@@ -2,6 +2,7 @@
 import Layout from '@/layouts/Layout.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import { createFAQPageLdJson, createLdJsonGraph, createServiceLdJson } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -194,6 +195,7 @@ const resources = [
           <p class="text-lg text-slate-300 max-w-2xl">
             Get a clean breakdown of developer fees, revenue share, and launch expenses for Apple and Google. Plan your release budget and avoid surprises before you submit.
           </p>
+          <HumanSupport class="mb-2" size="sm" align="start" />
           <div class="flex flex-wrap items-center gap-4">
             <a
               href={getRelativeLocaleUrl(locale, '/register/')}
@@ -487,7 +489,8 @@ const resources = [
             <p class="mt-4 text-base text-slate-200">
               Every store update adds review time. Capgo helps you deliver web updates instantly while keeping native releases for the moments that truly need them.
             </p>
-            <div class="flex flex-wrap items-center gap-4 mt-6">
+            <HumanSupport class="mt-6 mb-2" size="sm" align="start" />
+            <div class="flex flex-wrap items-center gap-4 mt-4">
               <a
                 href={getRelativeLocaleUrl(locale, '/register/')}
                 class="inline-flex items-center justify-center px-6 py-3 text-sm font-bold text-slate-950 bg-white rounded-xl transition hover:-translate-y-0.5 hover:bg-slate-100"
@@ -550,7 +553,8 @@ const resources = [
         <p class="mt-4 text-base text-slate-300">
           Start with Capgo to move faster after approval and keep your release costs predictable.
         </p>
-        <div class="flex flex-col items-center justify-center gap-4 mt-6 sm:flex-row">
+        <HumanSupport class="mt-6" size="sm" />
+        <div class="flex flex-col items-center justify-center gap-4 mt-4 sm:flex-row">
           <a
             href={getRelativeLocaleUrl(locale, '/register/')}
             class="inline-flex items-center justify-center px-6 py-3 text-sm font-bold text-slate-950 bg-white rounded-xl transition hover:-translate-y-0.5 hover:bg-slate-100"

--- a/apps/web/src/pages/enterprise.astro
+++ b/apps/web/src/pages/enterprise.astro
@@ -9,6 +9,7 @@ import type { Database } from '@/services/supabase.types'
 import { createFAQPageLdJson, createLdJsonGraph, createServiceLdJson, createProductLdJson } from '@/lib/ldJson'
 import { numberWithSpaces } from '@/services/misc'
 import { pluginCountLabel } from '@/config/plugins'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const config = Astro.locals.runtimeConfig
@@ -507,6 +508,7 @@ const comparisonAfterLabel = m.enterprise_comparison_after({}, { locale })
         </h1>
         <p class="lead hero-lead">{m.enterprise_hero_desc({}, { locale })}</p>
         <div class="hero-ctas">
+          <HumanSupport class="mb-3" size="sm" align="start" />
           <div class="hero-cta-buttons">
             <a
               class="btn btn-lg btn-primary"
@@ -565,6 +567,7 @@ const comparisonAfterLabel = m.enterprise_comparison_after({}, { locale })
                 ))
               }
             </ul>
+            <HumanSupport class="mb-4" size="sm" />
             <a
               class="enterprise-partnership-cta"
               href="https://book.capgo.app/enterprise-inquiry/"
@@ -741,6 +744,7 @@ const comparisonAfterLabel = m.enterprise_comparison_after({}, { locale })
                 ))
               }
             </ul>
+            <HumanSupport class="mb-4" size="sm" />
             <a
               class="enterprise-partnership-cta"
               href="https://book.capgo.app/enterprise-inquiry/"

--- a/apps/web/src/pages/ionic-appflow.astro
+++ b/apps/web/src/pages/ionic-appflow.astro
@@ -5,6 +5,7 @@ import { productVideos } from '@/config/productVideos'
 import { getRelativeLocaleUrl } from '@/services/links'
 import m from '@/copy/messages'
 import { pluginCountLabel } from '@/config/plugins'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const title = m.capflow_title({}, { locale })
@@ -412,7 +413,10 @@ const nativeBuildUrl = getRelativeLocaleUrl(locale, 'native-build')
             <p class="mx-auto mb-8 max-w-2xl text-gray-300">
               {m.appflow_cta_subtitle({}, { locale })}
             </p>
+            <HumanSupport class="mb-4" size="sm" />
             <div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
+              <a
+                href={getRelativeLocaleUrl(locale, 'register')}            <div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-8 py-4 text-lg font-bold text-white transition-all hover:bg-emerald-700"

--- a/apps/web/src/pages/ionic-appflow.astro
+++ b/apps/web/src/pages/ionic-appflow.astro
@@ -416,8 +416,6 @@ const nativeBuildUrl = getRelativeLocaleUrl(locale, 'native-build')
             <HumanSupport class="mb-4" size="sm" />
             <div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
-                href={getRelativeLocaleUrl(locale, 'register')}            <div class="flex flex-col items-center justify-center gap-4 sm:flex-row">
-              <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="inline-flex items-center justify-center rounded-xl bg-emerald-600 px-8 py-4 text-lg font-bold text-white transition-all hover:bg-emerald-700"
               >

--- a/apps/web/src/pages/ionic-enterprise-plugins.astro
+++ b/apps/web/src/pages/ionic-enterprise-plugins.astro
@@ -8,6 +8,7 @@ import m from '@/copy/messages'
 import { pluginCountLabel } from '@/config/plugins'
 import { getRelativeLocaleUrl } from '@/services/links'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -517,7 +518,8 @@ const content = { title, description, image: `${Astro.locals.runtimeConfig.publi
           <p class="mt-4 text-lg text-emerald-100">
             {m.solutions_ionic_plugins_cta_subtitle({}, { locale })}
           </p>
-          <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-6" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-emerald-600 px-8 py-4 text-base font-semibold text-white transition-all duration-200 hover:bg-emerald-700"

--- a/apps/web/src/pages/live-update.astro
+++ b/apps/web/src/pages/live-update.astro
@@ -8,6 +8,7 @@ import Layout from '@/layouts/Layout.astro'
 import m, { type MessageValues } from '@/copy/messages'
 import { getRelativeLocaleUrl } from '@/services/links'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -234,6 +235,7 @@ const featureTiles = [
         </h1>
         <p class="lead hero-lead">{m.live_update_hero_subtitle({}, { locale })}</p>
         <div class="hero-ctas">
+          <HumanSupport class="mb-3" size="sm" align="start" />
           <div class="hero-cta-buttons">
             <a class="btn btn-lg btn-primary" href={registerUrl}>{m.live_update_hero_cta({}, { locale })}</a>
             <a class="btn btn-lg btn-ghost" href={docsUrl}>{m.live_update_view_docs({}, { locale })}</a>
@@ -387,6 +389,7 @@ const featureTiles = [
               {guidanceChecks.map((check) => <li>{check}</li>)}
             </ul>
             <div class="hero-ctas" style="margin-top: 28px; align-items: flex-start;">
+              <HumanSupport class="mb-3" size="sm" align="start" />
               <div class="hero-cta-buttons">
                 <a class="btn btn-md btn-primary" href={getRelativeLocaleUrl(locale, 'docs/live-updates/compatibility')}>
                   {m.live_update_guidance_docs_cta({}, { locale })}
@@ -494,6 +497,7 @@ const featureTiles = [
           {m.live_update_cta_title({}, { locale })}
         </h2>
         <p class="tagline">{m.live_update_cta_subtitle({}, { locale })}</p>
+        <HumanSupport class="mb-4" size="sm" />
         <a class="btn btn-lg btn-primary btn-cta" href={registerUrl}>{m.live_update_hero_cta({}, { locale })} →</a>
         <div class="hero-meta hero-meta--cta">
           <span><span class="check">✓</span> {copy('live_update_v2_cta_meta1')}</span>

--- a/apps/web/src/pages/native-build.astro
+++ b/apps/web/src/pages/native-build.astro
@@ -10,6 +10,7 @@ import m, { type MessageValues } from '@/copy/messages'
 import { createLdJsonGraph, createServiceLdJson } from '@/lib/ldJson'
 import type { Database } from '@/services/supabase.types'
 import { getRelativeLocaleUrl } from '@/services/links'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 type Plan = Database['public']['Tables']['plans']['Row']
 
@@ -283,6 +284,7 @@ function buildTimeDisplay(buildTimeSeconds: number, name?: string) {
         </h1>
         <p class="lead hero-lead">{copy('native_build_v2_hero_lead')}</p>
         <div class="hero-ctas">
+          <HumanSupport class="mb-3" size="sm" align="start" />
           <div class="hero-cta-buttons">
             <a class="btn btn-lg btn-primary" href={registerUrl}>{copy('native_build_v2_hero_cta')}</a>
             <a class="btn btn-lg btn-ghost" href="#how">{copy('native_build_v2_hero_secondary')} ↓</a>
@@ -949,6 +951,7 @@ $ capgo build request --platform android  ✔ 1m 22s</pre>
           {copy('native_build_v2_cta_title')}
         </h2>
         <p class="tagline">{copy('native_build_v2_cta_tagline')}</p>
+        <HumanSupport class="mb-4" size="sm" />
         <a class="btn btn-lg btn-primary btn-cta" href={registerUrl}>{copy('native_build_builder_start_trial')} →</a>
         <div class="hero-meta hero-meta--cta">
           <span><span class="check">✓</span> {copy('native_build_v2_cta_meta1')}</span>

--- a/apps/web/src/pages/notifications.astro
+++ b/apps/web/src/pages/notifications.astro
@@ -3,6 +3,7 @@ import '@/styles/lu-product.css'
 import Layout from '@/layouts/Layout.astro'
 import { createLdJsonGraph, createServiceLdJson } from '@/lib/ldJson'
 import { getRelativeLocaleUrl } from '@/services/links'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -147,6 +148,7 @@ const guidanceChecks = [
           instead of leaving release teams to stitch it together.
         </p>
         <div class="hero-ctas">
+          <HumanSupport class="mb-3" size="sm" align="start" />
           <div class="hero-cta-buttons">
             <a class="btn btn-lg btn-primary" href={registerUrl}>Start with Capgo</a>
             <a class="btn btn-lg btn-ghost" href={liveUpdateUrl}>See live updates</a>
@@ -305,6 +307,7 @@ provider ready | recipients linked | update check enabled</pre>
               {guidanceChecks.map((check) => <li>{check}</li>)}
             </ul>
             <div class="hero-ctas" style="margin-top: 28px; align-items: flex-start;">
+              <HumanSupport class="mb-3" size="sm" align="start" />
               <div class="hero-cta-buttons">
                 <a class="btn btn-md btn-primary" href={pricingUrl}>Compare plans</a>
                 <a class="btn btn-md btn-ghost" href={pluginUrl}>View plugin page</a>
@@ -337,6 +340,7 @@ provider ready | recipients linked | update check enabled</pre>
           Reach users and move releases forward.
         </h2>
         <p class="tagline">Add native push, badge control, campaign stats, and silent update checks to your Capacitor release workflow.</p>
+        <HumanSupport class="mb-4" size="sm" />
         <a class="btn btn-lg btn-primary btn-cta" href={registerUrl}>Start with Capgo</a>
         <div class="hero-meta hero-meta--cta">
           <span><span class="check">+</span> Native iOS and Android push</span>

--- a/apps/web/src/pages/observe.astro
+++ b/apps/web/src/pages/observe.astro
@@ -4,6 +4,7 @@ import Layout from '@/layouts/Layout.astro'
 import m from '@/copy/messages'
 import { createLdJsonGraph, createServiceLdJson } from '@/lib/ldJson'
 import { getRelativeLocaleUrl } from '@/services/links'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -173,6 +174,7 @@ const screenSignals = [
         <p class="eyebrow eyebrow--blue">Observe every rollout</p>
         <h2><span class="name">Ship with proof,</span><br />not just hope.</h2>
         <p class="tagline">Put deployment history, release health, and Logs Insights in one release workflow.</p>
+        <HumanSupport class="mb-4" size="sm" />
         <a class="btn btn-lg btn-primary btn-cta" href={registerUrl}>{m.cta_start_free({}, { locale })}</a>
         <div class="hero-meta hero-meta--cta">
           <span><span class="check">+</span> Deployment history</span>

--- a/apps/web/src/pages/premium-support.astro
+++ b/apps/web/src/pages/premium-support.astro
@@ -3,6 +3,7 @@ import Layout from '@/layouts/Layout.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import m from '@/copy/messages'
 import { createServiceLdJson, createLdJsonGraph, createFAQPageLdJson } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -129,7 +130,8 @@ const helpAreas = [
           <p class="mt-4 text-sm text-gray-400">{m.ps_rate_info({}, { locale })}</p>
         </div>
 
-        <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+        <HumanSupport class="mt-8" size="sm" />
+        <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
           <a
             href="https://pay.capgo.app/b/8wM8wNaKHbTMbsIfZg"
             target="_blank"

--- a/apps/web/src/pages/solutions/agencies.astro
+++ b/apps/web/src/pages/solutions/agencies.astro
@@ -7,6 +7,7 @@ import AgencyDashboardIllustration from '@/components/solutions/AgencyDashboardI
 import WhiteLabelIllustration from '@/components/solutions/WhiteLabelIllustration.astro'
 import HandoffIllustration from '@/components/solutions/HandoffIllustration.astro'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -61,7 +62,8 @@ const content = { title, description, ldJSON }
             {m.solutions_agencies_hero_subtitle({}, { locale })}
           </p>
 
-          <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-8" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-amber-600 px-8 py-4 text-base font-semibold text-white shadow-lg shadow-amber-500/25 transition-all duration-200 hover:bg-amber-700 focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
@@ -425,7 +427,8 @@ const content = { title, description, ldJSON }
           <div class="relative text-center">
             <h2 class="text-3xl font-bold text-white sm:text-4xl">{m.solutions_agencies_cta_title({}, { locale })}</h2>
             <p class="mx-auto mt-4 max-w-2xl text-lg text-amber-100">{m.solutions_agencies_cta_subtitle({}, { locale })}</p>
-            <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="rounded-xl bg-white px-8 py-4 text-base font-semibold text-amber-600 shadow-lg transition-all duration-200 hover:bg-gray-100"

--- a/apps/web/src/pages/solutions/beta-testing.astro
+++ b/apps/web/src/pages/solutions/beta-testing.astro
@@ -4,6 +4,7 @@ import m from '@/copy/messages'
 import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -67,7 +68,8 @@ const content = { title, description, ldJSON }
             {m.solutions_beta_testing_hero_subtitle({}, { locale })}
           </p>
 
-          <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-8" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-amber-600 px-8 py-4 text-base font-semibold text-white transition-all duration-200 hover:bg-amber-700 focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
@@ -328,7 +330,8 @@ App.addListener('appUrlOpen', async (data) => {'{'}
           <div class="relative text-center">
             <h2 class="text-3xl font-bold text-white sm:text-4xl">{m.solutions_beta_testing_cta_title({}, { locale })}</h2>
             <p class="mx-auto mt-4 max-w-2xl text-lg text-amber-100">{m.solutions_beta_testing_cta_subtitle({}, { locale })}</p>
-            <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="rounded-xl bg-white px-8 py-4 text-base font-semibold text-amber-600 transition-all duration-200 hover:bg-gray-100"

--- a/apps/web/src/pages/solutions/build-without-mac.astro
+++ b/apps/web/src/pages/solutions/build-without-mac.astro
@@ -285,7 +285,6 @@ npx @capgo/cli@latest build request --platform ios`
         <p class="mx-auto mt-4 max-w-3xl text-lg leading-8 text-slate-300">{copy('solutions_build_without_mac_cta_subtitle')}</p>
         <HumanSupport class="mt-6" size="sm" />
         <div class="mt-4 flex flex-col justify-center gap-3 sm:flex-row">
-        <div class="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
           <a
             class="inline-flex min-h-12 items-center justify-center rounded-lg bg-blue-500 px-6 font-semibold text-white transition-colors hover:bg-blue-400 focus:ring-2 focus:ring-blue-300 focus:ring-offset-2 focus:ring-offset-gray-950 focus:outline-none"
             href={registerUrl}

--- a/apps/web/src/pages/solutions/build-without-mac.astro
+++ b/apps/web/src/pages/solutions/build-without-mac.astro
@@ -4,6 +4,7 @@ import m, { type MessageKey, type MessageValues } from '@/copy/messages'
 import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -96,7 +97,8 @@ npx @capgo/cli@latest build request --platform ios`
             <p class="mt-6 max-w-3xl text-lg leading-8 text-slate-300 sm:text-xl">
               {copy('solutions_build_without_mac_lead')}
             </p>
-            <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col gap-3 sm:flex-row">
               <a
                 class="inline-flex min-h-12 items-center justify-center rounded-lg bg-blue-500 px-6 font-semibold text-white transition-colors hover:bg-blue-400 focus:ring-2 focus:ring-blue-300 focus:ring-offset-2 focus:ring-offset-gray-950 focus:outline-none"
                 href={registerUrl}
@@ -281,6 +283,8 @@ npx @capgo/cli@latest build request --platform ios`
       <div class="mx-auto max-w-5xl px-4 text-center sm:px-6 lg:px-8">
         <h2 class="text-3xl font-bold text-white sm:text-4xl">{copy('solutions_build_without_mac_cta_title')}</h2>
         <p class="mx-auto mt-4 max-w-3xl text-lg leading-8 text-slate-300">{copy('solutions_build_without_mac_cta_subtitle')}</p>
+        <HumanSupport class="mt-6" size="sm" />
+        <div class="mt-4 flex flex-col justify-center gap-3 sm:flex-row">
         <div class="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
           <a
             class="inline-flex min-h-12 items-center justify-center rounded-lg bg-blue-500 px-6 font-semibold text-white transition-colors hover:bg-blue-400 focus:ring-2 focus:ring-blue-300 focus:ring-offset-2 focus:ring-offset-gray-950 focus:outline-none"

--- a/apps/web/src/pages/solutions/cordova-to-capacitor-ai.astro
+++ b/apps/web/src/pages/solutions/cordova-to-capacitor-ai.astro
@@ -4,6 +4,7 @@ import { createLdJsonGraph, createServiceLdJson } from '@/lib/ldJson'
 import m from '@/copy/messages'
 import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -80,7 +81,8 @@ const content = {
             <time datetime={dateModified}>{m.solutions_cordova_to_capacitor_ai_last_updated_date({}, { locale })}</time>
           </div>
 
-          <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-8" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'solutions/cordova-to-capacitor')}
               class="rounded-xl bg-sky-600 px-8 py-4 text-base font-semibold text-white shadow-lg shadow-sky-500/20 transition-all duration-200 hover:bg-sky-700 focus:ring-2 focus:ring-sky-500 focus:ring-offset-2"

--- a/apps/web/src/pages/solutions/cordova-to-capacitor.astro
+++ b/apps/web/src/pages/solutions/cordova-to-capacitor.astro
@@ -8,6 +8,7 @@ import BugFixIllustration from '@/components/solutions/BugFixIllustration.astro'
 import RolloutIllustration from '@/components/solutions/RolloutIllustration.astro'
 import SecurityIllustration from '@/components/solutions/SecurityIllustration.astro'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -60,7 +61,8 @@ const content = { title, description, ldJSON }
             {m.solutions_cordova_to_capacitor_hero_subtitle({}, { locale })}
           </p>
 
-          <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-8" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-sky-600 px-8 py-4 text-base font-semibold text-white shadow-lg shadow-sky-500/20 transition-all duration-200 hover:bg-sky-700 focus:ring-2 focus:ring-sky-500 focus:ring-offset-2"
@@ -580,7 +582,8 @@ const content = { title, description, ldJSON }
           <div class="relative text-center">
             <h2 class="text-3xl font-bold text-white sm:text-4xl">{m.solutions_cordova_to_capacitor_cta_title({}, { locale })}</h2>
             <p class="mx-auto mt-4 max-w-2xl text-lg text-white/90">{m.solutions_cordova_to_capacitor_cta_subtitle({}, { locale })}</p>
-            <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="rounded-xl bg-white px-8 py-4 text-base font-semibold text-gray-900 shadow-lg transition-all duration-200 hover:bg-gray-100"

--- a/apps/web/src/pages/solutions/direct-updates.astro
+++ b/apps/web/src/pages/solutions/direct-updates.astro
@@ -4,6 +4,7 @@ import m from '@/copy/messages'
 import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -54,7 +55,8 @@ const content = { title, description, ldJSON }
             {m.solutions_direct_updates_hero_subtitle({}, { locale })}
           </p>
 
-          <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-8" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-emerald-600 px-8 py-4 text-base font-semibold text-white shadow-lg shadow-emerald-500/25 transition-all duration-200 hover:bg-emerald-700 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
@@ -747,7 +749,8 @@ CapacitorUpdater: {'{'}
           <div class="relative text-center">
             <h2 class="text-3xl font-bold text-white sm:text-4xl">{m.solutions_direct_final_cta_title({}, { locale })}</h2>
             <p class="mx-auto mt-4 max-w-2xl text-lg text-emerald-100">{m.solutions_direct_final_cta_subtitle({}, { locale })}</p>
-            <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="rounded-xl bg-white px-8 py-4 text-base font-semibold text-emerald-600 shadow-lg transition-all duration-200 hover:bg-gray-100"

--- a/apps/web/src/pages/solutions/ecommerce.astro
+++ b/apps/web/src/pages/solutions/ecommerce.astro
@@ -8,6 +8,7 @@ import ABTestIllustration from '@/components/solutions/ABTestIllustration.astro'
 import BugFixIllustration from '@/components/solutions/BugFixIllustration.astro'
 import WhiteLabelIllustration from '@/components/solutions/WhiteLabelIllustration.astro'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -62,7 +63,8 @@ const content = { title, description, ldJSON }
             {m.solutions_ecommerce_hero_subtitle({}, { locale })}
           </p>
 
-          <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-8" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-rose-600 px-8 py-4 text-base font-semibold text-white shadow-lg shadow-rose-500/25 transition-all duration-200 hover:bg-rose-700 focus:ring-2 focus:ring-rose-500 focus:ring-offset-2"
@@ -329,7 +331,8 @@ const content = { title, description, ldJSON }
           <div class="relative text-center">
             <h2 class="text-3xl font-bold text-white sm:text-4xl">{m.solutions_ecommerce_cta_title({}, { locale })}</h2>
             <p class="mx-auto mt-4 max-w-2xl text-lg text-rose-100">{m.solutions_ecommerce_cta_subtitle({}, { locale })}</p>
-            <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="rounded-xl bg-white px-8 py-4 text-base font-semibold text-rose-600 shadow-lg transition-all duration-200 hover:bg-gray-100"

--- a/apps/web/src/pages/solutions/fintech.astro
+++ b/apps/web/src/pages/solutions/fintech.astro
@@ -7,6 +7,7 @@ import RolloutIllustration from '@/components/solutions/RolloutIllustration.astr
 import BugFixIllustration from '@/components/solutions/BugFixIllustration.astro'
 import SecurityIllustration from '@/components/solutions/SecurityIllustration.astro'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -62,7 +63,8 @@ const content = { title, description, ldJSON }
             {m.solutions_fintech_hero_subtitle({}, { locale })}
           </p>
 
-          <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-8" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-green-600 px-8 py-4 text-base font-semibold text-white shadow-lg shadow-green-500/25 transition-all duration-200 hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
@@ -411,7 +413,8 @@ const content = { title, description, ldJSON }
           <div class="relative text-center">
             <h2 class="text-3xl font-bold text-white sm:text-4xl">{m.solutions_fintech_cta_title({}, { locale })}</h2>
             <p class="mx-auto mt-4 max-w-2xl text-lg text-green-100">{m.solutions_fintech_cta_subtitle({}, { locale })}</p>
-            <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="rounded-xl bg-white px-8 py-4 text-base font-semibold text-green-600 shadow-lg transition-all duration-200 hover:bg-gray-100"

--- a/apps/web/src/pages/solutions/healthcare.astro
+++ b/apps/web/src/pages/solutions/healthcare.astro
@@ -4,6 +4,7 @@ import m from '@/copy/messages'
 import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -58,7 +59,8 @@ const content = { title, description, ldJSON }
             {m.solutions_healthcare_hero_subtitle({}, { locale })}
           </p>
 
-          <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-8" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-cyan-600 px-8 py-4 text-base font-semibold text-white shadow-lg shadow-cyan-500/25 transition-all duration-200 hover:bg-cyan-700 focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2"
@@ -476,7 +478,8 @@ console.log(info.bundle.url)      <span class="text-gray-500">// Link to commit<
           <div class="relative text-center">
             <h2 class="text-3xl font-bold text-white sm:text-4xl">{m.solutions_healthcare_cta_title({}, { locale })}</h2>
             <p class="mx-auto mt-4 max-w-2xl text-lg text-cyan-100">{m.solutions_healthcare_cta_subtitle({}, { locale })}</p>
-            <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="rounded-xl bg-white px-8 py-4 text-base font-semibold text-cyan-600 shadow-lg transition-all duration-200 hover:bg-gray-100"

--- a/apps/web/src/pages/solutions/ionic-enterprise-plugins.astro
+++ b/apps/web/src/pages/solutions/ionic-enterprise-plugins.astro
@@ -4,6 +4,7 @@ import m from '@/copy/messages'
 import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -59,7 +60,8 @@ const content = { title, description, ldJSON }
             {m.solutions_ionic_plugins_hero_subtitle({}, { locale })}
           </p>
 
-          <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-8" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-emerald-600 px-8 py-4 text-base font-semibold text-white transition-all duration-200 hover:bg-emerald-700 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
@@ -221,7 +223,8 @@ const content = { title, description, ldJSON }
           <p class="mt-4 text-lg text-emerald-100">
             {m.solutions_ionic_plugins_cta_subtitle({}, { locale })}
           </p>
-          <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-6" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-emerald-600 px-8 py-4 text-base font-semibold text-white transition-all duration-200 hover:bg-emerald-700"

--- a/apps/web/src/pages/solutions/lovable-vibecoding-to-mobile.astro
+++ b/apps/web/src/pages/solutions/lovable-vibecoding-to-mobile.astro
@@ -320,7 +320,6 @@ npx @capgo/cli@latest build request --platform ios`
         <p class="mx-auto mt-4 max-w-3xl text-lg leading-8 text-slate-300">{copy('solutions_lovable_to_mobile_cta_subtitle')}</p>
         <HumanSupport class="mt-6" size="sm" />
         <div class="mt-4 flex flex-col justify-center gap-3 sm:flex-row">
-        <div class="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
           <a
             class="inline-flex min-h-12 items-center justify-center rounded-lg bg-pink-500 px-6 font-semibold text-white transition-colors hover:bg-pink-400 focus:ring-2 focus:ring-pink-300 focus:ring-offset-2 focus:ring-offset-slate-900 focus:outline-none"
             href={registerUrl}

--- a/apps/web/src/pages/solutions/lovable-vibecoding-to-mobile.astro
+++ b/apps/web/src/pages/solutions/lovable-vibecoding-to-mobile.astro
@@ -4,6 +4,7 @@ import m, { type MessageKey, type MessageValues } from '@/copy/messages'
 import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -128,7 +129,8 @@ npx @capgo/cli@latest build request --platform ios`
             <p class="mt-6 max-w-3xl text-lg leading-8 text-slate-300 sm:text-xl">
               {copy('solutions_lovable_to_mobile_lead')}
             </p>
-            <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col gap-3 sm:flex-row">
               <a
                 class="inline-flex min-h-12 items-center justify-center rounded-lg bg-pink-500 px-6 font-semibold text-white transition-colors hover:bg-pink-400 focus:ring-2 focus:ring-pink-300 focus:ring-offset-2 focus:ring-offset-gray-950 focus:outline-none"
                 href={registerUrl}
@@ -316,6 +318,8 @@ npx @capgo/cli@latest build request --platform ios`
       <div class="mx-auto max-w-5xl px-4 text-center sm:px-6 lg:px-8">
         <h2 class="text-3xl font-bold text-white sm:text-4xl">{copy('solutions_lovable_to_mobile_cta_title')}</h2>
         <p class="mx-auto mt-4 max-w-3xl text-lg leading-8 text-slate-300">{copy('solutions_lovable_to_mobile_cta_subtitle')}</p>
+        <HumanSupport class="mt-6" size="sm" />
+        <div class="mt-4 flex flex-col justify-center gap-3 sm:flex-row">
         <div class="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
           <a
             class="inline-flex min-h-12 items-center justify-center rounded-lg bg-pink-500 px-6 font-semibold text-white transition-colors hover:bg-pink-400 focus:ring-2 focus:ring-pink-300 focus:ring-offset-2 focus:ring-offset-slate-900 focus:outline-none"

--- a/apps/web/src/pages/solutions/pr-preview.astro
+++ b/apps/web/src/pages/solutions/pr-preview.astro
@@ -4,6 +4,7 @@ import m from '@/copy/messages'
 import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -54,7 +55,8 @@ const content = { title, description, ldJSON }
             {m.solutions_pr_preview_hero_subtitle({}, { locale })}
           </p>
 
-          <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-8" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-purple-600 px-8 py-4 text-base font-semibold text-white shadow-lg shadow-purple-500/25 transition-all duration-200 hover:bg-purple-700 focus:ring-2 focus:ring-purple-500 focus:ring-offset-2"
@@ -702,7 +704,8 @@ await CapacitorUpdater.setChannel({'{'}
           <div class="relative text-center">
             <h2 class="text-3xl font-bold text-white sm:text-4xl">{m.solutions_pr_final_cta_title({}, { locale })}</h2>
             <p class="mx-auto mt-4 max-w-2xl text-lg text-purple-100">{m.solutions_pr_final_cta_subtitle({}, { locale })}</p>
-            <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="rounded-xl bg-white px-8 py-4 text-base font-semibold text-purple-600 shadow-lg transition-all duration-200 hover:bg-gray-100"

--- a/apps/web/src/pages/solutions/production-updates.astro
+++ b/apps/web/src/pages/solutions/production-updates.astro
@@ -4,6 +4,7 @@ import m from '@/copy/messages'
 import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -55,7 +56,8 @@ const content = { title, description, ldJSON }
             {m.solutions_production_updates_hero_subtitle({}, { locale })}
           </p>
 
-          <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-8" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-blue-600 px-8 py-4 text-base font-semibold text-white shadow-lg shadow-blue-500/25 transition-all duration-200 hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
@@ -846,7 +848,8 @@ npx @capgo/cli bundle upload
           <div class="relative text-center">
             <h2 class="text-3xl font-bold text-white sm:text-4xl">{m.solutions_final_cta_title({}, { locale })}</h2>
             <p class="mx-auto mt-4 max-w-2xl text-lg text-blue-100">{m.solutions_final_cta_subtitle({}, { locale })}</p>
-            <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="rounded-xl bg-white px-8 py-4 text-base font-semibold text-blue-600 shadow-lg transition-all duration-200 hover:bg-gray-100"

--- a/apps/web/src/pages/solutions/qsr.astro
+++ b/apps/web/src/pages/solutions/qsr.astro
@@ -4,6 +4,7 @@ import m from '@/copy/messages'
 import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -54,7 +55,8 @@ const content = { title, description, ldJSON }
             {m.solutions_qsr_hero_subtitle({}, { locale })}
           </p>
 
-          <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-8" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-orange-600 px-8 py-4 text-base font-semibold text-white shadow-lg shadow-orange-500/25 transition-all duration-200 hover:bg-orange-700 focus:ring-2 focus:ring-orange-500 focus:ring-offset-2"
@@ -554,7 +556,8 @@ jobs:
           <div class="relative text-center">
             <h2 class="text-3xl font-bold text-white sm:text-4xl">{m.solutions_qsr_cta_title({}, { locale })}</h2>
             <p class="mx-auto mt-4 max-w-2xl text-lg text-orange-100">{m.solutions_qsr_cta_subtitle({}, { locale })}</p>
-            <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="rounded-xl bg-white px-8 py-4 text-base font-semibold text-orange-600 transition-all duration-200 hover:bg-gray-100"

--- a/apps/web/src/pages/solutions/set-and-forget.astro
+++ b/apps/web/src/pages/solutions/set-and-forget.astro
@@ -4,6 +4,7 @@ import m from '@/copy/messages'
 import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -118,7 +119,8 @@ const boundaries = [
             <p class="mt-6 max-w-[64ch] text-lg text-pretty text-slate-300 sm:text-xl">
               {m.solutions_set_and_forget_hero_subtitle({}, { locale })}
             </p>
-            <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col gap-3 sm:flex-row">
               <a
                 href="https://book.capgo.app/demo/"
                 target="_blank"

--- a/apps/web/src/pages/solutions/solo-developers.astro
+++ b/apps/web/src/pages/solutions/solo-developers.astro
@@ -5,6 +5,7 @@ import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import RolloutIllustration from '@/components/solutions/RolloutIllustration.astro'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -55,7 +56,8 @@ const content = { title, description, ldJSON }
             {m.solutions_solo_hero_subtitle({}, { locale })}
           </p>
 
-          <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-8" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-violet-600 px-8 py-4 text-base font-semibold text-white shadow-lg shadow-violet-500/25 transition-all duration-200 hover:bg-violet-700 focus:ring-2 focus:ring-violet-500 focus:ring-offset-2"
@@ -527,7 +529,8 @@ const content = { title, description, ldJSON }
           <div class="relative text-center">
             <h2 class="text-3xl font-bold text-white sm:text-4xl">{m.solutions_solo_cta_title({}, { locale })}</h2>
             <p class="mx-auto mt-4 max-w-2xl text-lg text-violet-100">{m.solutions_solo_cta_subtitle({}, { locale })}</p>
-            <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="rounded-xl bg-white px-8 py-4 text-base font-semibold text-violet-600 shadow-lg transition-all duration-200 hover:bg-gray-100"

--- a/apps/web/src/pages/solutions/startups.astro
+++ b/apps/web/src/pages/solutions/startups.astro
@@ -6,6 +6,7 @@ import { getRelativeLocaleUrl } from '@/services/links'
 import RolloutIllustration from '@/components/solutions/RolloutIllustration.astro'
 import BugFixIllustration from '@/components/solutions/BugFixIllustration.astro'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -56,7 +57,8 @@ const content = { title, description, ldJSON }
             {m.solutions_startups_hero_subtitle({}, { locale })}
           </p>
 
-          <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-8" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-emerald-600 px-8 py-4 text-base font-semibold text-white shadow-lg shadow-emerald-500/25 transition-all duration-200 hover:bg-emerald-700 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
@@ -408,7 +410,8 @@ npx @capgo/cli bundle upload
           <div class="relative text-center">
             <h2 class="text-3xl font-bold text-white sm:text-4xl">{m.solutions_startups_cta_title({}, { locale })}</h2>
             <p class="mx-auto mt-4 max-w-2xl text-lg text-emerald-100">{m.solutions_startups_cta_subtitle({}, { locale })}</p>
-            <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="rounded-xl bg-white px-8 py-4 text-base font-semibold text-emerald-600 shadow-lg transition-all duration-200 hover:bg-gray-100"

--- a/apps/web/src/pages/solutions/version-targeting.astro
+++ b/apps/web/src/pages/solutions/version-targeting.astro
@@ -4,6 +4,7 @@ import m from '@/copy/messages'
 import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -66,7 +67,8 @@ const content = { title, description, ldJSON }
             {m.solutions_version_targeting_hero_subtitle({}, { locale })}
           </p>
 
-          <div class="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <HumanSupport class="mt-8" size="sm" />
+          <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
             <a
               href={getRelativeLocaleUrl(locale, 'register')}
               class="rounded-xl bg-rose-600 px-8 py-4 text-base font-semibold text-white transition-all duration-200 hover:bg-rose-700 focus:ring-2 focus:ring-rose-500 focus:ring-offset-2"
@@ -327,7 +329,8 @@ npx @capgo/cli bundle upload --channel native-1.5.2
           <div class="relative text-center">
             <h2 class="text-3xl font-bold text-white sm:text-4xl">{m.solutions_version_targeting_cta_title({}, { locale })}</h2>
             <p class="mx-auto mt-4 max-w-2xl text-lg text-rose-100">{m.solutions_version_targeting_cta_subtitle({}, { locale })}</p>
-            <div class="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col items-center justify-center gap-4 sm:flex-row">
               <a
                 href={getRelativeLocaleUrl(locale, 'register')}
                 class="rounded-xl bg-white px-8 py-4 text-base font-semibold text-rose-600 transition-all duration-200 hover:bg-gray-100"

--- a/apps/web/src/pages/solutions/white-label.astro
+++ b/apps/web/src/pages/solutions/white-label.astro
@@ -5,6 +5,7 @@ import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
 import { getRelativeLocaleUrl } from '@/services/links'
 import WhiteLabelIllustration from '@/components/solutions/WhiteLabelIllustration.astro'
 import { createServiceLdJson, createLdJsonGraph } from '@/lib/ldJson'
+import HumanSupport from '@/components/HumanSupport.astro'
 
 const locale = Astro.locals.locale
 const brand = Astro.locals.runtimeConfig.public.brand
@@ -99,7 +100,8 @@ export async function switchTenant(channel: string) {
             <p class="mt-6 max-w-3xl text-lg leading-8 text-slate-300 sm:text-xl">
               {copy('solutions_white_label_page_lead')}
             </p>
-            <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col gap-3 sm:flex-row">
               <a
                 class="inline-flex min-h-12 items-center justify-center rounded-lg bg-cyan-500 px-6 font-semibold text-white transition-colors hover:bg-cyan-400 focus:ring-2 focus:ring-cyan-300 focus:ring-offset-2 focus:ring-offset-gray-950 focus:outline-none"
                 href={registerUrl}
@@ -258,6 +260,8 @@ export async function switchTenant(channel: string) {
       <div class="mx-auto max-w-5xl px-4 text-center sm:px-6 lg:px-8">
         <h2 class="text-3xl font-bold text-white sm:text-4xl">{copy('solutions_white_label_page_cta_title')}</h2>
         <p class="mx-auto mt-4 max-w-3xl text-lg leading-8 text-slate-300">{copy('solutions_white_label_page_cta_subtitle')}</p>
+        <HumanSupport class="mt-6" size="sm" />
+        <div class="mt-4 flex flex-col justify-center gap-3 sm:flex-row">
         <div class="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
           <a
             class="inline-flex min-h-12 items-center justify-center rounded-lg bg-cyan-500 px-6 font-semibold text-white transition-colors hover:bg-cyan-400 focus:ring-2 focus:ring-cyan-300 focus:ring-offset-2 focus:ring-offset-slate-900 focus:outline-none"

--- a/apps/web/src/pages/solutions/white-label.astro
+++ b/apps/web/src/pages/solutions/white-label.astro
@@ -262,7 +262,6 @@ export async function switchTenant(channel: string) {
         <p class="mx-auto mt-4 max-w-3xl text-lg leading-8 text-slate-300">{copy('solutions_white_label_page_cta_subtitle')}</p>
         <HumanSupport class="mt-6" size="sm" />
         <div class="mt-4 flex flex-col justify-center gap-3 sm:flex-row">
-        <div class="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
           <a
             class="inline-flex min-h-12 items-center justify-center rounded-lg bg-cyan-500 px-6 font-semibold text-white transition-colors hover:bg-cyan-400 focus:ring-2 focus:ring-cyan-300 focus:ring-offset-2 focus:ring-offset-slate-900 focus:outline-none"
             href={registerUrl}

--- a/apps/web/src/pages/top_cordova_app.astro
+++ b/apps/web/src/pages/top_cordova_app.astro
@@ -2,6 +2,7 @@
 import Layout from '@/layouts/Layout.astro'
 import m from '@/copy/messages'
 import { getRelativeLocaleUrl } from '@/services/links'
+import HumanSupport from '@/components/HumanSupport.astro'
 import { renameCat, shortNumber } from '@/services/misc'
 
 const title = [Astro.locals.runtimeConfig.public.brand, m.top_cordova_apps_title({}, { locale: Astro.locals.locale })].join(' | ')
@@ -112,7 +113,8 @@ try {
           <div class="relative">
             <h3 class="text-2xl font-bold text-white sm:text-3xl">{m.top_cordova_migrate_cta_title({}, { locale: Astro.locals.locale })}</h3>
             <p class="mt-3 text-gray-200">{m.top_cordova_migrate_cta_subtitle({}, { locale: Astro.locals.locale })}</p>
-            <div class="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center">
+            <HumanSupport class="mt-6" size="sm" />
+            <div class="mt-4 flex flex-col gap-4 sm:flex-row sm:items-center">
               <a
                 href={getRelativeLocaleUrl(Astro.locals.locale, 'solutions/cordova-to-capacitor')}
                 class="inline-flex items-center justify-center rounded-xl bg-white px-6 py-3 text-base font-semibold text-gray-900 transition-colors hover:bg-gray-100"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Reusable `HumanSupport` on marketing CTAs across solutions, products, homepage sections (not hero)
- **Hero:** no HumanSupport line (too crowded)
- **Pricing:** HumanSupport removed from plan CTAs; added as last item under each plan’s **Includes:** list with Martin’s avatar

## Screenshots (updated)

### Homepage hero — no human support line
[Homepage hero without human support](https://cursor.com/agents/bc-019fd909-b726-7ce6-b9b7-c7565ffb2726/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhero-no-human-support.png)

### Pricing — human support under Includes
[Pricing Includes human support](https://cursor.com/agents/bc-019fd909-b726-7ce6-b9b7-c7565ffb2726/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpricing-human-support-in-includes.png)

## Test plan
- [x] Hero has no “human support from Martin” line above CTA
- [x] Pricing plan cards show it under Includes, not above trial buttons
- [x] Other marketing CTAs still show HumanSupport
- [x] Fresh screenshots recaptured after the trim
- [x] `bun run build` succeeds in `apps/web`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd909-b726-7ce6-b9b7-c7565ffb2726?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd909-b726-7ce6-b9b7-c7565ffb2726&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788644873&installation_model_id=430928&pr_number=931&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F931&signature=d44e3d8fe28553380ce4e2f1c35b92c50ecaa4ddf0d922d716c9638cd1346a25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added human support prompts with localized messaging and an avatar across landing pages, solution pages, pricing plans, and key calls to action.
  - Visitors can now access support information directly from hero sections, registration prompts, migration guidance, and final CTAs.
  - Updated CTA layouts and spacing to keep support prompts and action buttons clear and responsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->