### PR TITLE
fix translation length + repair localized /data/

### DIFF
--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -268,6 +268,27 @@ assert(
   quotedAttrFalsePositiveParsed.segments.some((segment) => segment.inBody && segment.text.includes('Translate this paragraph')),
   'Parser skipped translatable text after translate=no substring inside quoted attribute value',
 )
+
+const unquotedHrefHtml = `<!doctype html><html><body><a href=/pricing/ tier>Plans</a></body></html>`
+const unquotedHrefParsed = __translationWorkerTest.collectSegments(unquotedHrefHtml)
+assert(
+  unquotedHrefParsed.parts.some((part) => typeof part === 'string' && part.includes('href=/pricing/')),
+  'Unquoted attribute scanner truncated / inside attribute values',
+)
+
+const unquotedTitleHtml = `<!doctype html><html><body><section title=Overview><p>99%</p></section></body></html>`
+const unquotedTitleParsed = __translationWorkerTest.collectSegments(unquotedTitleHtml)
+const unquotedTitleSegmentIndex = unquotedTitleParsed.segments.findIndex((segment) => segment.mode === 'attribute' && segment.text === 'Overview')
+assert(unquotedTitleSegmentIndex >= 0, 'Parser did not collect unquoted translatable title attribute')
+const unquotedTitleRendered = __translationWorkerTest.renderTranslatedHtml(
+  unquotedTitleParsed.parts,
+  unquotedTitleParsed.segments,
+  unquotedTitleParsed.segments.map((segment, index) => (index === unquotedTitleSegmentIndex ? 'Vue d\u2019ensemble' : segment.text)),
+)
+assert(
+  unquotedTitleRendered.includes('title="Vue d\u2019ensemble"'),
+  'Rendered translation of unquoted attribute must quote values containing spaces',
+)
 assert(
   __translationWorkerTest.guardTranslatedBatchLengths(
     ['Deploy updates safely to every device'],

--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -167,6 +167,7 @@ assert(typeof emptySuffixContext === 'string' && emptySuffixContext.includes('na
 assert(__translationWorkerTest.TRANSLATION_CACHE_VERSION.includes('message-context'), 'Cache version was not bumped for message context support')
 assert(__translationWorkerTest.TRANSLATION_CACHE_VERSION.includes('fr-elision'), 'Cache version was not bumped for French elision polish')
 assert(__translationWorkerTest.TRANSLATION_CACHE_VERSION.includes('length-translate-no'), 'Cache version was not bumped for length + translate=no support')
+assert(__translationWorkerTest.TRANSLATION_CACHE_VERSION.includes('unquoted-cjk'), 'Cache version was not bumped for unquoted attrs + CJK length support')
 assert(
   __translationWorkerTest.applyFrenchArticleElision('Évitez la attente. Livrez la correction.') === 'Évitez l\u2019attente. Livrez la correction.',
   'French elision did not fix "la attente"',
@@ -225,12 +226,32 @@ assert(
   'Parser collected translatable attributes from translate=no element',
 )
 
+const unquotedSkipHtml = `<!doctype html><html><body><section translate=no class=notranslate><p>Keep KPI English</p></section><p>Translate this chrome.</p></body></html>`
+const unquotedSkipParsed = __translationWorkerTest.collectSegments(unquotedSkipHtml)
+const unquotedSkipBody = unquotedSkipParsed.segments.filter((segment) => segment.inBody).map((segment) => segment.text)
+assert(
+  unquotedSkipBody.some((text) => text.includes('Translate this chrome')),
+  'Parser did not resume after unquoted translate=no',
+)
+assert(
+  unquotedSkipBody.every((text) => !text.includes('Keep KPI English')),
+  'Parser collected text from unquoted translate=no / notranslate regions',
+)
+
 assert(
   __translationWorkerTest.translationLengthViolation(
     'Deploy updates safely to every device',
     'Deploy updates safely to every device with detailed guidance for all supported environments and release channels',
   ),
   'Length guard did not flag an overlong translation',
+)
+assert(
+  !__translationWorkerTest.translationLengthViolation('Deploy updates safely to every device', '全デバイスへ安全に配信', 'ja'),
+  'Length guard flagged a valid shorter Japanese translation',
+)
+assert(
+  !__translationWorkerTest.translationLengthViolation('Deploy updates safely to every device', '모든 기기에 안전하게 배포', 'ko'),
+  'Length guard flagged a valid shorter Korean translation',
 )
 assert(
   __translationWorkerTest.guardTranslatedBatchLengths(

--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -166,6 +166,7 @@ const emptySuffixContext = __translationWorkerTest.resolveTranslationContexts(['
 assert(typeof emptySuffixContext === 'string' && emptySuffixContext.includes('native_build_builder_build_hour'), 'Empty placeholder suffix did not resolve build-hour context')
 assert(__translationWorkerTest.TRANSLATION_CACHE_VERSION.includes('message-context'), 'Cache version was not bumped for message context support')
 assert(__translationWorkerTest.TRANSLATION_CACHE_VERSION.includes('fr-elision'), 'Cache version was not bumped for French elision polish')
+assert(__translationWorkerTest.TRANSLATION_CACHE_VERSION.includes('length-translate-no'), 'Cache version was not bumped for length + translate=no support')
 assert(
   __translationWorkerTest.applyFrenchArticleElision('Évitez la attente. Livrez la correction.') === 'Évitez l\u2019attente. Livrez la correction.',
   'French elision did not fix "la attente"',
@@ -182,6 +183,66 @@ assert(__translationWorkerTest.polishTranslatedText('French', 'Évitez la attent
 assert(__translationWorkerTest.polishTranslatedText('Spanish', 'Évitez la attente.') === 'Évitez la attente.', 'Non-French polish path should leave text unchanged')
 const heroHeadlineContext = __translationWorkerTest.resolveTranslationContexts(['Skip the wait. Ship the fix.'])[0]
 assert(typeof heroHeadlineContext === 'string' && heroHeadlineContext.toLowerCase().includes('hotfix'), 'Missing marketing context override for live update hero headline')
+
+const noTranslateHtml = `<!doctype html>
+<html lang="en">
+  <body>
+    <h1>Live Update delivery data</h1>
+    <p>Translate this chrome copy.</p>
+    <tbody translate="no"><tr><td>United States</td><td title="A long failure explanation that must stay intact">Download failure (46%)</td></tr></tbody>
+    <div class="notranslate"><p>Keep metrics English</p></div>
+    <p>Translate the trailing chrome too.</p>
+  </body>
+</html>`
+const noTranslateParsed = __translationWorkerTest.collectSegments(noTranslateHtml)
+const noTranslateBody = noTranslateParsed.segments.filter((segment) => segment.inBody).map((segment) => segment.text)
+assert(
+  noTranslateBody.some((text) => text.includes('Translate this chrome copy')),
+  'Parser skipped normal body copy near translate=no',
+)
+assert(
+  noTranslateBody.some((text) => text.includes('Translate the trailing chrome too')),
+  'Parser did not resume after translate=no',
+)
+assert(
+  noTranslateBody.every((text) => !text.includes('United States') && !text.includes('Download failure') && !text.includes('Keep metrics English')),
+  'Parser collected text from translate=no / notranslate regions',
+)
+assert(
+  noTranslateParsed.parts.some((part) => typeof part === 'string' && part.includes('United States') && part.includes('Download failure (46%)')),
+  'Parser did not preserve translate=no markup as raw HTML',
+)
+assert(
+  noTranslateParsed.parts.some(
+    (part) => typeof part === 'string' && part.includes('class="notranslate"') && part.includes('Keep metrics English'),
+  ),
+  'Parser did not preserve notranslate opening tag as raw HTML',
+)
+assert(
+  noTranslateParsed.parts.some((part) => typeof part === 'string' && part.includes('</div>') && part.includes('Keep metrics English')),
+  'Parser did not preserve notranslate closing tag as raw HTML',
+)
+
+const skipAttrHtml = `<!doctype html><html><body><section translate="no" title="Metric region label"><p>99%</p></section></body></html>`
+const skipAttrParsed = __translationWorkerTest.collectSegments(skipAttrHtml)
+assert(
+  !skipAttrParsed.segments.some((segment) => segment.mode === 'attribute' && segment.text.includes('Metric region label')),
+  'Parser collected translatable attributes from translate=no element',
+)
+
+assert(
+  __translationWorkerTest.translationLengthViolation('Deploy updates safely to every device', 'Deploy updates safely to every device with detailed guidance for all supported environments and release channels'),
+  'Length guard did not flag an overlong translation',
+)
+assert(
+  __translationWorkerTest.guardTranslationLength('Deploy updates safely to every device', 'Deploy updates safely to every device with detailed guidance for all supported environments and release channels') === 'Deploy updates safely to every device',
+  'Length guard did not fall back to source for overlong translation',
+)
+assert(
+  !__translationWorkerTest.translationLengthViolation('Deploy updates safely to every device', 'Déployez les mises à jour en toute sécurité'),
+  'Length guard flagged a reasonably sized translation',
+)
+
 
 const localizedMeta = __translationWorkerTest.expandShortMetaDescriptions(
   '<head><meta name="description" content="短い説明"><meta property="og:description" content="短い説明"></head>',

--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -212,15 +212,10 @@ assert(
   noTranslateParsed.parts.some((part) => typeof part === 'string' && part.includes('United States') && part.includes('Download failure (46%)')),
   'Parser did not preserve translate=no markup as raw HTML',
 )
+const noTranslateRaw = noTranslateParsed.parts.filter((part): part is string => typeof part === 'string').join('')
 assert(
-  noTranslateParsed.parts.some(
-    (part) => typeof part === 'string' && part.includes('class="notranslate"') && part.includes('Keep metrics English'),
-  ),
-  'Parser did not preserve notranslate opening tag as raw HTML',
-)
-assert(
-  noTranslateParsed.parts.some((part) => typeof part === 'string' && part.includes('</div>') && part.includes('Keep metrics English')),
-  'Parser did not preserve notranslate closing tag as raw HTML',
+  noTranslateRaw.includes('class="notranslate"') && noTranslateRaw.includes('<p>Keep metrics English</p>') && noTranslateRaw.includes('</div>'),
+  'Parser did not preserve notranslate fragment as raw HTML',
 )
 
 const skipAttrHtml = `<!doctype html><html><body><section translate="no" title="Metric region label"><p>99%</p></section></body></html>`
@@ -231,18 +226,23 @@ assert(
 )
 
 assert(
-  __translationWorkerTest.translationLengthViolation('Deploy updates safely to every device', 'Deploy updates safely to every device with detailed guidance for all supported environments and release channels'),
+  __translationWorkerTest.translationLengthViolation(
+    'Deploy updates safely to every device',
+    'Deploy updates safely to every device with detailed guidance for all supported environments and release channels',
+  ),
   'Length guard did not flag an overlong translation',
 )
 assert(
-  __translationWorkerTest.guardTranslationLength('Deploy updates safely to every device', 'Deploy updates safely to every device with detailed guidance for all supported environments and release channels') === 'Deploy updates safely to every device',
-  'Length guard did not fall back to source for overlong translation',
+  __translationWorkerTest.guardTranslatedBatchLengths(
+    ['Deploy updates safely to every device'],
+    ['Deploy updates safely to every device with detailed guidance for all supported environments and release channels'],
+  )[0] === 'Deploy updates safely to every device',
+  'Batch length guard did not fall back to source for overlong translation',
 )
 assert(
   !__translationWorkerTest.translationLengthViolation('Deploy updates safely to every device', 'Déployez les mises à jour en toute sécurité'),
   'Length guard flagged a reasonably sized translation',
 )
-
 
 const localizedMeta = __translationWorkerTest.expandShortMetaDescriptions(
   '<head><meta name="description" content="短い説明"><meta property="og:description" content="短い説明"></head>',
@@ -416,15 +416,17 @@ try {
           assert(typeof aboutItem.context === 'string' && aboutItem.context.includes('navigation'), 'About item missed translator context')
         }
 
+        const translateText = (text: string) => {
+          if (text.includes('Read our guides')) return 'Leggi le guide'
+          if (text.includes('Docs title')) return 'Titolo doc'
+          if (text === 'About') return 'Chi siamo'
+          return 'IT ' + text
+        }
+
         const sourceTexts = payload.items.map((item) => item.text)
         return {
           response: JSON.stringify({
-            translations: sourceTexts.map((text) => {
-              if (text.includes('Read our guides')) return 'Leggi le nostre guide'
-              if (text.includes('Docs title')) return 'Titolo documentazione'
-              if (text === 'About') return 'Chi siamo'
-              return 'IT ' + text
-            }),
+            translations: sourceTexts.map((text) => translateText(text)),
           }),
         }
       },
@@ -489,7 +491,7 @@ try {
 
   assert(translatedResponse.status === 200, 'A completed cache-miss translation was not served successfully')
   assert(translatedResponse.headers.get('X-Capgo-Translation-Cache') === 'HIT', 'A completed cache-miss translation was not cached')
-  assert(translatedHtml.includes('Leggi le nostre guide'), 'A completed cache-miss translation did not contain the translated document')
+  assert(translatedHtml.includes('Leggi le guide'), 'A completed cache-miss translation did not contain the translated document')
   assert(translatedHtml.includes('Chi siamo'), 'A completed cache-miss translation did not keep context-backed About copy')
 
   const staleBlogUrl = new URL('https://capgo.app/de/blog/capacitor-app-initialization-step-by-step-guide/')

--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -250,8 +250,23 @@ assert(
   'Length guard flagged a valid shorter Japanese translation',
 )
 assert(
+  !__translationWorkerTest.translationLengthViolation('Deploy updates safely to every device', '全デバイスへ安全に配信', 'Japanese'),
+  'Length guard flagged a valid shorter Japanese translation for production language name',
+)
+assert(
   !__translationWorkerTest.translationLengthViolation('Deploy updates safely to every device', '모든 기기에 안전하게 배포', 'ko'),
   'Length guard flagged a valid shorter Korean translation',
+)
+assert(
+  !__translationWorkerTest.translationLengthViolation('Deploy updates safely to every device', '모든 기기에 안전하게 배포', 'Korean'),
+  'Length guard flagged a valid shorter Korean translation for production language name',
+)
+
+const quotedAttrFalsePositiveHtml = `<!doctype html><html><body><div data-note="translate=no"><p>Translate this paragraph.</p></div></body></html>`
+const quotedAttrFalsePositiveParsed = __translationWorkerTest.collectSegments(quotedAttrFalsePositiveHtml)
+assert(
+  quotedAttrFalsePositiveParsed.segments.some((segment) => segment.inBody && segment.text.includes('Translate this paragraph')),
+  'Parser skipped translatable text after translate=no substring inside quoted attribute value',
 )
 assert(
   __translationWorkerTest.guardTranslatedBatchLengths(

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -793,7 +793,10 @@ function collectQuotedAttributes(tag: string): AttributeMatch[] {
 
     const valueStart = quoteIndex
     let valueEnd = valueStart
-    while (valueEnd < tag.length && !isWhitespace(tag[valueEnd]) && tag[valueEnd] !== '>' && tag[valueEnd] !== '/') {
+    while (valueEnd < tag.length) {
+      const char = tag[valueEnd]
+      if (isWhitespace(char) || char === '>') break
+      if (char === '/' && tag[valueEnd + 1] === '>') break
       valueEnd += 1
     }
     if (valueEnd === valueStart) {
@@ -891,9 +894,11 @@ function appendTag(parts: HtmlPart[], segments: Segment[], tag: string, skipText
   for (const attribute of collectQuotedAttributes(tag)) {
     if (!shouldTranslateAttribute(tag, tagName, attribute.name, attribute.value)) continue
 
+    const outputQuote = attribute.quote || '"'
     parts.push(tag.slice(lastIndex, attribute.start), tag.slice(attribute.start, attribute.valueStart))
-    addSegment(parts, segments, attribute.value, 'attribute', inBody, attribute.quote)
-    parts.push(attribute.quote)
+    if (!attribute.quote) parts.push(outputQuote)
+    addSegment(parts, segments, attribute.value, 'attribute', inBody, outputQuote)
+    parts.push(outputQuote)
     lastIndex = attribute.end
     matched = true
   }

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -167,7 +167,6 @@ const TRANSLATION_COORDINATOR_PENDING_MS = 15 * 60 * 1000
 const TRANSLATION_CACHE_VERSION = '2026-08-13-message-context-fr-elision-length-translate-no-unquoted-cjk-v1'
 const TRANSLATION_LENGTH_MAX_RATIO = 1.3
 const TRANSLATION_LENGTH_MIN_RATIO = 0.7
-const COMPACT_TRANSLATION_LOCALES = new Set<Locale>(['ja', 'ko', 'zh'])
 const TRANSLATION_SOURCE_HASH_HEADER = 'X-Capgo-Translation-Source-Hash'
 const TRANSLATION_SCRIPTS_HEADER = 'X-Capgo-Translation-Scripts'
 const CLIENT_NO_STORE = 'no-store, max-age=0, must-revalidate'
@@ -194,6 +193,8 @@ const LANGUAGE_NAMES: Record<Locale, string> = {
   ko: 'Korean',
   zh: 'Simplified Chinese',
 }
+
+const COMPACT_TRANSLATION_TARGETS = new Set<string>(['ja', 'ko', 'zh', LANGUAGE_NAMES.ja, LANGUAGE_NAMES.ko, LANGUAGE_NAMES.zh])
 
 const LANGUAGE_FLAG_ENTITIES: Record<string, string> = {
   de: '&#127465;&#127466;',
@@ -765,41 +766,60 @@ function collectQuotedAttributes(tag: string): AttributeMatch[] {
     while (quoteIndex < tag.length && isWhitespace(tag[quoteIndex])) quoteIndex += 1
 
     const quote = tag[quoteIndex]
-    if (nameStart === nameEnd || (quote !== '"' && quote !== "'")) {
+    if (nameStart === nameEnd) {
       index = equalsIndex + 1
       continue
     }
 
-    const valueStart = quoteIndex + 1
-    const valueEnd = tag.indexOf(quote, valueStart)
-    if (valueEnd === -1) break
+    const attributeName = tag.slice(nameStart, nameEnd)
+
+    if (quote === '"' || quote === "'") {
+      const valueStart = quoteIndex + 1
+      const valueEnd = tag.indexOf(quote, valueStart)
+      if (valueEnd === -1) break
+
+      attributes.push({
+        name: attributeName,
+        quote,
+        value: tag.slice(valueStart, valueEnd),
+        start: nameStart,
+        valueStart,
+        valueEnd,
+        end: valueEnd + 1,
+      })
+      index = valueEnd + 1
+      continue
+    }
+
+    const valueStart = quoteIndex
+    let valueEnd = valueStart
+    while (valueEnd < tag.length && !isWhitespace(tag[valueEnd]) && tag[valueEnd] !== '>' && tag[valueEnd] !== '/') {
+      valueEnd += 1
+    }
+    if (valueEnd === valueStart) {
+      index = equalsIndex + 1
+      continue
+    }
 
     attributes.push({
-      name: tag.slice(nameStart, nameEnd),
-      quote,
+      name: attributeName,
+      quote: '',
       value: tag.slice(valueStart, valueEnd),
       start: nameStart,
       valueStart,
       valueEnd,
-      end: valueEnd + 1,
+      end: valueEnd,
     })
-    index = valueEnd + 1
+    index = valueEnd
   }
 
   return attributes
 }
 
-function readUnquotedAttributeValue(tag: string, attrName: string): string | null {
-  const normalizedAttr = attrName.toLowerCase()
-  const pattern = new RegExp(`\\b${normalizedAttr.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*=\\s*([^\\s>/"']+)`, 'i')
-  const match = pattern.exec(tag)
-  return match?.[1] ?? null
-}
-
 function readAttributeValue(tag: string, attrName: string): string | null {
   const normalizedAttr = attrName.toLowerCase()
   const attribute = collectQuotedAttributes(tag).find((item) => item.name.toLowerCase() === normalizedAttr)
-  return attribute?.value ?? readUnquotedAttributeValue(tag, normalizedAttr)
+  return attribute?.value ?? null
 }
 
 function isSupportedLanguagePath(value: string): boolean {
@@ -1559,7 +1579,7 @@ function translationLengthViolation(source: string, translated: string, targetLa
   const translatedLen = translated.length
   if (sourceLen < 12) return translatedLen > sourceLen + 8
   if (translatedLen > sourceLen * TRANSLATION_LENGTH_MAX_RATIO) return true
-  if (COMPACT_TRANSLATION_LOCALES.has(targetLanguage as Locale)) return false
+  if (COMPACT_TRANSLATION_TARGETS.has(targetLanguage)) return false
   return translatedLen < sourceLen * TRANSLATION_LENGTH_MIN_RATIO
 }
 

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -1806,6 +1806,7 @@ async function translateBatchWithJsonMode(env: Env, targetLanguage: string, batc
           }
           return polishTranslatedText(targetLanguage, result.text)
         })
+        assertTranslatedBatch(targetLanguage, batch, restored)
         const guarded = guardTranslatedBatchLengths(batch, restored, targetLanguage).map((text, index) => {
           if (text === batch[index] && translationLengthViolation(batch[index], restored[index], targetLanguage)) {
             console.warn('Translation kept source after length bound violation', {
@@ -1819,7 +1820,6 @@ async function translateBatchWithJsonMode(env: Env, targetLanguage: string, batc
           }
           return text
         })
-        assertTranslatedBatch(targetLanguage, batch, guarded)
         return guarded
       }
     } catch (error) {
@@ -1945,7 +1945,6 @@ async function translateBatchIndividually(env: Env, targetLanguage: string, batc
   for (const text of batch) {
     translated.push(await translateSingleText(env, targetLanguage, text, pagePath))
   }
-  assertTranslatedBatch(targetLanguage, batch, translated)
   return translated
 }
 

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -164,7 +164,9 @@ const TRANSLATION_SOURCE_CHECK_SECONDS = 5 * 60
 const TRANSLATION_PENDING_SECONDS = 10 * 60
 const TRANSLATION_RETRY_SECONDS = 5
 const TRANSLATION_COORDINATOR_PENDING_MS = 15 * 60 * 1000
-const TRANSLATION_CACHE_VERSION = '2026-08-12-message-context-fr-elision-v1'
+const TRANSLATION_CACHE_VERSION = '2026-08-12-message-context-fr-elision-length-translate-no-v1'
+const TRANSLATION_LENGTH_MAX_RATIO = 1.3
+const TRANSLATION_LENGTH_MIN_RATIO = 0.7
 const TRANSLATION_SOURCE_HASH_HEADER = 'X-Capgo-Translation-Source-Hash'
 const TRANSLATION_SCRIPTS_HEADER = 'X-Capgo-Translation-Scripts'
 const CLIENT_NO_STORE = 'no-store, max-age=0, must-revalidate'
@@ -179,7 +181,7 @@ const TRANSLATION_SINGLE_TEXT_ATTEMPTS = 2
 const TRANSLATION_QUEUE_RETRY_DELAY_SECONDS = 60
 const AI_OUTPUT_PREVIEW_CHARS = 240
 const TRANSLATION_TEST_ROUTE_PREFIX = '/__translation-test__'
-const PROTECTED_TRANSLATION_TOKENS = ['Cloudflare', 'Capacitor', 'GitHub', 'Capgo', 'code', 'API', 'SDK', 'CLI', 'npm', 'bun'] as const
+const PROTECTED_TRANSLATION_TOKENS = ['Live Update', 'Cloudflare', 'Capacitor', 'GitHub', 'Capgo', 'code', 'API', 'SDK', 'CLI', 'npm', 'bun'] as const
 
 const LANGUAGE_NAMES: Record<Locale, string> = {
   de: 'German',
@@ -807,8 +809,20 @@ function languageSelectorTargetLocale(tag: string): string | null {
   return isSupportedLanguagePath(idLocale) ? idLocale : null
 }
 
+function hasNoTranslateClass(className: string | null): boolean {
+  if (!className) return false
+  return className
+    .split(/\s+/)
+    .filter(Boolean)
+    .some((item) => item.toLowerCase() === 'notranslate')
+}
+
 function shouldSkipElementText(tag: string, tagName: string): boolean {
   if (SKIP_TEXT_TAGS.has(tagName)) return true
+
+  const translate = readAttributeValue(tag, 'translate')
+  if (translate?.trim().toLowerCase() === 'no') return true
+  if (hasNoTranslateClass(readAttributeValue(tag, 'class'))) return true
 
   const id = readAttributeValue(tag, 'id')
   if (id && (LANGUAGE_SELECTOR_SKIP_IDS.has(id) || id.startsWith('language_'))) return true
@@ -1278,14 +1292,19 @@ function collectSegments(html: string): { parts: HtmlPart[]; segments: Segment[]
     }
 
     const tagName = tagNameOf(tag)
+    const skipElement = Boolean(tagName && !isClosingTag(tag) && shouldSkipElementText(tag, tagName))
 
-    appendTag(parts, segments, tag, false, insideBody)
+    if (skipElement) {
+      parts.push(tag)
+    } else {
+      appendTag(parts, segments, tag, false, insideBody)
+    }
 
     if (tagName === 'body' && isClosingTag(tag)) {
       insideBody = false
     }
 
-    if (tagName && !isClosingTag(tag) && !isSelfClosingTag(tag, tagName) && shouldSkipElementText(tag, tagName)) {
+    if (tagName && !isClosingTag(tag) && !isSelfClosingTag(tag, tagName) && skipElement) {
       skipStack.push(tagName)
     }
 
@@ -1522,6 +1541,29 @@ function shouldCheckUnchangedTranslation(value: string): boolean {
   return true
 }
 
+function translationLengthViolation(source: string, translated: string): boolean {
+  const sourceLen = source.length
+  if (sourceLen === 0) return false
+  const translatedLen = translated.length
+  return translatedLen > sourceLen * TRANSLATION_LENGTH_MAX_RATIO || translatedLen < sourceLen * TRANSLATION_LENGTH_MIN_RATIO
+}
+
+function guardTranslationLength(source: string, translated: string): string {
+  return translationLengthViolation(source, translated) ? source : translated
+}
+
+function assertTranslationLengths(targetLanguage: string, batch: string[], translated: string[]): void {
+  for (let index = 0; index < batch.length; index += 1) {
+    const source = batch[index]
+    const target = translated[index] ?? ''
+    if (translationLengthViolation(source, target)) {
+      throw new Error(
+        `Translation length out of bounds for ${targetLanguage} at index ${index}: ${target.length} chars vs source ${source.length}`,
+      )
+    }
+  }
+}
+
 function assertTranslatedBatch(targetLanguage: string, batch: string[], translated: string[]): void {
   const candidates = batch
     .map((source, index) => ({
@@ -1650,6 +1692,10 @@ function translationGrammarSystemHint(): string {
   return 'Prefer natural native phrasing over literal calques. Apply correct target-language grammar and morphology. For French, always elide singular articles before a vowel (l’attente, not la attente). Do not elide before aspirate h (la haute, le héros).'
 }
 
+function translationLengthSystemHint(): string {
+  return 'Keep each translation about the same length as the source (similar character count, roughly within ±30%). Do not expand short UI labels, buttons, nav items, table headers, or headings into longer sentences. Over-long translations break Capgo page layouts and UI spacing.'
+}
+
 /** Fix unelided French le/la before a vowel (e.g. "la attente" → "l’attente").
  * Vowels only — aspirate-h words (haute, héros, haricot…) must keep le/la. */
 function applyFrenchArticleElision(text: string): string {
@@ -1691,8 +1737,9 @@ async function translateBatchWithJsonMode(env: Env, targetLanguage: string, batc
               'Translate every human-readable label, heading, sentence, and paragraph into the target language, including short navigation labels.',
               translationContextSystemHint(),
               translationGrammarSystemHint(),
+              translationLengthSystemHint(),
               'Preserve brand names, product names, developer terms, URLs, code identifiers, file paths, package names, language codes, numbers, punctuation, and whitespace meaning.',
-              'Do not translate or transliterate literal tokens such as Capgo, Capacitor, code, API, SDK, CLI, npm, bun, GitHub, Cloudflare, package names, command names, and framework names.',
+              'Do not translate or transliterate literal tokens such as Capgo, Capacitor, Live Update, code, API, SDK, CLI, npm, bun, GitHub, Cloudflare, package names, command names, and framework names.',
               'Source text may include placeholders like __CAPGO_KEEP_0__. Copy every placeholder exactly as written; placeholders are restored after translation.',
               `Return a JSON object with exactly one key named "translations". Its value must be an array of exactly ${batch.length} strings in the same order as the input. Do not return Markdown, comments, or explanations.`,
               attempt > 1 ? 'Your previous response was rejected. Fix the format and return only the JSON object matching the schema.' : '',
@@ -1732,6 +1779,7 @@ async function translateBatchWithJsonMode(env: Env, targetLanguage: string, batc
           }
           return polishTranslatedText(targetLanguage, result.text)
         })
+        assertTranslationLengths(targetLanguage, batch, restored)
         assertTranslatedBatch(targetLanguage, batch, restored)
         return restored
       }
@@ -1787,8 +1835,9 @@ async function translateSingleText(env: Env, targetLanguage: string, text: strin
               'Translate naturally for the user cultural context; adapt idioms, grammar, tone, and phrasing instead of translating word for word.',
               translationContextSystemHint(),
               translationGrammarSystemHint(),
+              translationLengthSystemHint(),
               'Preserve brand names, product names, developer terms, URLs, code identifiers, file paths, package names, language codes, numbers, punctuation, and whitespace meaning.',
-              'Do not translate or transliterate literal tokens such as Capgo, Capacitor, code, API, SDK, CLI, npm, bun, GitHub, Cloudflare, package names, command names, and framework names.',
+              'Do not translate or transliterate literal tokens such as Capgo, Capacitor, Live Update, code, API, SDK, CLI, npm, bun, GitHub, Cloudflare, package names, command names, and framework names.',
               'Source text may include placeholders like __CAPGO_KEEP_0__. Copy every placeholder exactly as written; placeholders are restored after translation.',
               'Return only the translated text. Do not return JSON, Markdown, labels, explanations, quotes around the whole answer, or extra lines.',
             ].join(' '),
@@ -1808,8 +1857,16 @@ async function translateSingleText(env: Env, targetLanguage: string, text: strin
 
       payload = extractAiPayload(result)
       const translated = plainTranslationFromUnknown(payload)
-      if (translated) return polishTranslatedText(targetLanguage, protectedText.restore(translated))
-      lastError = new Error(`Translation model returned empty text for ${targetLanguage}`)
+      if (translated) {
+        const restored = polishTranslatedText(targetLanguage, protectedText.restore(translated))
+        if (translationLengthViolation(text, restored)) {
+          lastError = new Error(`Translation length out of bounds for ${targetLanguage}: ${restored.length} chars vs source ${text.length}`)
+        } else {
+          return restored
+        }
+      } else {
+        lastError = new Error(`Translation model returned empty text for ${targetLanguage}`)
+      }
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(errorMessage(error))
     }
@@ -1825,6 +1882,15 @@ async function translateSingleText(env: Env, targetLanguage: string, text: strin
 
   if (lastError?.message.startsWith('Translation dropped protected token: ')) {
     console.warn('Single-text translation kept source after protected token drop', {
+      targetLanguage,
+      error: lastError.message,
+      sourcePreview: aiPayloadPreview(text),
+    })
+    return text
+  }
+
+  if (lastError?.message.includes('length out of bounds')) {
+    console.warn('Single-text translation kept source after length bound violation', {
       targetLanguage,
       error: lastError.message,
       sourcePreview: aiPayloadPreview(text),
@@ -3105,11 +3171,13 @@ export const __translationWorkerTest = {
   cacheKeyFor,
   sourceCheckKeyFor,
   collectSegments,
+  guardTranslationLength,
   renderTranslatedHtml,
   expandShortMetaDescriptions,
   rewriteMetadataAndLinks,
   resolveTranslationContexts,
   syncExecutableScriptsFromEnglish,
+  translationLengthViolation,
 }
 
 export default {

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -1541,10 +1541,15 @@ function shouldCheckUnchangedTranslation(value: string): boolean {
   return true
 }
 
+function shouldEnforceTranslationLength(source: string): boolean {
+  return source.trim().length > 0
+}
+
 function translationLengthViolation(source: string, translated: string): boolean {
+  if (!shouldEnforceTranslationLength(source)) return false
   const sourceLen = source.length
-  if (sourceLen === 0) return false
   const translatedLen = translated.length
+  if (sourceLen < 12) return translatedLen > sourceLen + 8
   return translatedLen > sourceLen * TRANSLATION_LENGTH_MAX_RATIO || translatedLen < sourceLen * TRANSLATION_LENGTH_MIN_RATIO
 }
 
@@ -1552,16 +1557,8 @@ function guardTranslationLength(source: string, translated: string): string {
   return translationLengthViolation(source, translated) ? source : translated
 }
 
-function assertTranslationLengths(targetLanguage: string, batch: string[], translated: string[]): void {
-  for (let index = 0; index < batch.length; index += 1) {
-    const source = batch[index]
-    const target = translated[index] ?? ''
-    if (translationLengthViolation(source, target)) {
-      throw new Error(
-        `Translation length out of bounds for ${targetLanguage} at index ${index}: ${target.length} chars vs source ${source.length}`,
-      )
-    }
-  }
+function guardTranslatedBatchLengths(batch: string[], translated: string[]): string[] {
+  return batch.map((source, index) => guardTranslationLength(source, translated[index] ?? source))
 }
 
 function assertTranslatedBatch(targetLanguage: string, batch: string[], translated: string[]): void {
@@ -1779,9 +1776,21 @@ async function translateBatchWithJsonMode(env: Env, targetLanguage: string, batc
           }
           return polishTranslatedText(targetLanguage, result.text)
         })
-        assertTranslationLengths(targetLanguage, batch, restored)
-        assertTranslatedBatch(targetLanguage, batch, restored)
-        return restored
+        const guarded = guardTranslatedBatchLengths(batch, restored).map((text, index) => {
+          if (text === batch[index] && translationLengthViolation(batch[index], restored[index])) {
+            console.warn('Translation kept source after length bound violation', {
+              targetLanguage,
+              index,
+              sourceLength: batch[index].length,
+              translatedLength: restored[index].length,
+              sourcePreview: aiPayloadPreview(batch[index]),
+              outputPreview: aiPayloadPreview(restored[index]),
+            })
+          }
+          return text
+        })
+        assertTranslatedBatch(targetLanguage, batch, guarded)
+        return guarded
       }
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(errorMessage(error))
@@ -3172,6 +3181,7 @@ export const __translationWorkerTest = {
   sourceCheckKeyFor,
   collectSegments,
   guardTranslationLength,
+  guardTranslatedBatchLengths,
   renderTranslatedHtml,
   expandShortMetaDescriptions,
   rewriteMetadataAndLinks,

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -164,9 +164,10 @@ const TRANSLATION_SOURCE_CHECK_SECONDS = 5 * 60
 const TRANSLATION_PENDING_SECONDS = 10 * 60
 const TRANSLATION_RETRY_SECONDS = 5
 const TRANSLATION_COORDINATOR_PENDING_MS = 15 * 60 * 1000
-const TRANSLATION_CACHE_VERSION = '2026-08-12-message-context-fr-elision-length-translate-no-v1'
+const TRANSLATION_CACHE_VERSION = '2026-08-13-message-context-fr-elision-length-translate-no-unquoted-cjk-v1'
 const TRANSLATION_LENGTH_MAX_RATIO = 1.3
 const TRANSLATION_LENGTH_MIN_RATIO = 0.7
+const COMPACT_TRANSLATION_LOCALES = new Set<Locale>(['ja', 'ko', 'zh'])
 const TRANSLATION_SOURCE_HASH_HEADER = 'X-Capgo-Translation-Source-Hash'
 const TRANSLATION_SCRIPTS_HEADER = 'X-Capgo-Translation-Scripts'
 const CLIENT_NO_STORE = 'no-store, max-age=0, must-revalidate'
@@ -788,10 +789,17 @@ function collectQuotedAttributes(tag: string): AttributeMatch[] {
   return attributes
 }
 
+function readUnquotedAttributeValue(tag: string, attrName: string): string | null {
+  const normalizedAttr = attrName.toLowerCase()
+  const pattern = new RegExp(`\\b${normalizedAttr.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*=\\s*([^\\s>/"']+)`, 'i')
+  const match = pattern.exec(tag)
+  return match?.[1] ?? null
+}
+
 function readAttributeValue(tag: string, attrName: string): string | null {
   const normalizedAttr = attrName.toLowerCase()
   const attribute = collectQuotedAttributes(tag).find((item) => item.name.toLowerCase() === normalizedAttr)
-  return attribute?.value ?? null
+  return attribute?.value ?? readUnquotedAttributeValue(tag, normalizedAttr)
 }
 
 function isSupportedLanguagePath(value: string): boolean {
@@ -1545,20 +1553,22 @@ function shouldEnforceTranslationLength(source: string): boolean {
   return source.trim().length > 0
 }
 
-function translationLengthViolation(source: string, translated: string): boolean {
+function translationLengthViolation(source: string, translated: string, targetLanguage = ''): boolean {
   if (!shouldEnforceTranslationLength(source)) return false
   const sourceLen = source.length
   const translatedLen = translated.length
   if (sourceLen < 12) return translatedLen > sourceLen + 8
-  return translatedLen > sourceLen * TRANSLATION_LENGTH_MAX_RATIO || translatedLen < sourceLen * TRANSLATION_LENGTH_MIN_RATIO
+  if (translatedLen > sourceLen * TRANSLATION_LENGTH_MAX_RATIO) return true
+  if (COMPACT_TRANSLATION_LOCALES.has(targetLanguage as Locale)) return false
+  return translatedLen < sourceLen * TRANSLATION_LENGTH_MIN_RATIO
 }
 
-function guardTranslationLength(source: string, translated: string): string {
-  return translationLengthViolation(source, translated) ? source : translated
+function guardTranslationLength(source: string, translated: string, targetLanguage = ''): string {
+  return translationLengthViolation(source, translated, targetLanguage) ? source : translated
 }
 
-function guardTranslatedBatchLengths(batch: string[], translated: string[]): string[] {
-  return batch.map((source, index) => guardTranslationLength(source, translated[index] ?? source))
+function guardTranslatedBatchLengths(batch: string[], translated: string[], targetLanguage = ''): string[] {
+  return batch.map((source, index) => guardTranslationLength(source, translated[index] ?? source, targetLanguage))
 }
 
 function assertTranslatedBatch(targetLanguage: string, batch: string[], translated: string[]): void {
@@ -1776,8 +1786,8 @@ async function translateBatchWithJsonMode(env: Env, targetLanguage: string, batc
           }
           return polishTranslatedText(targetLanguage, result.text)
         })
-        const guarded = guardTranslatedBatchLengths(batch, restored).map((text, index) => {
-          if (text === batch[index] && translationLengthViolation(batch[index], restored[index])) {
+        const guarded = guardTranslatedBatchLengths(batch, restored, targetLanguage).map((text, index) => {
+          if (text === batch[index] && translationLengthViolation(batch[index], restored[index], targetLanguage)) {
             console.warn('Translation kept source after length bound violation', {
               targetLanguage,
               index,
@@ -1868,7 +1878,7 @@ async function translateSingleText(env: Env, targetLanguage: string, text: strin
       const translated = plainTranslationFromUnknown(payload)
       if (translated) {
         const restored = polishTranslatedText(targetLanguage, protectedText.restore(translated))
-        if (translationLengthViolation(text, restored)) {
+        if (translationLengthViolation(text, restored, targetLanguage)) {
           lastError = new Error(`Translation length out of bounds for ${targetLanguage}: ${restored.length} chars vs source ${text.length}`)
         } else {
           return restored

--- a/apps/web/src/lib/liveUpdateMetrics.ts
+++ b/apps/web/src/lib/liveUpdateMetrics.ts
@@ -154,17 +154,9 @@ export async function resolveLiveUpdateMetrics(baseApiUrl: string): Promise<Live
 /** JSON safe to embed inside <script> via set:html (blocks </script> breakouts). */
 export function jsonForInlineScript(value: unknown): string {
   return JSON.stringify(value)
-<<<<<<< HEAD
     .replaceAll('<', String.raw`\u003c`)
     .replaceAll('>', String.raw`\u003e`)
     .replaceAll('&', String.raw`\u0026`)
     .replaceAll('\u2028', String.raw`\u2028`)
     .replaceAll('\u2029', String.raw`\u2029`)
-=======
-    .replace(/</g, '\\u003c')
-    .replace(/>/g, '\\u003e')
-    .replace(/&/g, '\\u0026')
-    .replace(/\u2028/g, '\\u2028')
-    .replace(/\u2029/g, '\\u2029')
->>>>>>> 5b2a42855 (fix: escape /data metrics JSON for inline script embeds)
 }

--- a/apps/web/src/lib/liveUpdateMetrics.ts
+++ b/apps/web/src/lib/liveUpdateMetrics.ts
@@ -154,9 +154,17 @@ export async function resolveLiveUpdateMetrics(baseApiUrl: string): Promise<Live
 /** JSON safe to embed inside <script> via set:html (blocks </script> breakouts). */
 export function jsonForInlineScript(value: unknown): string {
   return JSON.stringify(value)
+<<<<<<< HEAD
     .replaceAll('<', String.raw`\u003c`)
     .replaceAll('>', String.raw`\u003e`)
     .replaceAll('&', String.raw`\u0026`)
     .replaceAll('\u2028', String.raw`\u2028`)
     .replaceAll('\u2029', String.raw`\u2029`)
+=======
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')
+>>>>>>> 5b2a42855 (fix: escape /data metrics JSON for inline script embeds)
 }

--- a/apps/web/src/lib/liveUpdateMetrics.ts
+++ b/apps/web/src/lib/liveUpdateMetrics.ts
@@ -150,3 +150,13 @@ export async function resolveLiveUpdateMetrics(baseApiUrl: string): Promise<Live
   const live = await fetchLiveUpdateMetrics(baseApiUrl)
   return live ?? getCachedLiveUpdateMetrics()
 }
+
+/** JSON safe to embed inside <script> via set:html (blocks </script> breakouts). */
+export function jsonForInlineScript(value: unknown): string {
+  return JSON.stringify(value)
+    .replaceAll('<', String.raw`\u003c`)
+    .replaceAll('>', String.raw`\u003e`)
+    .replaceAll('&', String.raw`\u0026`)
+    .replaceAll('\u2028', String.raw`\u2028`)
+    .replaceAll('\u2029', String.raw`\u2029`)
+}

--- a/apps/web/src/pages/data.astro
+++ b/apps/web/src/pages/data.astro
@@ -57,7 +57,11 @@ function formatPct(value: number | null) {
   <link slot="head" rel="preconnect" href={apiOrigin} crossorigin="anonymous" />
   <link slot="head" rel="dns-prefetch" href={apiOrigin} />
   {/* Keep bootstrap metrics out of attributes so the edge translator cannot mangle JSON / inflate SSR tables. */}
+<<<<<<< HEAD
   <script type="application/json" id="capgo-live-update-metrics-bootstrap" is:inline set:html={jsonForInlineScript(metrics)} />
+=======
+  <script is:inline type="application/json" id="capgo-live-update-metrics-bootstrap" set:html={jsonForInlineScript(metrics)} />
+>>>>>>> 5b2a42855 (fix: escape /data metrics JSON for inline script embeds)
   <main class="data-page" data-metrics-endpoint={`${config.public.baseApiUrl}/private/website_stats/live_updates`} aria-busy="false">
     <section class="data-hero">
       <div class="data-shell">

--- a/apps/web/src/pages/data.astro
+++ b/apps/web/src/pages/data.astro
@@ -57,11 +57,7 @@ function formatPct(value: number | null) {
   <link slot="head" rel="preconnect" href={apiOrigin} crossorigin="anonymous" />
   <link slot="head" rel="dns-prefetch" href={apiOrigin} />
   {/* Keep bootstrap metrics out of attributes so the edge translator cannot mangle JSON / inflate SSR tables. */}
-<<<<<<< HEAD
   <script type="application/json" id="capgo-live-update-metrics-bootstrap" is:inline set:html={jsonForInlineScript(metrics)} />
-=======
-  <script is:inline type="application/json" id="capgo-live-update-metrics-bootstrap" set:html={jsonForInlineScript(metrics)} />
->>>>>>> 5b2a42855 (fix: escape /data metrics JSON for inline script embeds)
   <main class="data-page" data-metrics-endpoint={`${config.public.baseApiUrl}/private/website_stats/live_updates`} aria-busy="false">
     <section class="data-hero">
       <div class="data-shell">
@@ -405,9 +401,7 @@ function formatPct(value: number | null) {
       dailyStart.textContent = metrics.daily[0]?.date ?? ''
       dailyEnd.textContent = metrics.daily.at(-1)?.date ?? ''
       if (dailyStatus) {
-        dailyStatus.textContent = metrics.daily.length
-          ? `Daily install success chart updated with ${metrics.daily.length} days of data`
-          : 'Daily install success chart unavailable'
+        dailyStatus.textContent = metrics.daily.length ? `Daily install success chart updated with ${metrics.daily.length} days of data` : 'Daily install success chart unavailable'
       }
     }
 
@@ -424,9 +418,7 @@ function formatPct(value: number | null) {
         }
       }
       if (failuresStatus) {
-        failuresStatus.textContent = metrics.failures.length
-          ? `Top failure reasons updated with ${metrics.failures.length} categories`
-          : 'No failures in this window'
+        failuresStatus.textContent = metrics.failures.length ? `Top failure reasons updated with ${metrics.failures.length} categories` : 'No failures in this window'
       }
       for (const [index, item] of metrics.failures.entries()) {
         const info = getFailureReasonInfo(item.reason)

--- a/apps/web/src/pages/data.astro
+++ b/apps/web/src/pages/data.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '@/layouts/Layout.astro'
 import { getFailureReasonInfo } from '@/lib/liveUpdateFailureReasons'
-import { resolveLiveUpdateMetrics } from '@/lib/liveUpdateMetrics'
+import { jsonForInlineScript, resolveLiveUpdateMetrics } from '@/lib/liveUpdateMetrics'
 import { createLdJsonGraph, createWebPageLdJson } from '@/lib/ldJson'
 
 const config = Astro.locals.runtimeConfig
@@ -56,7 +56,9 @@ function formatPct(value: number | null) {
 <Layout content={content}>
   <link slot="head" rel="preconnect" href={apiOrigin} crossorigin="anonymous" />
   <link slot="head" rel="dns-prefetch" href={apiOrigin} />
-  <main class="data-page" data-metrics-endpoint={`${config.public.baseApiUrl}/private/website_stats/live_updates`} data-initial-metrics={JSON.stringify(metrics)} aria-busy="false">
+  {/* Keep bootstrap metrics out of attributes so the edge translator cannot mangle JSON / inflate SSR tables. */}
+  <script type="application/json" id="capgo-live-update-metrics-bootstrap" is:inline set:html={jsonForInlineScript(metrics)} />
+  <main class="data-page" data-metrics-endpoint={`${config.public.baseApiUrl}/private/website_stats/live_updates`} aria-busy="false">
     <section class="data-hero">
       <div class="data-shell">
         <p class="data-eyebrow"><span aria-hidden="true"></span> Our data</p>
@@ -65,7 +67,7 @@ function formatPct(value: number | null) {
           Last 30 days of Capgo install success. Each rate uses app, device, and UTC-day outcomes — overall and by country, platform, and updater version. We publish failures too,
           with plain-language explanations from our docs.
         </p>
-        <p class="data-updated" data-updated aria-live="polite">{updatedLabel}</p>
+        <p class="data-updated" data-updated aria-live="polite" translate="no">{updatedLabel}</p>
       </div>
     </section>
 
@@ -80,15 +82,17 @@ function formatPct(value: number | null) {
         </div>
 
         <div class="data-kpis" aria-label="Reliability summary">
-          <div><p>Success rate</p><strong data-kpi="success-rate">{Math.ceil(metrics.success_rate)}%</strong></div>
+          <p class="data-sr-only" data-kpi-status aria-live="polite"></p>
+          <div><p>Success rate</p><strong data-kpi="success-rate" translate="no">{Math.ceil(metrics.success_rate)}%</strong></div>
           <div><p>Window</p><strong>30 days</strong></div>
           <div><p>Scope</p><strong>All apps</strong></div>
         </div>
 
+        <p class="data-sr-only" data-daily-status aria-live="polite"></p>
         <div class="data-chart-skeleton" data-daily-skeleton aria-hidden="true">
           <div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div>
         </div>
-        <div class="data-chart" data-daily-chart aria-label="Daily install success chart" hidden>
+        <div class="data-chart" data-daily-chart aria-label="Daily install success chart" hidden translate="no">
           <div class="data-chart-scale" aria-hidden="true"><span>100%</span><span>50%</span><span>0%</span></div>
           <div class="data-bars" data-daily-bars role="list" aria-label="Daily install success rates"></div>
           <div class="data-axis"><span data-daily-start></span><span data-daily-end></span></div>
@@ -106,6 +110,7 @@ function formatPct(value: number | null) {
           </div>
           <p>Share of active devices, success rate, and leading failure by country. Success uses app/device/UTC-day outcomes.</p>
         </div>
+        <p class="data-sr-only" data-countries-status aria-live="polite"></p>
         <div class="data-table-wrap">
           <table class="data-table" data-countries-table>
             <thead>
@@ -116,7 +121,7 @@ function formatPct(value: number | null) {
                 <th scope="col">Top failure</th>
               </tr>
             </thead>
-            <tbody data-countries>
+            <tbody data-countries translate="no">
               {
                 metrics.countries.map((item) => {
                   const failure = item.top_failure ? getFailureReasonInfo(item.top_failure.reason) : null
@@ -149,6 +154,7 @@ function formatPct(value: number | null) {
           </div>
           <p>Share of active devices, success rate, and leading failure by platform. Success uses app/device/UTC-day outcomes.</p>
         </div>
+        <p class="data-sr-only" data-platforms-status aria-live="polite"></p>
         <div class="data-table-wrap">
           <table class="data-table" data-platforms-table>
             <thead>
@@ -159,7 +165,7 @@ function formatPct(value: number | null) {
                 <th scope="col">Top failure</th>
               </tr>
             </thead>
-            <tbody data-platforms>
+            <tbody data-platforms translate="no">
               {
                 metrics.platforms.map((item) => {
                   const failure = item.top_failure ? getFailureReasonInfo(item.top_failure.reason) : null
@@ -188,7 +194,8 @@ function formatPct(value: number | null) {
         <div>
           <p class="data-eyebrow">Failures</p>
           <h2 id="failures-title">Top failure reasons</h2>
-          <p class="data-copy" data-failures-lead>{topFailureLead}</p>
+          <p class="data-sr-only" data-failures-status aria-live="polite"></p>
+          <p class="data-copy" data-failures-lead translate="no">{topFailureLead}</p>
           <p class="data-copy data-copy-secondary">
             Many failures are normal on real devices — flaky networks, intentional channel policies, and automatic rollbacks all show up here. We keep the list public so you can
             trust the numbers.
@@ -197,7 +204,7 @@ function formatPct(value: number | null) {
             Code meanings follow our <a class="data-inline-link" href="/docs/webapp/logs/">logs docs</a>.
           </p>
         </div>
-        <ol class="data-failures" data-failures aria-live="polite">
+        <ol class="data-failures" data-failures aria-live="polite" translate="no">
           {
             metrics.failures.length
               ? metrics.failures.map((item, index) => {
@@ -231,6 +238,7 @@ function formatPct(value: number | null) {
           </div>
           <p>Share of active devices, success rate, and leading failure by updater version. Success uses app/device/UTC-day outcomes.</p>
         </div>
+        <p class="data-sr-only" data-versions-status aria-live="polite"></p>
         <div class="data-table-wrap">
           <table class="data-table" data-versions-table>
             <thead>
@@ -241,7 +249,7 @@ function formatPct(value: number | null) {
                 <th scope="col">Top failure</th>
               </tr>
             </thead>
-            <tbody data-versions>
+            <tbody data-versions translate="no">
               {
                 metrics.updater_versions.map((item) => {
                   const failure = item.top_failure ? getFailureReasonInfo(item.top_failure.reason) : null
@@ -276,6 +284,8 @@ function formatPct(value: number | null) {
     const endpoint = page?.dataset.metricsEndpoint
     const updated = page?.querySelector<HTMLElement>('[data-updated]')
     const successRateKpi = page?.querySelector<HTMLElement>('[data-kpi="success-rate"]')
+    const kpiStatus = page?.querySelector<HTMLElement>('[data-kpi-status]')
+    const dailyStatus = page?.querySelector<HTMLElement>('[data-daily-status]')
     const dailyChart = page?.querySelector<HTMLElement>('[data-daily-chart]')
     const dailySkeleton = page?.querySelector<HTMLElement>('[data-daily-skeleton]')
     const dailyBars = page?.querySelector<HTMLElement>('[data-daily-bars]')
@@ -284,12 +294,16 @@ function formatPct(value: number | null) {
     const dailyEmpty = page?.querySelector<HTMLElement>('[data-daily-empty]')
     const failuresList = page?.querySelector<HTMLOListElement>('[data-failures]')
     const failuresLead = page?.querySelector<HTMLElement>('[data-failures-lead]')
+    const failuresStatus = page?.querySelector<HTMLElement>('[data-failures-status]')
     const countriesBody = page?.querySelector<HTMLElement>('[data-countries]')
     const countriesEmpty = page?.querySelector<HTMLElement>('[data-countries-empty]')
+    const countriesStatus = page?.querySelector<HTMLElement>('[data-countries-status]')
     const platformsBody = page?.querySelector<HTMLElement>('[data-platforms]')
     const platformsEmpty = page?.querySelector<HTMLElement>('[data-platforms-empty]')
+    const platformsStatus = page?.querySelector<HTMLElement>('[data-platforms-status]')
     const versionsBody = page?.querySelector<HTMLElement>('[data-versions]')
     const versionEmpty = page?.querySelector<HTMLElement>('[data-version-empty]')
+    const versionsStatus = page?.querySelector<HTMLElement>('[data-versions-status]')
     const styleScopeAttributes = page?.getAttributeNames().filter((attribute) => attribute.startsWith('data-astro-cid-')) ?? []
 
     const countryNames = typeof Intl !== 'undefined' && 'DisplayNames' in Intl ? new Intl.DisplayNames(['en'], { type: 'region' }) : null
@@ -323,9 +337,11 @@ function formatPct(value: number | null) {
     function renderBreakdownRows(
       body: HTMLElement | null | undefined,
       empty: HTMLElement | null | undefined,
+      status: HTMLElement | null | undefined,
       rows: LiveUpdateMetrics['countries'],
       kind: 'country' | 'platform' | 'version',
       emptyText: string,
+      statusLabel: string,
     ) {
       if (!body) return
       body.replaceChildren()
@@ -356,6 +372,9 @@ function formatPct(value: number | null) {
         empty.hidden = rows.length > 0
         empty.textContent = emptyText
       }
+      if (status) {
+        status.textContent = rows.length ? `${statusLabel} updated with ${rows.length} rows` : emptyText
+      }
     }
 
     function renderDaily(metrics: LiveUpdateMetrics) {
@@ -381,6 +400,11 @@ function formatPct(value: number | null) {
       dailyEmpty.textContent = 'Success-rate data is temporarily unavailable.'
       dailyStart.textContent = metrics.daily[0]?.date ?? ''
       dailyEnd.textContent = metrics.daily.at(-1)?.date ?? ''
+      if (dailyStatus) {
+        dailyStatus.textContent = metrics.daily.length
+          ? `Daily install success chart updated with ${metrics.daily.length} days of data`
+          : 'Daily install success chart unavailable'
+      }
     }
 
     function renderFailures(metrics: LiveUpdateMetrics) {
@@ -394,6 +418,11 @@ function formatPct(value: number | null) {
         } else {
           failuresLead.textContent = 'Normalized categories across all apps.'
         }
+      }
+      if (failuresStatus) {
+        failuresStatus.textContent = metrics.failures.length
+          ? `Top failure reasons updated with ${metrics.failures.length} categories`
+          : 'No failures in this window'
       }
       for (const [index, item] of metrics.failures.entries()) {
         const info = getFailureReasonInfo(item.reason)
@@ -422,11 +451,12 @@ function formatPct(value: number | null) {
 
     function renderMetrics(metrics: LiveUpdateMetrics) {
       if (successRateKpi) successRateKpi.textContent = formatPct(metrics.success_rate)
+      if (kpiStatus) kpiStatus.textContent = `Success rate updated to ${formatPct(metrics.success_rate)}`
       renderDaily(metrics)
       renderFailures(metrics)
-      renderBreakdownRows(countriesBody, countriesEmpty, metrics.countries, 'country', 'Country breakdown is temporarily unavailable.')
-      renderBreakdownRows(platformsBody, platformsEmpty, metrics.platforms, 'platform', 'Platform breakdown is temporarily unavailable.')
-      renderBreakdownRows(versionsBody, versionEmpty, metrics.updater_versions, 'version', 'Updater breakdown is temporarily unavailable.')
+      renderBreakdownRows(countriesBody, countriesEmpty, countriesStatus, metrics.countries, 'country', 'Country breakdown is temporarily unavailable.', 'Country breakdown')
+      renderBreakdownRows(platformsBody, platformsEmpty, platformsStatus, metrics.platforms, 'platform', 'Platform breakdown is temporarily unavailable.', 'Platform breakdown')
+      renderBreakdownRows(versionsBody, versionEmpty, versionsStatus, metrics.updater_versions, 'version', 'Updater breakdown is temporarily unavailable.', 'Updater versions')
       if (updated) {
         const timestamp = new Date(metrics.updated_at)
         updated.textContent = Number.isNaN(timestamp.getTime())
@@ -445,9 +475,12 @@ function formatPct(value: number | null) {
       }
       if (failuresList) failuresList.replaceChildren(Object.assign(createScopedElement('li'), { className: 'data-empty', textContent: 'Failure data is temporarily unavailable.' }))
       if (failuresLead) failuresLead.textContent = 'Failure data is temporarily unavailable.'
-      renderBreakdownRows(countriesBody, countriesEmpty, [], 'country', 'Country breakdown is temporarily unavailable.')
-      renderBreakdownRows(platformsBody, platformsEmpty, [], 'platform', 'Platform breakdown is temporarily unavailable.')
-      renderBreakdownRows(versionsBody, versionEmpty, [], 'version', 'Updater breakdown is temporarily unavailable.')
+      if (failuresStatus) failuresStatus.textContent = 'Failure data is temporarily unavailable.'
+      if (kpiStatus) kpiStatus.textContent = 'Success rate unavailable'
+      if (dailyStatus) dailyStatus.textContent = 'Daily install success chart unavailable'
+      renderBreakdownRows(countriesBody, countriesEmpty, countriesStatus, [], 'country', 'Country breakdown is temporarily unavailable.', 'Country breakdown')
+      renderBreakdownRows(platformsBody, platformsEmpty, platformsStatus, [], 'platform', 'Platform breakdown is temporarily unavailable.', 'Platform breakdown')
+      renderBreakdownRows(versionsBody, versionEmpty, versionsStatus, [], 'version', 'Updater breakdown is temporarily unavailable.', 'Updater versions')
     }
 
     const METRICS_CACHE_KEY = 'capgo-live-update-metrics-v3'
@@ -480,7 +513,7 @@ function formatPct(value: number | null) {
 
     function readBootstrapMetrics(): LiveUpdateMetrics | null {
       try {
-        const raw = page?.dataset.initialMetrics
+        const raw = document.getElementById('capgo-live-update-metrics-bootstrap')?.textContent?.trim()
         if (!raw) return null
         return normalizeLiveUpdateMetrics(JSON.parse(raw))
       } catch {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Instruct the edge translation worker to keep translations roughly the same length as the source (±30%) so UI layouts stay intact.
- Honor `translate="no"` and `class="notranslate"` when collecting HTML segments.
- Protect the `Live Update` product name and bump `TRANSLATION_CACHE_VERSION` so stale locale caches refresh.
- Fix `/data/`: bootstrap metrics live in an inline JSON script (not a huge attribute), and live metric regions are marked `translate="no"`.
- Escape bootstrap JSON for script embeds (`jsonForInlineScript`) so `</script>` cannot break out of the tag.

## Why `/fr/data/` was broken

Localized `/data/` pages were still serving the **pre-#947 loading shell** (spinner + empty tables, no bootstrap metrics). English already SSR-boots metrics. All locales (`fr`, `de`, `es`, …) were stuck on that stale translated HTML.

After deploy of web + translation worker, the cache version bump forces a fresh translation of the fixed English page.

## Test plan

- [x] `bun run check` in `apps/translation-worker` (parser tests include `translate=no`)
- [x] `jsonForInlineScript` round-trips and blocks `</script>` breakouts
- [ ] Deploy translation worker, then hit `/fr/data/` and confirm SSR tables + no loading shell
- [ ] Confirm chrome copy is translated, metric rows stay English/stable
- [ ] Spot-check that short nav/labels are not expanded into long sentences
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d2233c5-08da-470b-9890-030b842cb7eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d2233c5-08da-470b-9890-030b842cb7eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789046211&installation_model_id=430928&pr_number=949&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F949&signature=da6fd1ddf88247fa0ce035ff75c751dcb05e5bd7d418192ded1eb41fd07339eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved translation handling for excluded content, markup, attributes, and protected terms such as “Live Update.”
  * Added safeguards for translation length, with retries and source-text fallback when needed.
  * Improved loading and display of data metrics, charts, and tables.
  * Added clearer screen-reader status updates for dynamic data.

* **Bug Fixes**
  * Prevented dynamic data and marked content from being translated unintentionally.
  * Improved safe handling of metrics embedded in the data page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->