### PR TITLE
Fix app_mobile Astro check failure

### DIFF
--- a/apps/web/src/pages/app_mobile.astro
+++ b/apps/web/src/pages/app_mobile.astro
@@ -287,8 +287,6 @@ const appExampleIds: SolutionStoreAppId[] = ['com.windyty.android', 'com.studysm
         <HumanSupport class="mb-3" size="sm" />
         <a
           href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
-          class="inline-flex min-h-12 items-center justify-center rounded-lg bg-white px-5 py-3 text-sm font-semibold text-slate-950        <a
-          href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}
           class="inline-flex min-h-12 items-center justify-center rounded-lg bg-white px-5 py-3 text-sm font-semibold text-slate-950 transition-colors hover:bg-slate-200 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white"
         >
           Create account

--- a/apps/web/src/pages/capgo-cli.astro
+++ b/apps/web/src/pages/capgo-cli.astro
@@ -27,7 +27,6 @@ function copy(key: string, values: MessageValues = {}) {
 }
 
 const docsUrl = getRelativeLocaleUrl(locale, 'docs/cli')
-const registerUrl = getRelativeLocaleUrl(locale, 'register')
 
 const heroMeta = ['MCP tools for AI agents', 'OTA or native release checks', 'Signed builds from the same terminal']
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Restored the corrupted `Create account` anchor markup in `apps/web/src/pages/app_mobile.astro` that caused `astro check` parse/TS errors.
- Removed unused `registerUrl` in `apps/web/src/pages/capgo-cli.astro`.

## Test plan
- [x] `cd apps/web && bun run check` → **0 errors** (1 unrelated hint in `readme-banner.ts`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccf1dd63-ef65-4274-b4ac-a43cb5960e9f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccf1dd63-ef65-4274-b4ac-a43cb5960e9f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788853935&installation_model_id=430928&pr_number=936&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F936&signature=69909fdd275d653d1ac3faf91189d089bebb33b219b8c9d3cfe0e0c5fdfd3669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a malformed registration link on the mobile app page.
  * Removed an unused registration URL reference from the CLI documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->