### PR TITLE
docs(cli): document bundle upload --auto-bump ai

### DIFF
--- a/apps/docs/src/content/docs/docs/cli/commands.mdx
+++ b/apps/docs/src/content/docs/docs/cli/commands.mdx
@@ -173,7 +173,7 @@ Optionally, you can give:
 * `--no-code-check` Ignore checking if notifyAppReady() is called in source code and index present in root folder.
 * `--display-iv-session` Show in the console the IV and session key used to encrypt the update.
 * `--bundle <bundle>` Bundle version number of the bundle to upload.
-* `--auto-bump [level]` Auto-increment from the channel's linked bundle, else the latest remote app version. Level: `major`, `minor` (default), `patch` (alias `fix`), or `metadata`. Bumps until a free name is found (deleted names stay occupied). Cannot be combined with `--bundle`.
+* `--auto-bump [level]` Auto-increment from the channel's linked bundle, else the latest remote app version. Level: `major`, `minor` (default), `patch` (alias `fix`), `metadata`, or `ai` (Workers AI compares local files to the previous Capgo/channel delta manifest, infers the level, and logs a short reason; skips AI and bumps `patch` if no previous Capgo version). Bumps until a free name is found (deleted names stay occupied). Cannot be combined with `--bundle`.
 * `--min-update-version <minUpdateVersion>` Minimal version required to update to this version. Used only if the disable auto update is set to metadata in channel.
 * `--auto-min-update-version` Set the min update version based on native packages.
 * `--ignore-metadata-check` Ignores the metadata (node_modules) check when uploading.

--- a/apps/docs/src/content/docs/docs/cli/reference/bundle.mdx
+++ b/apps/docs/src/content/docs/docs/cli/reference/bundle.mdx
@@ -36,7 +36,10 @@ npx @capgo/cli@latest bundle upload --auto-bump major
 npx @capgo/cli@latest bundle upload --auto-bump minor   # default when the flag has no value
 npx @capgo/cli@latest bundle upload --auto-bump patch   # alias: fix
 npx @capgo/cli@latest bundle upload --auto-bump metadata
+npx @capgo/cli@latest bundle upload --channel=production --auto-bump ai
 ```
+
+With `--auto-bump ai`, Capgo Cloudflare Workers AI compares local bundle files to the previous Capgo/channel delta manifest, infers `major` | `minor` | `patch` | `metadata`, and prints a short reason in the CLI log. If no previous Capgo version exists, AI is skipped and the bump defaults to **patch**.
 
 **Options:**
 
@@ -64,7 +67,7 @@ npx @capgo/cli@latest bundle upload --auto-bump metadata
 | **--no-code-check** | <code>boolean</code> | Ignore checking if notifyAppReady() is called in source code and index present in root folder |
 | **--display-iv-session** | <code>boolean</code> | Show in the console the IV and session key used to encrypt the update |
 | **-b** | <code>string</code> | Bundle version number of the bundle to upload |
-| **--auto-bump** | <code>string</code> | Auto-increment from the channel's linked bundle, else the latest remote app version. Level: major, minor (default), patch (alias fix), or metadata. Bumps until a free name is found (deleted names stay occupied). Cannot be combined with --bundle (-b) |
+| **--auto-bump** | <code>string</code> | Auto-increment from the channel's linked bundle, else the latest remote app version. Level: major, minor (default), patch (alias fix), metadata, or ai (Workers AI infers level from local vs previous delta manifest; falls back to patch with no previous Capgo version). Bumps until a free name is found (deleted names stay occupied). Cannot be combined with --bundle (-b) |
 | **--link** | <code>string</code> | Link to external resource (e.g. GitHub release) |
 | **--comment** | <code>string</code> | Comment about this version, could be a release note, a commit hash, a commit message, etc. |
 | **--min-update-version** | <code>string</code> | Minimal version required to update to this version. Used only if the disable auto update is set to metadata in channel |

--- a/apps/docs/src/content/docs/docs/getting-started/cicd-integration.mdx
+++ b/apps/docs/src/content/docs/docs/getting-started/cicd-integration.mdx
@@ -158,7 +158,10 @@ npx @capgo/cli@latest bundle upload --auto-bump major
 npx @capgo/cli@latest bundle upload --auto-bump minor   # default when the flag has no value
 npx @capgo/cli@latest bundle upload --auto-bump patch   # alias: fix
 npx @capgo/cli@latest bundle upload --auto-bump metadata
+npx @capgo/cli@latest bundle upload --channel=production --auto-bump ai
 ```
