### PR TITLE
Explain /data failure reasons and fix slow first paint

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -80,6 +80,7 @@ jobs:
         run: |
           GITHUB_STATS_REFRESH=true bun run fetch:stars
           WEBSITE_STATS_REFRESH=true bun run fetch:website-stats
+          LIVE_UPDATE_METRICS_REFRESH=true bun run fetch:live-update-metrics
         env:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - run: cd apps/web && bun run check

--- a/apps/web/src/data/live-update-metrics.json
+++ b/apps/web/src/data/live-update-metrics.json
@@ -1,0 +1,390 @@
+{
+  "period_days": 30,
+  "updated_at": "2026-08-11T06:50:23.257Z",
+  "success_rate": 67.6,
+  "daily": [
+    {
+      "date": "2026-07-12",
+      "success_rate": 64.6
+    },
+    {
+      "date": "2026-07-13",
+      "success_rate": 67.5
+    },
+    {
+      "date": "2026-07-14",
+      "success_rate": 67.9
+    },
+    {
+      "date": "2026-07-15",
+      "success_rate": 72.6
+    },
+    {
+      "date": "2026-07-16",
+      "success_rate": 73.2
+    },
+    {
+      "date": "2026-07-17",
+      "success_rate": 70.4
+    },
+    {
+      "date": "2026-07-18",
+      "success_rate": 67.3
+    },
+    {
+      "date": "2026-07-19",
+      "success_rate": 63
+    },
+    {
+      "date": "2026-07-20",
+      "success_rate": 66.5
+    },
+    {
+      "date": "2026-07-21",
+      "success_rate": 66
+    },
+    {
+      "date": "2026-07-22",
+      "success_rate": 67.2
+    },
+    {
+      "date": "2026-07-23",
+      "success_rate": 70.2
+    },
+    {
+      "date": "2026-07-24",
+      "success_rate": 70.6
+    },
+    {
+      "date": "2026-07-25",
+      "success_rate": 65.7
+    },
+    {
+      "date": "2026-07-26",
+      "success_rate": 64.9
+    },
+    {
+      "date": "2026-07-27",
+      "success_rate": 62.3
+    },
+    {
+      "date": "2026-07-28",
+      "success_rate": 62.1
+    },
+    {
+      "date": "2026-07-29",
+      "success_rate": 63.5
+    },
+    {
+      "date": "2026-07-30",
+      "success_rate": 67.4
+    },
+    {
+      "date": "2026-07-31",
+      "success_rate": 68.3
+    },
+    {
+      "date": "2026-08-01",
+      "success_rate": 69.3
+    },
+    {
+      "date": "2026-08-02",
+      "success_rate": 66.1
+    },
+    {
+      "date": "2026-08-03",
+      "success_rate": 67.1
+    },
+    {
+      "date": "2026-08-04",
+      "success_rate": 65.8
+    },
+    {
+      "date": "2026-08-05",
+      "success_rate": 67.8
+    },
+    {
+      "date": "2026-08-06",
+      "success_rate": 69.7
+    },
+    {
+      "date": "2026-08-07",
+      "success_rate": 72
+    },
+    {
+      "date": "2026-08-08",
+      "success_rate": 66.1
+    },
+    {
+      "date": "2026-08-09",
+      "success_rate": 65.5
+    },
+    {
+      "date": "2026-08-10",
+      "success_rate": 69
+    }
+  ],
+  "failures": [
+    {
+      "reason": "download_manifest_file_fail",
+      "share": 37.7
+    },
+    {
+      "reason": "download_fail",
+      "share": 29.3
+    },
+    {
+      "reason": "backend_refusal",
+      "share": 16.4
+    },
+    {
+      "reason": "update_fail",
+      "share": 7.3
+    },
+    {
+      "reason": "finish_download_fail",
+      "share": 3.4
+    },
+    {
+      "reason": "checksum_fail",
+      "share": 3.3
+    },
+    {
+      "reason": "unzip_fail",
+      "share": 1.9
+    },
+    {
+      "reason": "set_fail",
+      "share": 0.2
+    }
+  ],
+  "platforms": [
+    {
+      "key": "ios",
+      "share": 66.8,
+      "success_rate": 75,
+      "top_failure": {
+        "reason": "download_fail",
+        "share": 45.9
+      }
+    },
+    {
+      "key": "android",
+      "share": 33.2,
+      "success_rate": 53.7,
+      "top_failure": {
+        "reason": "download_manifest_file_fail",
+        "share": 67.7
+      }
+    },
+    {
+      "key": "electron",
+      "share": 0,
+      "success_rate": 99.7,
+      "top_failure": {
+        "reason": "set_fail",
+        "share": 100
+      }
+    }
+  ],
+  "countries": [
+    {
+      "key": "US",
+      "share": 28.6,
+      "success_rate": 77.9,
+      "top_failure": {
+        "reason": "download_fail",
+        "share": 45.7
+      }
+    },
+    {
+      "key": "KR",
+      "share": 13.3,
+      "success_rate": 91,
+      "top_failure": {
+        "reason": "download_fail",
+        "share": 54.2
+      }
+    },
+    {
+      "key": "FR",
+      "share": 7.6,
+      "success_rate": 58.3,
+      "top_failure": {
+        "reason": "download_fail",
+        "share": 39.5
+      }
+    },
+    {
+      "key": "BR",
+      "share": 5.2,
+      "success_rate": 64.4,
+      "top_failure": {
+        "reason": "download_manifest_file_fail",
+        "share": 46.7
+      }
+    },
+    {
+      "key": "DE",
+      "share": 4.2,
+      "success_rate": 66.5,
+      "top_failure": {
+        "reason": "download_manifest_file_fail",
+        "share": 64.5
+      }
+    },
+    {
+      "key": "RU",
+      "share": 3.8,
+      "success_rate": 37,
+      "top_failure": {
+        "reason": "download_manifest_file_fail",
+        "share": 91.7
+      }
+    },
+    {
+      "key": "MX",
+      "share": 2.9,
+      "success_rate": 42.4,
+      "top_failure": {
+        "reason": "download_manifest_file_fail",
+        "share": 72.6
+      }
+    },
+    {
+      "key": "JP",
+      "share": 2.5,
+      "success_rate": 90.7,
+      "top_failure": {
+        "reason": "download_fail",
+        "share": 76.6
+      }
+    },
+    {
+      "key": "ES",
+      "share": 2.4,
+      "success_rate": 46.3,
+      "top_failure": {
+        "reason": "download_manifest_file_fail",
+        "share": 69.5
+      }
+    },
+    {
+      "key": "NL",
+      "share": 2.3,
+      "success_rate": 71.2,
+      "top_failure": {
+        "reason": "download_manifest_file_fail",
+        "share": 48.4
+      }
+    },
+    {
+      "key": "TH",
+      "share": 2.2,
+      "success_rate": 41.6,
+      "top_failure": {
+        "reason": "backend_refusal",
+        "share": 94.4
+      }
+    },
+    {
+      "key": "AR",
+      "share": 2.1,
+      "success_rate": 53.7,
+      "top_failure": {
+        "reason": "download_manifest_file_fail",
+        "share": 75.4
+      }
+    }
+  ],
+  "updater_versions": [
+    {
+      "key": "8.49.1",
+      "share": 22.6,
+      "success_rate": 85.3,
+      "top_failure": {
+        "reason": "download_fail",
+        "share": 49.9
+      }
+    },
+    {
+      "key": "8.45.8",
+      "share": 8.6,
+      "success_rate": 96.5,
+      "top_failure": {
+        "reason": "download_fail",
+        "share": 86.8
+      }
+    },
+    {
+      "key": "5.9.5",
+      "share": 5.3,
+      "success_rate": 39.4,
+      "top_failure": {
+        "reason": "decrypt_fail",
+        "share": 100
+      }
+    },
+    {
+      "key": "8.50.2",
+      "share": 4.3,
+      "success_rate": 39.8,
+      "top_failure": {
+        "reason": "download_manifest_file_fail",
+        "share": 83.6
+      }
+    },
+    {
+      "key": "8.45.0",
+      "share": 2.9,
+      "success_rate": 52.6,
+      "top_failure": {
+        "reason": "download_manifest_file_fail",
+        "share": 84
+      }
+    },
+    {
+      "key": "8.43.2",
+      "share": 2.8,
+      "success_rate": 72.5,
+      "top_failure": {
+        "reason": "download_fail",
+        "share": 90.2
+      }
+    },
+    {
+      "key": "8.43.10",
+      "share": 2.8,
+      "success_rate": 92.8,
+      "top_failure": {
+        "reason": "download_fail",
+        "share": 81.6
+      }
+    },
+    {
+      "key": "7.7.0",
+      "share": 2.7,
+      "success_rate": null,
+      "top_failure": null
+    },
+    {
+      "key": "5.45.10",
+      "share": 2.5,
+      "success_rate": null,
+      "top_failure": {
+        "reason": "update_fail",
+        "share": 100
+      }
+    },
+    {
+      "key": "7.42.3",
+      "share": 2.4,
+      "success_rate": 84.9,
+      "top_failure": {
+        "reason": "download_fail",
+        "share": 87.4
+      }
+    }
+  ],
+  "source": "api"
+}

