### PR TITLE
fix(ci): use lego rsa2048 for UDID signing cert

### DIFF
--- a/scripts/renew-ios-udid-signing-cert.sh
+++ b/scripts/renew-ios-udid-signing-cert.sh
@@ -132,7 +132,8 @@ issue_or_renew() {
 
   local work
   work="$(mktemp -d)"
-  trap 'rm -rf "$work"' EXIT
+  # EXIT runs after locals are unset; expand the path now so `set -u` cannot trip.
+  trap 'rm -rf -- '"$(printf '%q' "$work")" EXIT
 
   install_lego "$work"
 
@@ -144,7 +145,7 @@ issue_or_renew() {
     --email "$EMAIL"
     --dns cloudflare
     --domains "$DOMAIN"
-    --key-type rsa
+    --key-type rsa2048
     --path "$work"
   )
 


### PR DESCRIPTION
## Summary
- Lego rejected `--key-type rsa` (`Unsupported KeyType: rsa`). Use `rsa2048`, which node-forge CMS signing needs and Let's Encrypt accepts.
- The EXIT trap read a function-local `work` after `set -e` unwound it (`work: unbound variable`). Expand the temp dir path when the trap is registered.

## Test plan
- [ ] Re-run Deploy Web `iOS UDID signing cert` (or merge to `main`)
- [ ] Job logs show `Creating capgo.app via DNS-01` then a successful lego run, not `Unsupported KeyType`
- [ ] Worker secrets `IOS_UDID_PROFILE_SIGNING_*` are set
- [ ] `GET https://capgo.app/api/tools/ios-udid-finder/profile` returns `200` with `Content-Type: application/x-apple-aspen-config` after web deploy


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789380721&installation_model_id=430928&pr_number=961&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F961&signature=bff9ca7cb3132aee6126c54afdfe615f2be41f37e42f107dfccfd9c9ffb11b3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

