### PR TITLE
Val: Remove private-preview npm access copy for Notifications

### DIFF
--- a/apps/docs/src/content/docs/docs/live-updates/rollbacks.mdx
+++ b/apps/docs/src/content/docs/docs/live-updates/rollbacks.mdx
@@ -104,13 +104,13 @@ Rolling back to a previous build only affects the selected channel. If you have 
 
 After rolling back, devices configured to listen to the updated channel will receive the previous build the next time they check for an update. The rolled-back build will be treated as a new update, so the usual update flow and conditions apply.
 
-## Accelerate a Critical Rollback with Notifications (Private Preview)
+## Accelerate a Critical Rollback with Notifications
 
-Repointing a channel normally takes effect the next time a device checks for an update. The Capgo Notifications integration is currently in private preview and can send a silent update-check notification to a supported app while it is in the background. With the updater integration enabled, the app can check, download, and install the rollback according to its configured update mode.
+Repointing a channel normally takes effect the next time a device checks for an update. Capgo Notifications can send a silent update-check notification to a supported app while it is in the background. With the updater integration enabled, the app can check, download, and install the rollback according to its configured update mode.
 
 This is an acceleration path, not a forced fleet command. Delivery remains best-effort and depends on operating-system background scheduling, network availability, and device state. It cannot update an offline or force-quit app, so it cannot promise a fixed time to reach every device.
 
-To request private-preview access or set up this critical path, contact [support@capgo.app](mailto:support@capgo.app). You can also read [Notifications: Enable Silent Update Checks](/docs/plugins/notifications/getting-started/#11-enable-silent-update-checks).
+To set up this path, follow [Notifications: Enable Silent Update Checks](/docs/plugins/notifications/getting-started/#11-enable-silent-update-checks).
 
 ## Unlinking a Channel
 

--- a/apps/docs/src/content/docs/docs/plugins/notifications/getting-started.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/notifications/getting-started.mdx
@@ -7,8 +7,6 @@ sidebar:
 
 `@capgo/capacitor-notifications` is the first-party Capgo plugin for native iOS and Android push notifications. It is built for Capgo's dashboard, public API, Analytics Engine device registry, campaign stats, badge updates, and silent live-update checks.
 
-The package is currently in private preview. Capgo must enable package access for your npm account before the install command works.
-
 ## Requirements
 
 - A Capacitor app already added to Capgo.

--- a/apps/web/src/content/plugins-tutorials/en/capacitor-notifications.md
+++ b/apps/web/src/content/plugins-tutorials/en/capacitor-notifications.md
@@ -9,8 +9,6 @@ The plugin is built for the Capgo notification pipeline. Capgo stores platform c
 
 ## Install
 
-This package is currently in private preview. Capgo must enable package access for your npm account before installation works.
-
 Use the Capgo CLI for a guided setup:
 
 ```bash


### PR DESCRIPTION
## Summary
- Remove outdated “private preview / enable npm package access” copy from Notifications install docs and plugin tutorial
- Update rollback docs so silent update-check setup no longer asks users to request private-preview access

## Motivation
`@capgo/capacitor-notifications` is already public on npm. The docs still told users Capgo must enable package access before install works.

## Test Plan
- [ ] Confirm https://capgo.app/plugins/capacitor-notifications/ Install section no longer mentions private preview after deploy
- [ ] Confirm `/docs/plugins/notifications/getting-started/` no longer mentions npm package access gating
- [ ] Confirm rollbacks docs link to silent update-check setup without support-access wording


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788955295&installation_model_id=430928&pr_number=945&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F945&signature=d989c843981fae8c7edacc96f44682dfd1374cdd72e2663372e35d571e6bb478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated rollback notification documentation to remove private-preview labeling.
  * Added a direct link to the silent update-check setup guide.
  * Removed outdated private-preview access instructions from notification installation guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->