--- a/apps/web/src/layouts/Layout.astro
+++ b/apps/web/src/layouts/Layout.astro
@@ -54,6 +54,7 @@ const enableThirdPartyScripts = !isLocalhost && !disableThirdPartyScripts
     <link rel="preload" as="font" type="font/woff" href="/fonts/AirbnbCerealBold.woff" crossorigin />
     <link rel="stylesheet" href={globalStylesHref} />
     <SEO {...content} />
+    <slot name="head" />
     {enableThirdPartyScripts && <MetaPixel />}
     {enableThirdPartyScripts && <PostHog />}
     {enableThirdPartyScripts && <Affonso />}

--- a/apps/web/src/lib/liveUpdateFailureReasons.ts
+++ b/apps/web/src/lib/liveUpdateFailureReasons.ts
@@ -1,0 +1,182 @@
+/**
+ * Short trust-oriented explanations for live-update failure codes.
+ * Sourced from Capgo docs (`/docs/webapp/logs/` and updater debugging).
+ * Tone matches public transparency pages: normal causes first, no alarm.
+ */
+
+export type FailureReasonInfo = {
+  label: string
+  explanation: string
+}
+
+const FAILURE_REASON_INFO: Record<string, FailureReasonInfo> = {
+  download_fail: {
+    label: 'Download failure',
+    explanation: 'The bundle download was interrupted — usually a network timeout, drop, or CDN reachability issue. Devices retry on the next launch.',
+  },
+  download_manifest_file_fail: {
+    label: 'Manifest file failure',
+    explanation: 'A delta update file could not be fetched. Brief network issues or a missing asset are the usual causes; devices retry automatically.',
+  },
+  download_manifest_checksum_fail: {
+    label: 'Manifest checksum failure',
+    explanation: 'A delta file failed integrity checks, so the update was discarded instead of installing a corrupted payload.',
+  },
+  download_manifest_brotli_fail: {
+    label: 'Manifest decompress failure',
+    explanation: 'A compressed delta file could not be unpacked on the device. Often a partial download or unsupported compression artifact.',
+  },
+  finish_download_fail: {
+    label: 'Finish download failure',
+    explanation: 'The download did not complete cleanly before install could start — typically connectivity or storage pressure mid-transfer.',
+  },
+  checksum_fail: {
+    label: 'Checksum failure',
+    explanation: 'Downloaded bytes did not match the expected checksum, so Capgo discarded the update rather than risk a bad install.',
+  },
+  checksum_required: {
+    label: 'Checksum required',
+    explanation: 'The update could not be verified because checksum metadata was missing, so the device skipped the install.',
+  },
+  unzip_fail: {
+    label: 'Unzip failure',
+    explanation: 'The device could not unpack the bundle archive — often low storage or a corrupted download.',
+  },
+  decrypt_fail: {
+    label: 'Decrypt failure',
+    explanation: 'An encrypted bundle could not be decrypted on the device, usually from a key mismatch between app and upload.',
+  },
+  update_fail: {
+    label: 'Update failure',
+    explanation: 'The bundle installed but the app never called notifyAppReady(), so Capgo rolled back automatically for safety.',
+  },
+  set_fail: {
+    label: 'Set failure',
+    explanation: 'The device downloaded the bundle but failed to activate it as the next version.',
+  },
+  backend_refusal: {
+    label: 'Backend refusal',
+    explanation: 'Capgo rejected an outdated updater (v4). Those devices need a store build with a newer plugin — not a transient outage.',
+  },
+  needPlanUpgrade: {
+    label: 'Plan limit',
+    explanation: 'The organization hit its plan or device limit, so updates paused until the plan upgrades or the billing cycle resets.',
+  },
+  rateLimited: {
+    label: 'Rate limited',
+    explanation: 'The device called update endpoints too often in a short window, so Capgo asked it to back off.',
+  },
+  invalidIp: {
+    label: 'Invalid IP',
+    explanation: 'Traffic looked like bot or cloud-provider infrastructure, so Capgo blocked it. Normal end-user devices are unaffected.',
+  },
+  disableAutoUpdateToMajor: {
+    label: 'Major update blocked',
+    explanation: 'Channel policy intentionally blocked a major version jump. This is a configured safeguard, not a delivery outage.',
+  },
+  disableAutoUpdateToMinor: {
+    label: 'Minor update blocked',
+    explanation: 'Channel policy intentionally blocked a minor version jump.',
+  },
+  disableAutoUpdateToPatch: {
+    label: 'Patch update blocked',
+    explanation: 'Channel policy intentionally blocked a patch-level jump.',
+  },
+  disableAutoUpdate: {
+    label: 'Auto-update blocked',
+    explanation: 'Channel auto-update settings blocked this update style by design.',
+  },
+  disableAutoUpdateUnderNative: {
+    label: 'Under-native blocked',
+    explanation: 'The channel blocks updates older than the device native baseline.',
+  },
+  disableAutoUpdateMetadata: {
+    label: 'Metadata gate blocked',
+    explanation: 'The channel requires min_update_version metadata the app does not meet yet.',
+  },
+  disableEmulator: {
+    label: 'Emulator blocked',
+    explanation: 'This channel is configured to reject emulator updates.',
+  },
+  disableDevBuild: {
+    label: 'Dev build blocked',
+    explanation: 'This channel is configured to reject development builds.',
+  },
+  disableProdBuild: {
+    label: 'Prod build blocked',
+    explanation: 'This channel is configured to reject production builds.',
+  },
+  disableDevice: {
+    label: 'Real device blocked',
+    explanation: 'This channel is configured to block real phones and tablets.',
+  },
+  disablePlatformIos: {
+    label: 'iOS blocked',
+    explanation: 'iOS updates are disabled on this channel by policy.',
+  },
+  disablePlatformAndroid: {
+    label: 'Android blocked',
+    explanation: 'Android updates are disabled on this channel by policy.',
+  },
+  disablePlatformElectron: {
+    label: 'Electron blocked',
+    explanation: 'Electron updates are disabled on this channel by policy.',
+  },
+  low_mem_fail: {
+    label: 'Low memory',
+    explanation: 'The device ran out of memory while downloading or installing, so the update stopped.',
+  },
+  keyMismatch: {
+    label: 'Key mismatch',
+    explanation: 'The app encryption key does not match the bundle key, so Capgo refused the update.',
+  },
+  missingBundle: {
+    label: 'Missing bundle',
+    explanation: 'Capgo could not serve a downloadable payload for the selected version.',
+  },
+  cannotGetBundle: {
+    label: 'Cannot get bundle',
+    explanation: 'Capgo could not build a valid download URL for the selected bundle.',
+  },
+  NoChannelOrOverride: {
+    label: 'No channel',
+    explanation: 'No channel matched this device — no default, config fallback, or override was set.',
+  },
+  channelMisconfigured: {
+    label: 'Channel misconfigured',
+    explanation: 'Channel auto-update rules were missing required metadata, so the update was refused.',
+  },
+  cannotUpdateViaPrivateChannel: {
+    label: 'Private channel blocked',
+    explanation: 'The app tried to self-assign a private channel that does not allow it.',
+  },
+  blocked_by_server_url: {
+    label: 'Server URL blocked',
+    explanation: 'Capacitor server.url is set, so the app loads a remote URL instead of local files Capgo can update.',
+  },
+  customIdBlocked: {
+    label: 'Custom ID blocked',
+    explanation: 'The app sent a custom device ID, but this app is configured to reject them.',
+  },
+}
+
+function humanizeReason(reason: string) {
+  return reason
+    .replaceAll('_', ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+export function getFailureReasonInfo(reason: string): FailureReasonInfo {
+  const known = FAILURE_REASON_INFO[reason]
+  if (known) return known
+  return {
+    label: humanizeReason(reason),
+    explanation: 'A normalized install outcome from Capgo device logs. See the updater debugging docs for the full code reference.',
+  }
+}
+
+export const failureReasonInfoEntries = Object.entries(FAILURE_REASON_INFO).map(([reason, info]) => ({
+  reason,
+  ...info,
+}))

--- a/apps/web/src/lib/liveUpdateMetrics.ts
+++ b/apps/web/src/lib/liveUpdateMetrics.ts
@@ -1,0 +1,152 @@
+import cachedMetrics from '@/data/live-update-metrics.json'
+
+export type DailyMetric = { date: string; success_rate: number }
+export type FailureMetric = { reason: string; share: number }
+export type BreakdownMetric = {
+  key: string
+  share: number
+  success_rate: number | null
+  top_failure: { reason: string; share: number } | null
+}
+export type LiveUpdateMetrics = {
+  success_rate: number
+  updated_at: string
+  daily: DailyMetric[]
+  failures: FailureMetric[]
+  platforms: BreakdownMetric[]
+  countries: BreakdownMetric[]
+  updater_versions: BreakdownMetric[]
+  source?: 'api' | 'cache'
+}
+
+const FALLBACK = cachedMetrics as LiveUpdateMetrics
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function percentage(value: unknown) {
+  const number = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(number) ? Math.max(0, Math.min(100, number)) : 0
+}
+
+function nullablePercentage(value: unknown) {
+  if (value === null || value === undefined || value === '') return null
+  const number = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(number) ? Math.max(0, Math.min(100, number)) : null
+}
+
+function normalizeBreakdown(value: unknown): BreakdownMetric | null {
+  if (!isRecord(value) || typeof value.key !== 'string' || !value.key) return null
+  const top = isRecord(value.top_failure)
+    ? {
+        reason: typeof value.top_failure.reason === 'string' ? value.top_failure.reason : '',
+        share: percentage(value.top_failure.share),
+      }
+    : null
+  return {
+    key: value.key,
+    share: percentage(value.share),
+    success_rate: nullablePercentage(value.success_rate),
+    top_failure: top && top.reason ? top : null,
+  }
+}
+
+export function normalizeLiveUpdateMetrics(value: unknown): LiveUpdateMetrics | null {
+  if (!isRecord(value) || typeof value.updated_at !== 'string' || !Array.isArray(value.daily) || !Array.isArray(value.failures)) {
+    return null
+  }
+
+  const daily = value.daily
+    .map((item) => {
+      if (!isRecord(item) || typeof item.date !== 'string') return null
+      return { date: item.date, success_rate: percentage(item.success_rate) }
+    })
+    .filter((item): item is DailyMetric => item !== null)
+
+  const failures = value.failures
+    .map((item) => {
+      if (!isRecord(item) || typeof item.reason !== 'string') return null
+      return { reason: item.reason, share: percentage(item.share) }
+    })
+    .filter((item): item is FailureMetric => item !== null)
+
+  let platforms: BreakdownMetric[] = []
+  if (Array.isArray(value.platforms)) {
+    platforms = value.platforms.map(normalizeBreakdown).filter((item): item is BreakdownMetric => item !== null)
+  } else if (isRecord(value.platforms)) {
+    const legacyPlatforms = value.platforms
+    platforms = (['ios', 'android', 'electron'] as const)
+      .map((key) => ({
+        key,
+        share: percentage(legacyPlatforms[key]),
+        success_rate: null,
+        top_failure: null,
+      }))
+      .filter((item) => item.share > 0)
+  }
+
+  const countries = Array.isArray(value.countries) ? value.countries.map(normalizeBreakdown).filter((item): item is BreakdownMetric => item !== null) : []
+
+  let updater_versions: BreakdownMetric[] = []
+  if (Array.isArray(value.updater_versions)) {
+    const breakdowns = value.updater_versions.map(normalizeBreakdown).filter((item): item is BreakdownMetric => item !== null)
+
+    if (breakdowns.length > 0) {
+      updater_versions = breakdowns
+    } else {
+      const legacyRows = value.updater_versions
+        .map((item) => {
+          if (!isRecord(item) || typeof item.date !== 'string' || typeof item.version !== 'string') return null
+          return { date: item.date, version: item.version, share: percentage(item.share) }
+        })
+        .filter((item): item is { date: string; version: string; share: number } => item !== null)
+      const dayCount = new Set(legacyRows.map((item) => item.date)).size
+      const totals = new Map<string, number>()
+      for (const item of legacyRows) {
+        totals.set(item.version, (totals.get(item.version) ?? 0) + item.share)
+      }
+      updater_versions = [...totals]
+        .map(([key, share]) => ({
+          key,
+          share: dayCount ? share / dayCount : 0,
+          success_rate: null,
+          top_failure: null,
+        }))
+        .sort((a, b) => b.share - a.share)
+        .slice(0, 10)
+    }
+  }
+
+  return {
+    success_rate: percentage(value.success_rate),
+    updated_at: value.updated_at,
+    daily,
+    failures,
+    platforms,
+    countries,
+    updater_versions,
+  }
+}
+
+export function getCachedLiveUpdateMetrics(): LiveUpdateMetrics {
+  return { ...FALLBACK, source: 'cache' }
+}
+
+export async function fetchLiveUpdateMetrics(baseApiUrl: string): Promise<LiveUpdateMetrics | null> {
+  try {
+    const response = await fetch(`${baseApiUrl.replace(/\/$/, '')}/private/website_stats/live_updates`, {
+      headers: { Accept: 'application/json' },
+    })
+    if (!response.ok) return null
+    const metrics = normalizeLiveUpdateMetrics(await response.json())
+    return metrics ? { ...metrics, source: 'api' } : null
+  } catch {
+    return null
+  }
+}
+
+export async function resolveLiveUpdateMetrics(baseApiUrl: string): Promise<LiveUpdateMetrics> {
+  const live = await fetchLiveUpdateMetrics(baseApiUrl)
+  return live ?? getCachedLiveUpdateMetrics()
+}

--- a/apps/web/src/pages/data.astro
+++ b/apps/web/src/pages/data.astro
@@ -1,26 +1,71 @@
 ---
 import Layout from '@/layouts/Layout.astro'
+import { getFailureReasonInfo } from '@/lib/liveUpdateFailureReasons'
+import { resolveLiveUpdateMetrics } from '@/lib/liveUpdateMetrics'
 import { createLdJsonGraph, createWebPageLdJson } from '@/lib/ldJson'
 
 const config = Astro.locals.runtimeConfig
+const metrics = await resolveLiveUpdateMetrics(config.public.baseApiUrl)
+const apiOrigin = new URL(config.public.baseApiUrl).origin
 const title = 'Capgo Live Update data | Platform insights'
-const description = 'Live Update success by country, platform, and updater version. Rates use app, device, and UTC-day outcomes over the last 30 days.'
+const description =
+  'Live Update success by country, platform, and updater version. Rates use app, device, and UTC-day outcomes over the last 30 days — including honest failure reasons.'
 const content = {
   title,
   description,
   image: `${config.public.baseUrl}/social/capgo-live-update.png`,
   ldJSON: createLdJsonGraph(config.public, createWebPageLdJson(config.public, { name: title, description, url: Astro.url.href }), { includeOrganization: true }),
 }
+
+const updatedLabel = (() => {
+  const timestamp = new Date(metrics.updated_at)
+  return Number.isNaN(timestamp.getTime())
+    ? 'Updated moments ago'
+    : `Updated ${new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short', timeZone: 'UTC' }).format(timestamp)} UTC`
+})()
+
+const topFailure = metrics.failures[0]
+const topFailureInfo = topFailure ? getFailureReasonInfo(topFailure.reason) : null
+const topFailureLead = topFailureInfo
+  ? `${topFailureInfo.label} accounts for ${Math.ceil(topFailure.share)}% of failures in this window.`
+  : 'Normalized categories across all apps.'
+
+const countryNames = typeof Intl !== 'undefined' && 'DisplayNames' in Intl ? new Intl.DisplayNames(['en'], { type: 'region' }) : null
+
+function labelForKey(kind: 'country' | 'platform' | 'version', key: string) {
+  if (kind === 'platform') {
+    if (key === 'ios') return 'iOS'
+    if (key === 'android') return 'Android'
+    if (key === 'electron') return 'Electron'
+  }
+  if (kind === 'country') {
+    try {
+      return countryNames?.of(key.toUpperCase()) ?? key.toUpperCase()
+    } catch {
+      return key.toUpperCase()
+    }
+  }
+  return key
+}
+
+function formatPct(value: number | null) {
+  return value === null ? '—' : `${Math.ceil(value)}%`
+}
 ---
 
 <Layout content={content}>
-  <main class="data-page" data-metrics-endpoint={`${config.public.baseApiUrl}/private/website_stats/live_updates`} aria-busy="true">
+  <link slot="head" rel="preconnect" href={apiOrigin} crossorigin="anonymous" />
+  <link slot="head" rel="dns-prefetch" href={apiOrigin} />
+  <main class="data-page" data-metrics-endpoint={`${config.public.baseApiUrl}/private/website_stats/live_updates`} data-initial-metrics={JSON.stringify(metrics)} aria-busy="false">
     <section class="data-hero">
       <div class="data-shell">
         <p class="data-eyebrow"><span aria-hidden="true"></span> Our data</p>
         <h1>Live Update delivery data</h1>
-        <p class="data-summary">Last 30 days of Capgo install success. Each rate uses app, device, and UTC-day outcomes — overall and by country, platform, and updater version.</p>
-        <p class="data-updated" data-updated aria-live="polite"><span class="data-spinner" aria-hidden="true"></span> Loading delivery data…</p>
+        <p class="data-summary">
+          Last 30 days of Capgo install success. Each rate uses app, device, and UTC-day outcomes — overall and by country, platform, and updater version. We publish failures too,
+          with plain-language explanations from our docs.
+        </p>
+        <p class="data-updated" data-updated aria-live="polite">{updatedLabel}</p>
       </div>
     </section>
 
@@ -35,12 +80,12 @@ const content = {
         </div>
 
         <div class="data-kpis" aria-label="Reliability summary">
-          <div><p>Success rate</p><strong data-kpi="success-rate">—</strong></div>
+          <div><p>Success rate</p><strong data-kpi="success-rate">{Math.ceil(metrics.success_rate)}%</strong></div>
           <div><p>Window</p><strong>30 days</strong></div>
           <div><p>Scope</p><strong>All apps</strong></div>
         </div>
 
-        <div class="data-loading data-chart-skeleton" aria-hidden="true">
+        <div class="data-chart-skeleton" data-daily-skeleton aria-hidden="true">
           <div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div>
         </div>
         <div class="data-chart" data-daily-chart aria-label="Daily install success chart" hidden>
@@ -72,11 +117,26 @@ const content = {
               </tr>
             </thead>
             <tbody data-countries>
-              <tr class="data-loading"><td colspan="4"><span class="data-list-skeleton" aria-hidden="true"></span></td></tr>
+              {
+                metrics.countries.map((item) => {
+                  const failure = item.top_failure ? getFailureReasonInfo(item.top_failure.reason) : null
+                  const tone = item.success_rate === null ? undefined : item.success_rate >= 85 ? 'good' : item.success_rate >= 70 ? 'ok' : 'poor'
+                  return (
+                    <tr>
+                      <th scope="row">{labelForKey('country', item.key)}</th>
+                      <td>{formatPct(item.share)}</td>
+                      <td data-tone={tone}>{formatPct(item.success_rate)}</td>
+                      <td title={failure?.explanation}>{failure ? `${failure.label} (${Math.ceil(item.top_failure!.share)}%)` : '—'}</td>
+                    </tr>
+                  )
+                })
+              }
             </tbody>
           </table>
         </div>
-        <p class="data-empty" data-countries-empty aria-live="polite" hidden></p>
+        <p class="data-empty" data-countries-empty aria-live="polite" hidden={metrics.countries.length > 0}>
+          {metrics.countries.length ? '' : 'Country breakdown is temporarily unavailable.'}
+        </p>
       </div>
     </section>
 
@@ -100,11 +160,26 @@ const content = {
               </tr>
             </thead>
             <tbody data-platforms>
-              <tr class="data-loading"><td colspan="4"><span class="data-list-skeleton" aria-hidden="true"></span></td></tr>
+              {
+                metrics.platforms.map((item) => {
+                  const failure = item.top_failure ? getFailureReasonInfo(item.top_failure.reason) : null
+                  const tone = item.success_rate === null ? undefined : item.success_rate >= 85 ? 'good' : item.success_rate >= 70 ? 'ok' : 'poor'
+                  return (
+                    <tr>
+                      <th scope="row">{labelForKey('platform', item.key)}</th>
+                      <td>{formatPct(item.share)}</td>
+                      <td data-tone={tone}>{formatPct(item.success_rate)}</td>
+                      <td title={failure?.explanation}>{failure ? `${failure.label} (${Math.ceil(item.top_failure!.share)}%)` : '—'}</td>
+                    </tr>
+                  )
+                })
+              }
             </tbody>
           </table>
         </div>
-        <p class="data-empty" data-platforms-empty aria-live="polite" hidden></p>
+        <p class="data-empty" data-platforms-empty aria-live="polite" hidden={metrics.platforms.length > 0}>
+          {metrics.platforms.length ? '' : 'Platform breakdown is temporarily unavailable.'}
+        </p>
       </div>
     </section>
 
@@ -113,12 +188,36 @@ const content = {
         <div>
           <p class="data-eyebrow">Failures</p>
           <h2 id="failures-title">Top failure reasons</h2>
-          <p class="data-copy">Normalized categories across all apps.</p>
+          <p class="data-copy" data-failures-lead>{topFailureLead}</p>
+          <p class="data-copy data-copy-secondary">
+            Many failures are normal on real devices — flaky networks, intentional channel policies, and automatic rollbacks all show up here. We keep the list public so you can
+            trust the numbers.
+          </p>
+          <p class="data-copy data-copy-secondary">
+            Code meanings follow our <a class="data-inline-link" href="/docs/webapp/logs/">logs docs</a>.
+          </p>
         </div>
         <ol class="data-failures" data-failures aria-live="polite">
-          <li class="data-loading data-list-skeleton" aria-hidden="true"><span></span><div></div><b></b></li>
-          <li class="data-loading data-list-skeleton" aria-hidden="true"><span></span><div></div><b></b></li>
-          <li class="data-loading data-list-skeleton" aria-hidden="true"><span></span><div></div><b></b></li>
+          {
+            metrics.failures.length
+              ? metrics.failures.map((item, index) => {
+                  const info = getFailureReasonInfo(item.reason)
+                  return (
+                    <li>
+                      <span>{String(index + 1).padStart(2, '0')}</span>
+                      <div class="data-failure-copy">
+                        <strong>{info.label}</strong>
+                        <p>{info.explanation}</p>
+                      </div>
+                      <b>{Math.ceil(item.share)}%</b>
+                      <i aria-hidden="true">
+                        <em style={`--share: ${item.share}%`} />
+                      </i>
+                    </li>
+                  )
+                })
+              : [<li class="data-empty">No failures in this window.</li>]
+          }
         </ol>
       </div>
     </section>
@@ -143,34 +242,34 @@ const content = {
               </tr>
             </thead>
             <tbody data-versions>
-              <tr class="data-loading"><td colspan="4"><span class="data-list-skeleton" aria-hidden="true"></span></td></tr>
+              {
+                metrics.updater_versions.map((item) => {
+                  const failure = item.top_failure ? getFailureReasonInfo(item.top_failure.reason) : null
+                  const tone = item.success_rate === null ? undefined : item.success_rate >= 85 ? 'good' : item.success_rate >= 70 ? 'ok' : 'poor'
+                  return (
+                    <tr>
+                      <th scope="row">{labelForKey('version', item.key)}</th>
+                      <td>{formatPct(item.share)}</td>
+                      <td data-tone={tone}>{formatPct(item.success_rate)}</td>
+                      <td title={failure?.explanation}>{failure ? `${failure.label} (${Math.ceil(item.top_failure!.share)}%)` : '—'}</td>
+                    </tr>
+                  )
+                })
+              }
             </tbody>
           </table>
         </div>
-        <p class="data-empty" data-version-empty aria-live="polite" hidden></p>
+        <p class="data-empty" data-version-empty aria-live="polite" hidden={metrics.updater_versions.length > 0}>
+          {metrics.updater_versions.length ? '' : 'Updater breakdown is temporarily unavailable.'}
+        </p>
       </div>
     </section>
   </main>
 </Layout>
 
 <script>
-  type DailyMetric = { date: string; success_rate: number }
-  type FailureMetric = { reason: string; share: number }
-  type BreakdownMetric = {
-    key: string
-    share: number
-    success_rate: number | null
-    top_failure: { reason: string; share: number } | null
-  }
-  type Metrics = {
-    success_rate: number
-    updated_at: string
-    daily: DailyMetric[]
-    failures: FailureMetric[]
-    platforms: BreakdownMetric[]
-    countries: BreakdownMetric[]
-    updater_versions: BreakdownMetric[]
-  }
+  import { getFailureReasonInfo } from '@/lib/liveUpdateFailureReasons'
+  import { normalizeLiveUpdateMetrics, type LiveUpdateMetrics } from '@/lib/liveUpdateMetrics'
 
   function boot() {
     const page = document.querySelector<HTMLElement>('.data-page')
@@ -178,11 +277,13 @@ const content = {
     const updated = page?.querySelector<HTMLElement>('[data-updated]')
     const successRateKpi = page?.querySelector<HTMLElement>('[data-kpi="success-rate"]')
     const dailyChart = page?.querySelector<HTMLElement>('[data-daily-chart]')
+    const dailySkeleton = page?.querySelector<HTMLElement>('[data-daily-skeleton]')
     const dailyBars = page?.querySelector<HTMLElement>('[data-daily-bars]')
     const dailyStart = page?.querySelector<HTMLElement>('[data-daily-start]')
     const dailyEnd = page?.querySelector<HTMLElement>('[data-daily-end]')
     const dailyEmpty = page?.querySelector<HTMLElement>('[data-daily-empty]')
     const failuresList = page?.querySelector<HTMLOListElement>('[data-failures]')
+    const failuresLead = page?.querySelector<HTMLElement>('[data-failures-lead]')
     const countriesBody = page?.querySelector<HTMLElement>('[data-countries]')
     const countriesEmpty = page?.querySelector<HTMLElement>('[data-countries-empty]')
     const platformsBody = page?.querySelector<HTMLElement>('[data-platforms]')
@@ -193,32 +294,10 @@ const content = {
 
     const countryNames = typeof Intl !== 'undefined' && 'DisplayNames' in Intl ? new Intl.DisplayNames(['en'], { type: 'region' }) : null
 
-    function isRecord(value: unknown): value is Record<string, unknown> {
-      return typeof value === 'object' && value !== null && !Array.isArray(value)
-    }
-
-    function percentage(value: unknown) {
-      const number = typeof value === 'number' ? value : Number(value)
-      return Number.isFinite(number) ? Math.max(0, Math.min(100, number)) : 0
-    }
-
-    function nullablePercentage(value: unknown) {
-      if (value === null || value === undefined || value === '') return null
-      const number = typeof value === 'number' ? value : Number(value)
-      return Number.isFinite(number) ? Math.max(0, Math.min(100, number)) : null
-    }
-
     function createScopedElement<K extends keyof HTMLElementTagNameMap>(tag: K) {
       const element = document.createElement(tag)
       for (const attribute of styleScopeAttributes) element.setAttribute(attribute, '')
       return element
-    }
-
-    function readableReason(reason: string) {
-      return reason
-        .replaceAll('_', ' ')
-        .replace(/([a-z])([A-Z])/g, '$1 $2')
-        .replace(/\b\w/g, (char) => char.toUpperCase())
     }
 
     function labelForKey(kind: 'country' | 'platform' | 'version', key: string) {
@@ -237,100 +316,6 @@ const content = {
       return key
     }
 
-    function normalizeBreakdown(value: unknown): BreakdownMetric | null {
-      if (!isRecord(value) || typeof value.key !== 'string' || !value.key) return null
-      const top = isRecord(value.top_failure)
-        ? {
-            reason: typeof value.top_failure.reason === 'string' ? value.top_failure.reason : '',
-            share: percentage(value.top_failure.share),
-          }
-        : null
-      return {
-        key: value.key,
-        share: percentage(value.share),
-        success_rate: nullablePercentage(value.success_rate),
-        top_failure: top && top.reason ? top : null,
-      }
-    }
-
-    function normalizeMetrics(value: unknown): Metrics | null {
-      if (!isRecord(value) || typeof value.updated_at !== 'string' || !Array.isArray(value.daily) || !Array.isArray(value.failures)) {
-        return null
-      }
-
-      const daily = value.daily
-        .map((item) => {
-          if (!isRecord(item) || typeof item.date !== 'string') return null
-          return { date: item.date, success_rate: percentage(item.success_rate) }
-        })
-        .filter((item): item is DailyMetric => item !== null)
-
-      const failures = value.failures
-        .map((item) => {
-          if (!isRecord(item) || typeof item.reason !== 'string') return null
-          return { reason: item.reason, share: percentage(item.share) }
-        })
-        .filter((item): item is FailureMetric => item !== null)
-
-      let platforms: BreakdownMetric[] = []
-      if (Array.isArray(value.platforms)) {
-        platforms = value.platforms.map(normalizeBreakdown).filter((item): item is BreakdownMetric => item !== null)
-      } else if (isRecord(value.platforms)) {
-        const legacyPlatforms = value.platforms
-        platforms = (['ios', 'android', 'electron'] as const)
-          .map((key) => ({
-            key,
-            share: percentage(legacyPlatforms[key]),
-            success_rate: null,
-            top_failure: null,
-          }))
-          .filter((item) => item.share > 0)
-      }
-
-      const countries = Array.isArray(value.countries) ? value.countries.map(normalizeBreakdown).filter((item): item is BreakdownMetric => item !== null) : []
-
-      let updater_versions: BreakdownMetric[] = []
-      if (Array.isArray(value.updater_versions)) {
-        const breakdowns = value.updater_versions.map(normalizeBreakdown).filter((item): item is BreakdownMetric => item !== null)
-
-        if (breakdowns.length > 0) {
-          updater_versions = breakdowns
-        } else {
-          const legacyRows = value.updater_versions
-            .map((item) => {
-              if (!isRecord(item) || typeof item.date !== 'string' || typeof item.version !== 'string') return null
-              return { date: item.date, version: item.version, share: percentage(item.share) }
-            })
-            .filter((item): item is { date: string; version: string; share: number } => item !== null)
-          const dayCount = new Set(legacyRows.map((item) => item.date)).size
-          const totals = new Map<string, number>()
-          for (const item of legacyRows) {
-            totals.set(item.version, (totals.get(item.version) ?? 0) + item.share)
-          }
-          // Legacy payloads report a percentage per day; average it across the reporting window.
-          updater_versions = [...totals]
-            .map(([key, share]) => ({
-              key,
-              share: dayCount ? share / dayCount : 0,
-              success_rate: null,
-              top_failure: null,
-            }))
-            .sort((a, b) => b.share - a.share)
-            .slice(0, 10)
-        }
-      }
-
-      return {
-        success_rate: percentage(value.success_rate),
-        updated_at: value.updated_at,
-        daily,
-        failures,
-        platforms,
-        countries,
-        updater_versions,
-      }
-    }
-
     function formatPct(value: number | null) {
       return value === null ? '—' : `${Math.ceil(value)}%`
     }
@@ -338,7 +323,7 @@ const content = {
     function renderBreakdownRows(
       body: HTMLElement | null | undefined,
       empty: HTMLElement | null | undefined,
-      rows: BreakdownMetric[],
+      rows: LiveUpdateMetrics['countries'],
       kind: 'country' | 'platform' | 'version',
       emptyText: string,
     ) {
@@ -357,7 +342,13 @@ const content = {
           success.dataset.tone = item.success_rate >= 85 ? 'good' : item.success_rate >= 70 ? 'ok' : 'poor'
         }
         const failure = createScopedElement('td')
-        failure.textContent = item.top_failure ? `${readableReason(item.top_failure.reason)} (${Math.ceil(item.top_failure.share)}%)` : '—'
+        if (item.top_failure) {
+          const info = getFailureReasonInfo(item.top_failure.reason)
+          failure.textContent = `${info.label} (${Math.ceil(item.top_failure.share)}%)`
+          failure.title = info.explanation
+        } else {
+          failure.textContent = '—'
+        }
         tr.append(name, usage, success, failure)
         body.append(tr)
       }
@@ -367,7 +358,7 @@ const content = {
       }
     }
 
-    function renderDaily(metrics: Metrics) {
+    function renderDaily(metrics: LiveUpdateMetrics) {
       if (!dailyChart || !dailyBars || !dailyStart || !dailyEnd || !dailyEmpty) return
       dailyBars.replaceChildren()
       for (const item of metrics.daily) {
@@ -385,21 +376,37 @@ const content = {
         dailyBars.append(bar)
       }
       dailyChart.hidden = metrics.daily.length === 0
+      if (dailySkeleton) dailySkeleton.hidden = metrics.daily.length > 0
       dailyEmpty.hidden = metrics.daily.length > 0
       dailyEmpty.textContent = 'Success-rate data is temporarily unavailable.'
       dailyStart.textContent = metrics.daily[0]?.date ?? ''
       dailyEnd.textContent = metrics.daily.at(-1)?.date ?? ''
     }
 
-    function renderFailures(metrics: Metrics) {
+    function renderFailures(metrics: LiveUpdateMetrics) {
       if (!failuresList) return
       failuresList.replaceChildren()
+      const lead = metrics.failures[0]
+      if (failuresLead) {
+        if (lead) {
+          const info = getFailureReasonInfo(lead.reason)
+          failuresLead.textContent = `${info.label} accounts for ${Math.ceil(lead.share)}% of failures in this window.`
+        } else {
+          failuresLead.textContent = 'Normalized categories across all apps.'
+        }
+      }
       for (const [index, item] of metrics.failures.entries()) {
+        const info = getFailureReasonInfo(item.reason)
         const row = createScopedElement('li')
         const rank = createScopedElement('span')
         rank.textContent = String(index + 1).padStart(2, '0')
+        const copy = createScopedElement('div')
+        copy.className = 'data-failure-copy'
         const reason = createScopedElement('strong')
-        reason.textContent = readableReason(item.reason)
+        reason.textContent = info.label
+        const explanation = createScopedElement('p')
+        explanation.textContent = info.explanation
+        copy.append(reason, explanation)
         const share = createScopedElement('b')
         share.textContent = formatPct(item.share)
         const track = createScopedElement('i')
@@ -407,13 +414,13 @@ const content = {
         const fill = createScopedElement('em')
         fill.style.setProperty('--share', `${item.share}%`)
         track.append(fill)
-        row.append(rank, reason, share, track)
+        row.append(rank, copy, share, track)
         failuresList.append(row)
       }
       if (!metrics.failures.length) failuresList.append(Object.assign(createScopedElement('li'), { className: 'data-empty', textContent: 'No failures in this window.' }))
     }
 
-    function renderMetrics(metrics: Metrics) {
+    function renderMetrics(metrics: LiveUpdateMetrics) {
       if (successRateKpi) successRateKpi.textContent = formatPct(metrics.success_rate)
       renderDaily(metrics)
       renderFailures(metrics)
@@ -431,26 +438,33 @@ const content = {
     function renderUnavailable() {
       if (updated) updated.textContent = 'Delivery data is temporarily unavailable. Check back shortly.'
       if (dailyChart) dailyChart.hidden = true
+      if (dailySkeleton) dailySkeleton.hidden = true
       if (dailyEmpty) {
         dailyEmpty.hidden = false
         dailyEmpty.textContent = 'Success-rate data is temporarily unavailable.'
       }
       if (failuresList) failuresList.replaceChildren(Object.assign(createScopedElement('li'), { className: 'data-empty', textContent: 'Failure data is temporarily unavailable.' }))
+      if (failuresLead) failuresLead.textContent = 'Failure data is temporarily unavailable.'
       renderBreakdownRows(countriesBody, countriesEmpty, [], 'country', 'Country breakdown is temporarily unavailable.')
       renderBreakdownRows(platformsBody, platformsEmpty, [], 'platform', 'Platform breakdown is temporarily unavailable.')
       renderBreakdownRows(versionsBody, versionEmpty, [], 'version', 'Updater breakdown is temporarily unavailable.')
     }
 
-    const METRICS_CACHE_KEY = 'capgo-live-update-metrics-v2'
-    const METRICS_CACHE_TTL_MS = 5 * 60 * 1000
+    const METRICS_CACHE_KEY = 'capgo-live-update-metrics-v3'
+    const METRICS_CACHE_FRESH_MS = 5 * 60 * 1000
+    const METRICS_CACHE_STALE_MS = 24 * 60 * 60 * 1000
 
-    function readCachedMetrics(): Metrics | null {
+    function readCachedMetrics(): { metrics: LiveUpdateMetrics; fresh: boolean } | null {
       try {
-        const raw = sessionStorage.getItem(METRICS_CACHE_KEY)
+        const raw = localStorage.getItem(METRICS_CACHE_KEY)
         if (!raw) return null
         const parsed = JSON.parse(raw) as { savedAt?: unknown; payload?: unknown }
-        if (typeof parsed.savedAt !== 'number' || Date.now() - parsed.savedAt > METRICS_CACHE_TTL_MS) return null
-        return normalizeMetrics(parsed.payload)
+        if (typeof parsed.savedAt !== 'number') return null
+        const age = Date.now() - parsed.savedAt
+        if (age > METRICS_CACHE_STALE_MS) return null
+        const metrics = normalizeLiveUpdateMetrics(parsed.payload)
+        if (!metrics) return null
+        return { metrics, fresh: age <= METRICS_CACHE_FRESH_MS }
       } catch {
         return null
       }
@@ -458,9 +472,19 @@ const content = {
 
     function writeCachedMetrics(payload: unknown) {
       try {
-        sessionStorage.setItem(METRICS_CACHE_KEY, JSON.stringify({ savedAt: Date.now(), payload }))
+        localStorage.setItem(METRICS_CACHE_KEY, JSON.stringify({ savedAt: Date.now(), payload }))
       } catch {
         // Ignore quota / private-mode failures.
+      }
+    }
+
+    function readBootstrapMetrics(): LiveUpdateMetrics | null {
+      try {
+        const raw = page?.dataset.initialMetrics
+        if (!raw) return null
+        return normalizeLiveUpdateMetrics(JSON.parse(raw))
+      } catch {
+        return null
       }
     }
 
@@ -469,9 +493,13 @@ const content = {
       const controller = new AbortController()
       const timeoutId = window.setTimeout(() => controller.abort(), 10_000)
       try {
-        const response = await fetch(endpoint, { headers: { Accept: 'application/json' }, signal: controller.signal })
+        const response = await fetch(endpoint, {
+          headers: { Accept: 'application/json' },
+          signal: controller.signal,
+          cache: 'default',
+        })
         const payload = response.ok ? await response.json() : null
-        const metrics = normalizeMetrics(payload)
+        const metrics = normalizeLiveUpdateMetrics(payload)
         if (!metrics) throw new Error('Invalid metrics response')
         writeCachedMetrics(payload)
         return metrics
@@ -481,16 +509,28 @@ const content = {
     }
 
     async function loadMetrics() {
+      const bootstrap = readBootstrapMetrics()
       const cached = readCachedMetrics()
-      if (cached) {
-        renderMetrics(cached)
+      const initial = cached?.metrics ?? bootstrap
+
+      if (initial) {
+        renderMetrics(initial)
         page?.setAttribute('aria-busy', 'false')
       }
+
+      if (cached?.fresh) {
+        // Still refresh quietly in the background so returning visitors stay current.
+        void fetchMetrics()
+          .then((metrics) => renderMetrics(metrics))
+          .catch(() => undefined)
+        return
+      }
+
       try {
         const metrics = await fetchMetrics()
         renderMetrics(metrics)
       } catch {
-        if (!cached) renderUnavailable()
+        if (!initial) renderUnavailable()
       } finally {
         page?.setAttribute('aria-busy', 'false')
       }
@@ -608,6 +648,20 @@ const content = {
     font-size: 1rem;
     line-height: 1.6;
     text-wrap: pretty;
+  }
+  .data-copy-secondary {
+    margin-top: 16px;
+    color: #91a2ba;
+    font-size: 0.95rem;
+  }
+  .data-inline-link {
+    color: #93c5fd;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+  .data-inline-link:hover,
+  .data-inline-link:focus-visible {
+    color: #bfdbfe;
   }
   .data-kpis {
     display: grid;
@@ -795,8 +849,8 @@ const content = {
   .data-failures li {
     display: grid;
     grid-template-columns: 34px minmax(0, 1fr) auto;
-    gap: 12px;
-    align-items: center;
+    gap: 8px 12px;
+    align-items: start;
     padding-bottom: 16px;
     border-bottom: 1px solid var(--line);
   }
@@ -804,16 +858,28 @@ const content = {
     color: #6f819b;
     font-size: 0.8rem;
     font-variant-numeric: tabular-nums;
+    padding-top: 3px;
+  }
+  .data-failure-copy {
+    min-width: 0;
   }
   .data-failures strong {
-    min-width: 0;
+    display: block;
     font-size: 1rem;
     font-weight: 600;
+  }
+  .data-failure-copy p {
+    margin: 6px 0 0;
+    color: #91a2ba;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    text-wrap: pretty;
   }
   .data-failures b {
     color: #d8e1ee;
     font-size: 0.875rem;
     font-variant-numeric: tabular-nums;
+    padding-top: 3px;
   }
   .data-failures i {
     grid-column: 2 / -1;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "fetch:downloads": "bun run scripts/fetch-npm-downloads.ts",
     "fetch:website-stats": "bun run scripts/fetch-website-stats.ts",
     "refresh:website-stats": "WEBSITE_STATS_REFRESH=true bun run scripts/fetch-website-stats.ts",
+    "fetch:live-update-metrics": "bun run scripts/fetch-live-update-metrics.ts",
+    "refresh:live-update-metrics": "LIVE_UPDATE_METRICS_REFRESH=true bun run scripts/fetch-live-update-metrics.ts",
     "refresh:stars": "GITHUB_STATS_REFRESH=true bun run scripts/fetch-github-stars.ts",
     "refresh:downloads": "NPM_DOWNLOADS_REFRESH=true bun run scripts/fetch-npm-downloads.ts",
     "scrape:distribution-charts": "bun run scripts/scrape-distribution-charts.ts",

--- a/scripts/fetch-live-update-metrics.ts
+++ b/scripts/fetch-live-update-metrics.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env bun
+
+/**
+ * Fetches Capgo live-update delivery metrics and saves to a JSON file.
+ * Run with: bun run fetch:live-update-metrics
+ * Refresh with: LIVE_UPDATE_METRICS_REFRESH=true bun run fetch:live-update-metrics
+ */
+
+import { normalizeLiveUpdateMetrics } from '../apps/web/src/lib/liveUpdateMetrics'
+import keys from '../configs.json'
+
+const REFRESH = process.env.LIVE_UPDATE_METRICS_REFRESH === 'true'
+const OUTPUT_PATH = new URL('../apps/web/src/data/live-update-metrics.json', import.meta.url).pathname
+const DEFAULT_API_URL = `https://api.${keys.base_domain.prod}`
+
+const readCached = async () => {
+  try {
+    const file = Bun.file(OUTPUT_PATH)
+    if (!(await file.exists())) return null
+    return await file.json()
+  } catch (error) {
+    console.warn('Could not read live-update metrics cache:', error)
+    return null
+  }
+}
+
+async function main() {
+  const baseApiUrl = (process.env.PUBLIC_BASE_API_URL || DEFAULT_API_URL).trim().replace(/\/$/, '')
+  const cached = await readCached()
+
+  if (!REFRESH) {
+    if (cached) {
+      console.log(`Using cached live-update metrics from ${cached.updated_at ?? 'unknown'}. Set LIVE_UPDATE_METRICS_REFRESH=true to refresh from ${baseApiUrl}.`)
+      return
+    }
+    console.warn('Live-update metrics cache is missing. Set LIVE_UPDATE_METRICS_REFRESH=true to fetch from the API.')
+    return
+  }
+
+  console.log(`Fetching live-update metrics from ${baseApiUrl}...`)
+  const response = await fetch(`${baseApiUrl}/private/website_stats/live_updates`, {
+    headers: { Accept: 'application/json' },
+  })
+
+  if (!response.ok) {
+    if (cached) {
+      console.warn(`Live fetch failed (HTTP ${response.status}). Keeping existing live-update-metrics.json cache.`)
+      return
+    }
+    throw new Error(`Could not fetch live-update metrics: HTTP ${response.status}`)
+  }
+
+  const payload = await response.json()
+  const metrics = normalizeLiveUpdateMetrics(payload)
+  if (!metrics) {
+    if (cached) {
+      console.warn('Live fetch returned invalid payload. Keeping existing cache.')
+      return
+    }
+    throw new Error('Could not normalize live-update metrics and no cache exists.')
+  }
+
+  const output = { ...payload, source: 'api' }
+  await Bun.write(OUTPUT_PATH, `${JSON.stringify(output, null, 2)}\n`)
+  console.log(`Saved live-update metrics to ${OUTPUT_PATH}`)
+  console.log(`  success_rate: ${metrics.success_rate}%`)
+  console.log(`  failures: ${metrics.failures.length}`)
+  console.log(`  updated_at: ${metrics.updated_at}`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `/data/` more transparent and faster, in the spirit of [bentonow.com/data](https://bentonow.com/data).

### Trust / explanations
- Each top failure now has a short plain-language explanation from Capgo docs (logs + updater debugging).
- Lead line mirrors Bento: “X accounts for Y% of failures in this window.”
- Copy clarifies many failures are normal (network, channel policy, automatic rollback).
- Table “Top failure” cells keep a hover `title` with the same explanation.
- Link to `/docs/webapp/logs/`.

### Load / cache
- Build-time bootstrap via `live-update-metrics.json` + live fetch during Astro build so HTML paints with real numbers (KPI, tables, failures) without waiting on the client API.
- Client cache moved from `sessionStorage` → `localStorage` with 5m fresh / 24h stale-while-revalidate.
- Deploy refreshes metrics (`LIVE_UPDATE_METRICS_REFRESH=true bun run fetch:live-update-metrics`).
- `preconnect` / `dns-prefetch` to the API origin.

Cold API responses can still take several seconds; first paint no longer depends on that.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fef8e-efe7-7ec2-9cfb-c9f419eb10b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fef8e-efe7-7ec2-9cfb-c9f419eb10b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789023042&installation_model_id=430928&pr_number=947&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F947&signature=df1b7e9bb4e2a9aaf2e4a390fbbccaa1f5767f851446c8651e499fa8e13e77d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live-update metrics covering success rates, daily trends, failure reasons, platforms, countries, and updater versions.
  * Added clear labels and explanations for live-update failure reasons.
  * Added formatted breakdown tables, charts, timestamps, and documentation links.
* **Improvements**
  * Metrics now appear server-rendered, improving initial page visibility.
  * Added cached and background-refresh behavior for more reliable metric availability.
  * Improved unavailable states and empty-result messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->