### PR TITLE
fix(udid): stop profile 500 when Worker certs are unset

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -16,11 +16,47 @@ on:
       - 'configs.json'
       - 'package.json'
       - 'bun.lock'
+      - '.github/workflows/deploy-web.yml'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
+  ios-udid-signing-cert:
+    name: iOS UDID signing cert
+    if: github.repository == 'Cap-go/website'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      - name: Check whether Let's Encrypt renewal is due
+        id: cert
+        env:
+          IOS_UDID_PROFILE_SIGNING_CERT_PEM: ${{ secrets.IOS_UDID_PROFILE_SIGNING_CERT_PEM }}
+        run: bash scripts/renew-ios-udid-signing-cert.sh check
+      - if: steps.cert.outputs.renew == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - if: steps.cert.outputs.renew == 'true'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.14
+      - name: Issue or renew UDID signing cert
+        if: steps.cert.outputs.renew == 'true'
+        env:
+          IOS_UDID_PROFILE_SIGNING_CERT_PEM: ${{ secrets.IOS_UDID_PROFILE_SIGNING_CERT_PEM }}
+          IOS_UDID_PROFILE_SIGNING_KEY_PEM: ${{ secrets.IOS_UDID_PROFILE_SIGNING_KEY_PEM }}
+          IOS_UDID_PROFILE_SIGNING_CHAIN_PEM: ${{ secrets.IOS_UDID_PROFILE_SIGNING_CHAIN_PEM }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_DNS_API_TOKEN: ${{ secrets.CLOUDFLARE_DNS_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: bash scripts/renew-ios-udid-signing-cert.sh issue
+
   typos:
     name: Check for Typos
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -36,6 +36,7 @@ jobs:
         id: cert
         env:
           IOS_UDID_PROFILE_SIGNING_CERT_PEM: ${{ secrets.IOS_UDID_PROFILE_SIGNING_CERT_PEM }}
+          IOS_UDID_PROFILE_SIGNING_KEY_PEM: ${{ secrets.IOS_UDID_PROFILE_SIGNING_KEY_PEM }}
         run: bash scripts/renew-ios-udid-signing-cert.sh check
       - if: steps.cert.outputs.renew == 'true'
         uses: actions/setup-node@v6

--- a/_typos.toml
+++ b/_typos.toml
@@ -27,6 +27,7 @@ extend-ignore-re = [
 # These are proper names, not typos
 Longe = "Longe"
 Damon = "Damon"
+Synopsys = "Synopsys"
 
 # Acronyms and technical terms
 ASO = "ASO"  # App Store Optimization

--- a/apps/web/src/lib/tools/api.ts
+++ b/apps/web/src/lib/tools/api.ts
@@ -256,7 +256,9 @@ async function handleUdidProfile(request: Request, env: ToolApiEnv): Promise<Res
     })
     appendCookie(headers, UDID_CHALLENGE_COOKIE, challenge, UDID_CALLBACK_PATH, 300, secure, true)
 
-    return new Response(signedProfile ?? profile, {
+    const body: BodyInit = signedProfile ? signedProfile.buffer.slice(signedProfile.byteOffset, signedProfile.byteOffset + signedProfile.byteLength) : profile
+
+    return new Response(body, {
       status: 200,
       headers,
     })

--- a/apps/web/src/lib/tools/api.ts
+++ b/apps/web/src/lib/tools/api.ts
@@ -256,14 +256,7 @@ async function handleUdidProfile(request: Request, env: ToolApiEnv): Promise<Res
     })
     appendCookie(headers, UDID_CHALLENGE_COOKIE, challenge, UDID_CALLBACK_PATH, 300, secure, true)
 
-    if (signedProfile) {
-      return new Response(new Blob([signedProfile]), {
-        status: 200,
-        headers,
-      })
-    }
-
-    return new Response(profile, {
+    return new Response(signedProfile ?? profile, {
       status: 200,
       headers,
     })

--- a/apps/web/src/lib/tools/api.ts
+++ b/apps/web/src/lib/tools/api.ts
@@ -256,7 +256,7 @@ async function handleUdidProfile(request: Request, env: ToolApiEnv): Promise<Res
     })
     appendCookie(headers, UDID_CHALLENGE_COOKIE, challenge, UDID_CALLBACK_PATH, 300, secure, true)
 
-    return new Response(signedProfile ? new Uint8Array(signedProfile) : profile, {
+    return new Response(signedProfile ?? profile, {
       status: 200,
       headers,
     })

--- a/apps/web/src/lib/tools/api.ts
+++ b/apps/web/src/lib/tools/api.ts
@@ -256,9 +256,14 @@ async function handleUdidProfile(request: Request, env: ToolApiEnv): Promise<Res
     })
     appendCookie(headers, UDID_CHALLENGE_COOKIE, challenge, UDID_CALLBACK_PATH, 300, secure, true)
 
-    const body: BodyInit = signedProfile ? signedProfile.buffer.slice(signedProfile.byteOffset, signedProfile.byteOffset + signedProfile.byteLength) : profile
+    if (signedProfile) {
+      return new Response(new Blob([signedProfile]), {
+        status: 200,
+        headers,
+      })
+    }
 
-    return new Response(body, {
+    return new Response(profile, {
       status: 200,
       headers,
     })

--- a/apps/web/src/lib/tools/udid.ts
+++ b/apps/web/src/lib/tools/udid.ts
@@ -40,6 +40,23 @@ function normalizePem(value: string | undefined): string {
     .trim()
 }
 
+function readViteEnv(name: string): string | undefined {
+  try {
+    const env = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env
+    return env?.[name]
+  } catch {
+    return undefined
+  }
+}
+
+function derBytesToUint8Array(derBytes: string): Uint8Array {
+  const bytes = new Uint8Array(derBytes.length)
+  for (let i = 0; i < derBytes.length; i++) {
+    bytes[i] = derBytes.charCodeAt(i) & 0xff
+  }
+  return bytes
+}
+
 export function createUdidMobileconfig(options: UdidProfileOptions): string {
   const payloadUuid = crypto.randomUUID().toUpperCase()
   const challengeBlock = options.challenge ? `<key>Challenge</key>\n      <string>${escapeXml(options.challenge)}</string>` : ''
@@ -82,16 +99,16 @@ export function createUdidMobileconfig(options: UdidProfileOptions): string {
 </plist>`
 }
 
-export async function signMobileconfig(profileXml: string, credentials?: UdidSigningCredentials): Promise<Buffer | null> {
-  const certificatePem = normalizePem(credentials?.certificatePem ?? import.meta.env.IOS_UDID_PROFILE_SIGNING_CERT_PEM)
-  const privateKeyPem = normalizePem(credentials?.privateKeyPem ?? import.meta.env.IOS_UDID_PROFILE_SIGNING_KEY_PEM)
-  const chainPem = normalizePem(credentials?.chainPem ?? import.meta.env.IOS_UDID_PROFILE_SIGNING_CHAIN_PEM)
-
-  if (!certificatePem || !privateKeyPem) {
-    return null
-  }
-
+export async function signMobileconfig(profileXml: string, credentials?: UdidSigningCredentials): Promise<Uint8Array | null> {
   try {
+    const certificatePem = normalizePem(credentials?.certificatePem ?? readViteEnv('IOS_UDID_PROFILE_SIGNING_CERT_PEM'))
+    const privateKeyPem = normalizePem(credentials?.privateKeyPem ?? readViteEnv('IOS_UDID_PROFILE_SIGNING_KEY_PEM'))
+    const chainPem = normalizePem(credentials?.chainPem ?? readViteEnv('IOS_UDID_PROFILE_SIGNING_CHAIN_PEM'))
+
+    if (!certificatePem || !privateKeyPem) {
+      return null
+    }
+
     const forge = await getForge()
     const signingCertificate = forge.pki.certificateFromPem(certificatePem)
     const privateKey = forge.pki.privateKeyFromPem(privateKeyPem)
@@ -126,7 +143,7 @@ export async function signMobileconfig(profileXml: string, credentials?: UdidSig
     })
 
     signedData.sign({ detached: false })
-    return Buffer.from(forge.asn1.toDer(signedData.toAsn1()).getBytes(), 'binary')
+    return derBytesToUint8Array(forge.asn1.toDer(signedData.toAsn1()).getBytes())
   } catch {
     return null
   }

--- a/apps/web/src/lib/tools/udid.ts
+++ b/apps/web/src/lib/tools/udid.ts
@@ -49,12 +49,13 @@ function readViteEnv(name: string): string | undefined {
   }
 }
 
-function derBytesToUint8Array(derBytes: string): Uint8Array {
-  const bytes = new Uint8Array(derBytes.length)
+function derBytesToArrayBuffer(derBytes: string): ArrayBuffer {
+  const buffer = new ArrayBuffer(derBytes.length)
+  const bytes = new Uint8Array(buffer)
   for (let i = 0; i < derBytes.length; i++) {
     bytes[i] = derBytes.charCodeAt(i) & 0xff
   }
-  return bytes
+  return buffer
 }
 
 export function createUdidMobileconfig(options: UdidProfileOptions): string {
@@ -99,7 +100,7 @@ export function createUdidMobileconfig(options: UdidProfileOptions): string {
 </plist>`
 }
 
-export async function signMobileconfig(profileXml: string, credentials?: UdidSigningCredentials): Promise<Uint8Array | null> {
+export async function signMobileconfig(profileXml: string, credentials?: UdidSigningCredentials): Promise<ArrayBuffer | null> {
   try {
     const certificatePem = normalizePem(credentials?.certificatePem ?? readViteEnv('IOS_UDID_PROFILE_SIGNING_CERT_PEM'))
     const privateKeyPem = normalizePem(credentials?.privateKeyPem ?? readViteEnv('IOS_UDID_PROFILE_SIGNING_KEY_PEM'))
@@ -143,7 +144,7 @@ export async function signMobileconfig(profileXml: string, credentials?: UdidSig
     })
 
     signedData.sign({ detached: false })
-    return derBytesToUint8Array(forge.asn1.toDer(signedData.toAsn1()).getBytes())
+    return derBytesToArrayBuffer(forge.asn1.toDer(signedData.toAsn1()).getBytes())
   } catch {
     return null
   }

--- a/scripts/renew-ios-udid-signing-cert.sh
+++ b/scripts/renew-ios-udid-signing-cert.sh
@@ -49,9 +49,9 @@ cert_is_fresh() {
   fi
 
   local cert_modulus key_modulus
-  cert_modulus="$(openssl x509 -noout -modulus -in "$cert_file" 2>/dev/null | openssl md5)"
-  key_modulus="$(openssl rsa -noout -modulus -in "$key_file" 2>/dev/null | openssl md5)"
-  if [[ -z "$cert_modulus" || "$cert_modulus" != "$key_modulus" ]]; then
+  cert_modulus="$(openssl x509 -noout -modulus -in "$cert_file" 2>/dev/null || true)"
+  key_modulus="$(openssl rsa -noout -modulus -in "$key_file" 2>/dev/null || true)"
+  if [[ -z "$cert_modulus" || -z "$key_modulus" || "$cert_modulus" != "$key_modulus" ]]; then
     echo "UDID signing cert and private key do not match."
     rm -f "$cert_file" "$key_file"
     return 1
@@ -95,8 +95,21 @@ install_lego() {
   curl --proto '=https' --tlsv1.2 -fsSL "$url" | tar -xz -C "$dest" lego
 }
 
+strip() {
+  local value="${1-}"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
 require_issue_credentials() {
-  if [[ -z "${CLOUDFLARE_DNS_API_TOKEN:-}" ]]; then
+  CLOUDFLARE_DNS_API_TOKEN="$(strip "${CLOUDFLARE_DNS_API_TOKEN:-}")"
+  CLOUDFLARE_API_TOKEN="$(strip "${CLOUDFLARE_API_TOKEN:-}")"
+  CLOUDFLARE_ACCOUNT_ID="$(strip "${CLOUDFLARE_ACCOUNT_ID:-}")"
+  PERSONAL_ACCESS_TOKEN="$(strip "${PERSONAL_ACCESS_TOKEN:-}")"
+  export CLOUDFLARE_DNS_API_TOKEN CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID PERSONAL_ACCESS_TOKEN
+
+  if [[ -z "${CLOUDFLARE_DNS_API_TOKEN}" ]]; then
     echo "CLOUDFLARE_DNS_API_TOKEN is required for DNS-01 (Zone.DNS Edit on capgo.app)." >&2
     exit 1
   fi

--- a/scripts/renew-ios-udid-signing-cert.sh
+++ b/scripts/renew-ios-udid-signing-cert.sh
@@ -24,7 +24,8 @@ write_pem() {
 }
 
 cert_expiry() {
-  openssl x509 -in "$1" -noout -enddate 2>/dev/null | sed 's/^notAfter=//'
+  local cert_file="$1"
+  openssl x509 -in "$cert_file" -noout -enddate 2>/dev/null | sed 's/^notAfter=//'
 }
 
 cert_is_fresh() {
@@ -78,7 +79,7 @@ install_lego() {
   esac
 
   local url="https://github.com/go-acme/lego/releases/download/v${LEGO_VERSION}/lego_v${LEGO_VERSION}_linux_${arch}.tar.gz"
-  curl -fsSL "$url" | tar -xz -C "$dest" lego
+  curl --proto '=https' --tlsv1.2 -fsSL "$url" | tar -xz -C "$dest" lego
 }
 
 restore_existing_material() {

--- a/scripts/renew-ios-udid-signing-cert.sh
+++ b/scripts/renew-ios-udid-signing-cert.sh
@@ -30,22 +30,35 @@ cert_expiry() {
 
 cert_is_fresh() {
   local pem="${IOS_UDID_PROFILE_SIGNING_CERT_PEM:-}"
-  if [[ -z "${pem//[[:space:]]/}" ]]; then
-    echo "No existing UDID signing cert in GitHub secrets."
+  local key="${IOS_UDID_PROFILE_SIGNING_KEY_PEM:-}"
+  if [[ -z "${pem//[[:space:]]/}" || -z "${key//[[:space:]]/}" ]]; then
+    echo "No existing UDID signing cert/key in GitHub secrets."
     return 1
   fi
 
-  local tmp
-  tmp="$(mktemp)"
-  write_pem "$pem" "$tmp"
-  if ! openssl x509 -in "$tmp" -noout -checkend "$((RENEW_DAYS * 86400))" >/dev/null 2>&1; then
-    echo "UDID signing cert missing, invalid, or expiring within ${RENEW_DAYS} days ($(cert_expiry "$tmp" || echo unknown))."
-    rm -f "$tmp"
+  local cert_file key_file
+  cert_file="$(mktemp)"
+  key_file="$(mktemp)"
+  write_pem "$pem" "$cert_file"
+  write_pem "$key" "$key_file"
+
+  if ! openssl x509 -in "$cert_file" -noout -checkend "$((RENEW_DAYS * 86400))" >/dev/null 2>&1; then
+    echo "UDID signing cert missing, invalid, or expiring within ${RENEW_DAYS} days ($(cert_expiry "$cert_file" || echo unknown))."
+    rm -f "$cert_file" "$key_file"
     return 1
   fi
 
-  echo "UDID signing cert is valid until $(cert_expiry "$tmp"). Skipping Let's Encrypt."
-  rm -f "$tmp"
+  local cert_modulus key_modulus
+  cert_modulus="$(openssl x509 -noout -modulus -in "$cert_file" 2>/dev/null | openssl md5)"
+  key_modulus="$(openssl rsa -noout -modulus -in "$key_file" 2>/dev/null | openssl md5)"
+  if [[ -z "$cert_modulus" || "$cert_modulus" != "$key_modulus" ]]; then
+    echo "UDID signing cert and private key do not match."
+    rm -f "$cert_file" "$key_file"
+    return 1
+  fi
+
+  echo "UDID signing cert is valid until $(cert_expiry "$cert_file"). Skipping Let's Encrypt."
+  rm -f "$cert_file" "$key_file"
   return 0
 }
 
@@ -82,34 +95,29 @@ install_lego() {
   curl --proto '=https' --tlsv1.2 -fsSL "$url" | tar -xz -C "$dest" lego
 }
 
-restore_existing_material() {
-  local lego_path="$1"
-  local cert_dir="${lego_path}/certificates"
-  mkdir -p "$cert_dir"
-
-  if [[ -z "${IOS_UDID_PROFILE_SIGNING_CERT_PEM:-}" || -z "${IOS_UDID_PROFILE_SIGNING_KEY_PEM:-}" ]]; then
-    return 0
-  fi
-
-  write_pem "$IOS_UDID_PROFILE_SIGNING_CERT_PEM" "${cert_dir}/${DOMAIN}.crt"
-  write_pem "$IOS_UDID_PROFILE_SIGNING_KEY_PEM" "${cert_dir}/${DOMAIN}.key"
-  if [[ -n "${IOS_UDID_PROFILE_SIGNING_CHAIN_PEM:-}" ]]; then
-    write_pem "$IOS_UDID_PROFILE_SIGNING_CHAIN_PEM" "${cert_dir}/${DOMAIN}.issuer.crt"
-  fi
-}
-
-issue_or_renew() {
+require_issue_credentials() {
   if [[ -z "${CLOUDFLARE_DNS_API_TOKEN:-}" ]]; then
     echo "CLOUDFLARE_DNS_API_TOKEN is required for DNS-01 (Zone.DNS Edit on capgo.app)." >&2
     exit 1
   fi
+  if [[ -z "${CLOUDFLARE_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+    echo "CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are required to update Worker secrets." >&2
+    exit 1
+  fi
+  if [[ -z "${PERSONAL_ACCESS_TOKEN:-${GH_TOKEN:-}}" ]]; then
+    echo "PERSONAL_ACCESS_TOKEN is required to persist GitHub secrets after a successful Worker update." >&2
+    exit 1
+  fi
+}
+
+issue_or_renew() {
+  require_issue_credentials
 
   local work
   work="$(mktemp -d)"
   trap 'rm -rf "$work"' EXIT
 
   install_lego "$work"
-  restore_existing_material "$work"
 
   local lego_bin="${work}/lego"
   local cert_file="${work}/certificates/${DOMAIN}.crt"
@@ -123,13 +131,8 @@ issue_or_renew() {
     --path "$work"
   )
 
-  if [[ -f "$cert_file" && -f "$key_file" ]]; then
-    echo "Renewing ${DOMAIN} via DNS-01 (threshold ${RENEW_DAYS} days)."
-    "$lego_bin" "${common_args[@]}" renew --days "$RENEW_DAYS" --no-random-sleep
-  else
-    echo "Creating ${DOMAIN} via DNS-01."
-    "$lego_bin" "${common_args[@]}" run
-  fi
+  echo "Creating ${DOMAIN} via DNS-01."
+  "$lego_bin" "${common_args[@]}" run
 
   if [[ ! -f "$cert_file" || ! -f "$key_file" ]]; then
     echo "lego did not write ${DOMAIN} certificate files." >&2
@@ -143,13 +146,13 @@ issue_or_renew() {
     : >"$chain"
   fi
 
-  push_github_secret "$CERT_SECRET_NAME" "$leaf"
-  push_github_secret "$KEY_SECRET_NAME" "$key_file"
-  push_github_secret "$CHAIN_SECRET_NAME" "$chain"
-
   push_worker_secret "$CERT_SECRET_NAME" "$leaf"
   push_worker_secret "$KEY_SECRET_NAME" "$key_file"
   push_worker_secret "$CHAIN_SECRET_NAME" "$chain"
+
+  push_github_secret "$CERT_SECRET_NAME" "$leaf"
+  push_github_secret "$KEY_SECRET_NAME" "$key_file"
+  push_github_secret "$CHAIN_SECRET_NAME" "$chain"
 
   echo "UDID signing cert updated. Valid until $(cert_expiry "$leaf")."
 }

--- a/scripts/renew-ios-udid-signing-cert.sh
+++ b/scripts/renew-ios-udid-signing-cert.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Issues or renews the Let's Encrypt cert used to sign the iOS UDID mobileconfig.
+# Never contacts ACME unless the current public cert is missing or expires within
+# UDID_CERT_RENEW_DAYS (default 30).
+
+DOMAIN="${UDID_CERT_DOMAIN:-capgo.app}"
+EMAIL="${UDID_CERT_EMAIL:-martin@capgo.app}"
+RENEW_DAYS="${UDID_CERT_RENEW_DAYS:-30}"
+WORKER_NAME="${UDID_CERT_WORKER_NAME:-capgo-website}"
+LEGO_VERSION="${UDID_CERT_LEGO_VERSION:-4.35.2}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+COMMAND="${1:-check}"
+
+CERT_SECRET_NAME="IOS_UDID_PROFILE_SIGNING_CERT_PEM"
+KEY_SECRET_NAME="IOS_UDID_PROFILE_SIGNING_KEY_PEM"
+CHAIN_SECRET_NAME="IOS_UDID_PROFILE_SIGNING_CHAIN_PEM"
+
+write_pem() {
+  local value="$1"
+  local dest="$2"
+  printf '%s' "$value" | sed 's/\\n/\n/g' | tr -d '\r' | sed -e '$a\' >"$dest"
+}
+
+cert_expiry() {
+  openssl x509 -in "$1" -noout -enddate 2>/dev/null | sed 's/^notAfter=//'
+}
+
+cert_is_fresh() {
+  local pem="${IOS_UDID_PROFILE_SIGNING_CERT_PEM:-}"
+  if [[ -z "${pem//[[:space:]]/}" ]]; then
+    echo "No existing UDID signing cert in GitHub secrets."
+    return 1
+  fi
+
+  local tmp
+  tmp="$(mktemp)"
+  write_pem "$pem" "$tmp"
+  if ! openssl x509 -in "$tmp" -noout -checkend "$((RENEW_DAYS * 86400))" >/dev/null 2>&1; then
+    echo "UDID signing cert missing, invalid, or expiring within ${RENEW_DAYS} days ($(cert_expiry "$tmp" || echo unknown))."
+    rm -f "$tmp"
+    return 1
+  fi
+
+  echo "UDID signing cert is valid until $(cert_expiry "$tmp"). Skipping Let's Encrypt."
+  rm -f "$tmp"
+  return 0
+}
+
+set_output() {
+  local key="$1"
+  local value="$2"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "${key}=${value}" >>"$GITHUB_OUTPUT"
+  fi
+}
+
+check_cert() {
+  if cert_is_fresh; then
+    set_output renew false
+    return 0
+  fi
+  set_output renew true
+  return 0
+}
+
+install_lego() {
+  local dest="$1"
+  local arch
+  case "$(uname -m)" in
+    x86_64) arch=amd64 ;;
+    aarch64 | arm64) arch=arm64 ;;
+    *)
+      echo "Unsupported architecture: $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+
+  local url="https://github.com/go-acme/lego/releases/download/v${LEGO_VERSION}/lego_v${LEGO_VERSION}_linux_${arch}.tar.gz"
+  curl -fsSL "$url" | tar -xz -C "$dest" lego
+}
+
+restore_existing_material() {
+  local lego_path="$1"
+  local cert_dir="${lego_path}/certificates"
+  mkdir -p "$cert_dir"
+
+  if [[ -z "${IOS_UDID_PROFILE_SIGNING_CERT_PEM:-}" || -z "${IOS_UDID_PROFILE_SIGNING_KEY_PEM:-}" ]]; then
+    return 0
+  fi
+
+  write_pem "$IOS_UDID_PROFILE_SIGNING_CERT_PEM" "${cert_dir}/${DOMAIN}.crt"
+  write_pem "$IOS_UDID_PROFILE_SIGNING_KEY_PEM" "${cert_dir}/${DOMAIN}.key"
+  if [[ -n "${IOS_UDID_PROFILE_SIGNING_CHAIN_PEM:-}" ]]; then
+    write_pem "$IOS_UDID_PROFILE_SIGNING_CHAIN_PEM" "${cert_dir}/${DOMAIN}.issuer.crt"
+  fi
+}
+
+issue_or_renew() {
+  if [[ -z "${CLOUDFLARE_DNS_API_TOKEN:-}" ]]; then
+    echo "CLOUDFLARE_DNS_API_TOKEN is required for DNS-01 (Zone.DNS Edit on capgo.app)." >&2
+    exit 1
+  fi
+
+  local work
+  work="$(mktemp -d)"
+  trap 'rm -rf "$work"' EXIT
+
+  install_lego "$work"
+  restore_existing_material "$work"
+
+  local lego_bin="${work}/lego"
+  local cert_file="${work}/certificates/${DOMAIN}.crt"
+  local key_file="${work}/certificates/${DOMAIN}.key"
+  local common_args=(
+    --accept-tos
+    --email "$EMAIL"
+    --dns cloudflare
+    --domains "$DOMAIN"
+    --key-type rsa
+    --path "$work"
+  )
+
+  if [[ -f "$cert_file" && -f "$key_file" ]]; then
+    echo "Renewing ${DOMAIN} via DNS-01 (threshold ${RENEW_DAYS} days)."
+    "$lego_bin" "${common_args[@]}" renew --days "$RENEW_DAYS" --no-random-sleep
+  else
+    echo "Creating ${DOMAIN} via DNS-01."
+    "$lego_bin" "${common_args[@]}" run
+  fi
+
+  if [[ ! -f "$cert_file" || ! -f "$key_file" ]]; then
+    echo "lego did not write ${DOMAIN} certificate files." >&2
+    exit 1
+  fi
+
+  local leaf="${work}/leaf.pem"
+  openssl x509 -in "$cert_file" -out "$leaf"
+  local chain="${work}/certificates/${DOMAIN}.issuer.crt"
+  if [[ ! -s "$chain" ]]; then
+    : >"$chain"
+  fi
+
+  push_github_secret "$CERT_SECRET_NAME" "$leaf"
+  push_github_secret "$KEY_SECRET_NAME" "$key_file"
+  push_github_secret "$CHAIN_SECRET_NAME" "$chain"
+
+  push_worker_secret "$CERT_SECRET_NAME" "$leaf"
+  push_worker_secret "$KEY_SECRET_NAME" "$key_file"
+  push_worker_secret "$CHAIN_SECRET_NAME" "$chain"
+
+  echo "UDID signing cert updated. Valid until $(cert_expiry "$leaf")."
+}
+
+push_github_secret() {
+  local name="$1"
+  local file="$2"
+  if [[ -z "${PERSONAL_ACCESS_TOKEN:-${GH_TOKEN:-}}" ]]; then
+    echo "PERSONAL_ACCESS_TOKEN is required to persist ${name}." >&2
+    exit 1
+  fi
+  GH_TOKEN="${PERSONAL_ACCESS_TOKEN:-$GH_TOKEN}" gh secret set "$name" --repo "${GITHUB_REPOSITORY:?}" <"$file"
+}
+
+push_worker_secret() {
+  local name="$1"
+  local file="$2"
+  if [[ -z "${CLOUDFLARE_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+    echo "CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are required to update worker secret ${name}." >&2
+    exit 1
+  fi
+  (
+    cd "${ROOT}/apps/web"
+    bunx wrangler secret put "$name" --name "$WORKER_NAME" <"$file"
+  )
+}
+
+case "$COMMAND" in
+  check)
+    check_cert
+    ;;
+  issue)
+    if cert_is_fresh; then
+      set_output renew false
+      exit 0
+    fi
+    issue_or_renew
+    ;;
+  *)
+    echo "Usage: $0 [check|issue]" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/renew-ios-udid-signing-cert.sh
+++ b/scripts/renew-ios-udid-signing-cert.sh
@@ -107,17 +107,21 @@ require_issue_credentials() {
   CLOUDFLARE_API_TOKEN="$(strip "${CLOUDFLARE_API_TOKEN:-}")"
   CLOUDFLARE_ACCOUNT_ID="$(strip "${CLOUDFLARE_ACCOUNT_ID:-}")"
   PERSONAL_ACCESS_TOKEN="$(strip "${PERSONAL_ACCESS_TOKEN:-}")"
-  export CLOUDFLARE_DNS_API_TOKEN CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID PERSONAL_ACCESS_TOKEN
+  GH_TOKEN="$(strip "${GH_TOKEN:-}")"
+  if [[ -z "$PERSONAL_ACCESS_TOKEN" ]]; then
+    PERSONAL_ACCESS_TOKEN="$GH_TOKEN"
+  fi
+  export CLOUDFLARE_DNS_API_TOKEN CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID PERSONAL_ACCESS_TOKEN GH_TOKEN
 
   if [[ -z "${CLOUDFLARE_DNS_API_TOKEN}" ]]; then
     echo "CLOUDFLARE_DNS_API_TOKEN is required for DNS-01 (Zone.DNS Edit on capgo.app)." >&2
     exit 1
   fi
-  if [[ -z "${CLOUDFLARE_API_TOKEN:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+  if [[ -z "${CLOUDFLARE_API_TOKEN}" || -z "${CLOUDFLARE_ACCOUNT_ID}" ]]; then
     echo "CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are required to update Worker secrets." >&2
     exit 1
   fi
-  if [[ -z "${PERSONAL_ACCESS_TOKEN:-${GH_TOKEN:-}}" ]]; then
+  if [[ -z "$PERSONAL_ACCESS_TOKEN" ]]; then
     echo "PERSONAL_ACCESS_TOKEN is required to persist GitHub secrets after a successful Worker update." >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary
- `/api/tools/ios-udid-finder/profile` returned 500 because the Worker read `import.meta.env.IOS_UDID_PROFILE_SIGNING_*`, which is undefined on Cloudflare. Missing or invalid certs now skip signing and still download the unsigned profile.
- Deploy Web runs a parallel Let's Encrypt job that only contacts ACME when the stored cert is missing or within 30 days of expiry, then writes GitHub and Worker secrets.

## Test plan
- [ ] `GET https://capgo.app/api/tools/ios-udid-finder/profile` returns `200` with `Content-Type: application/x-apple-aspen-config` after web deploy
- [ ] Confirm the new Deploy Web job `iOS UDID signing cert` does not block `build`
- [ ] First run may issue a cert; later runs should log skip unless expiry is under 30 days
- [ ] `CLOUDFLARE_API_TOKEN` (or `CLOUDFLARE_DNS_API_TOKEN`) has Zone.DNS Edit on `capgo.app`, and `PERSONAL_ACCESS_TOKEN` can set repo secrets


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789330769&installation_model_id=430928&pr_number=959&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F959&signature=11c2bc1af9ec5442a9d87ed244e4c4f4f70be48bda4f67d21d7c08a198ac0793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