+
+`--auto-bump ai` uses Capgo Cloudflare Workers AI to compare local bundle files against the previous Capgo/channel delta manifest, pick `major` | `minor` | `patch` | `metadata`, and print a short reason. With no previous Capgo version, AI is skipped and the bump is **patch**.
 
 Do not combine `--auto-bump` with `--bundle` / `-b`. See the [`bundle upload` reference](/docs/cli/reference/bundle/#bundle-upload) for the full option list.
 

--- a/apps/docs/src/content/docs/docs/live-updates/channels.mdx
+++ b/apps/docs/src/content/docs/docs/live-updates/channels.mdx
@@ -209,7 +209,7 @@ It's important to note that bundles in Capgo are global to your app, not specifi
 
 When versioning your bundles, we recommend using [semantic versioning with Capgo's Semver Tester](/semver_tester/) and pre-release identifiers for channel-specific builds. For example, a beta release might be versioned as `1.2.3-beta.1`.
 
-In CI, if the local version was already uploaded, use `npx @capgo/cli@latest bundle upload --auto-bump` (optionally `major`, `minor`, `patch`/`fix`, or `metadata`) so the CLI bumps from the channel's linked bundle until a free name is found. You cannot combine it with `--bundle`. See [CI/CD Integration](/docs/getting-started/cicd-integration/#auto-bump-when-the-local-version-is-already-on-capgo) and the [CLI reference](/docs/cli/reference/bundle/#bundle-upload).
+In CI, if the local version was already uploaded, use `npx @capgo/cli@latest bundle upload --auto-bump` (optionally `major`, `minor`, `patch`/`fix`, `metadata`, or `ai`) so the CLI bumps from the channel's linked bundle until a free name is found. With `ai`, Workers AI infers the level from the local vs previous delta manifest (falls back to `patch` with no previous Capgo version). You cannot combine it with `--bundle`. See [CI/CD Integration](/docs/getting-started/cicd-integration/#auto-bump-when-the-local-version-is-already-on-capgo) and the [CLI reference](/docs/cli/reference/bundle/#bundle-upload).
 
 This approach has several benefits:
 


### PR DESCRIPTION
## Summary (AI generated)

- Document `--auto-bump ai` for `bundle upload` across CLI reference, commands, CI/CD, and channels docs
- Describe Workers AI delta-manifest classification, CLI reason log, and patch fallback when no previous Capgo version exists
- Keep existing major/minor/patch|fix/metadata levels and the `--bundle` incompatibility note

## Motivation (AI generated)

Follow-up to #932 after the CLI gained Workers AI auto-bump. Customers need the `ai` level documented next to the other `--auto-bump` options.

## Business Impact (AI generated)

Makes the new AI versioning path discoverable in docs and CI examples, reducing support friction for automated Capgo uploads.

## Test Plan (AI generated)

- [ ] Confirm `bundle.mdx` shows `--auto-bump ai` example and option table text
- [ ] Confirm `commands.mdx` lists `ai` among levels
- [ ] Confirm CI/CD section includes the `ai` command and behavior note
- [ ] Confirm channels.mdx mentions `ai` and the patch fallback
- [ ] Spot-check customer-facing commands use `npx @capgo/cli@latest`

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788709273&installation_model_id=430928&pr_number=934&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F934&signature=aa19d0d5c9b1651283c74cc2c27a31378c9c2de44a6c76225d9102d87ff6af34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

