### PR TITLE
fix: accept /webhook/ trailing slash on article webhooks

### DIFF
--- a/apps/distrib-worker/src/index.ts
+++ b/apps/distrib-worker/src/index.ts
@@ -193,7 +193,7 @@ export default {
       return jsonResponse({ status: 'ok' })
     }
 
-    if (url.pathname !== '/webhook') return jsonResponse({ error: 'not_found' }, 404)
+    if (url.pathname !== '/webhook' && url.pathname !== '/webhook/') return jsonResponse({ error: 'not_found' }, 404)
     if (request.method !== 'POST') return jsonResponse({ error: 'method_not_allowed' }, 405)
     if (!env.DISTRIB_ACCESS_TOKEN) return jsonResponse({ error: 'missing_distrib_access_token' }, 500)
 

--- a/apps/outrank-worker/src/index.ts
+++ b/apps/outrank-worker/src/index.ts
@@ -172,7 +172,7 @@ export default {
       return jsonResponse({ status: 'ok' })
     }
 
-    if (url.pathname !== '/webhook') return jsonResponse({ error: 'not_found' }, 404)
+    if (url.pathname !== '/webhook' && url.pathname !== '/webhook/') return jsonResponse({ error: 'not_found' }, 404)
     if (request.method !== 'POST') return jsonResponse({ error: 'method_not_allowed' }, 405)
     if (!env.OUTRANK_ACCESS_TOKEN) return jsonResponse({ error: 'missing_outrank_access_token' }, 500)
 


### PR DESCRIPTION
## Summary
- Accept both `/webhook` and `/webhook/` on distrib + outrank workers
- Root cause of Distrib 404: URL with trailing slash did not match path check

## Test plan
- [ ] Deploy
- [ ] `POST https://distrib.capgo.app/webhook/` with token → not 404 (401 without body / 202 with valid payload)

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789054159&installation_model_id=430928&pr_number=950&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F950&signature=1dffdc8020a72def151c601729dab252d3f81f78eb582cd17bf5f35158f139c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

