### PR TITLE
fix(ci): probe Cloudflare DNS token before Let's Encrypt

### DIFF
--- a/scripts/renew-ios-udid-signing-cert.sh
+++ b/scripts/renew-ios-udid-signing-cert.sh
@@ -130,7 +130,8 @@ require_issue_credentials() {
 }
 
 dns_token_hint() {
-  echo "Create a Cloudflare API token with Zone.Zone:Read and Zone.DNS:Edit on ${DOMAIN}, then set GitHub secret CLOUDFLARE_DNS_API_TOKEN. The Worker deploy token cannot create _acme-challenge TXT records."
+  local zone="${1:-$DOMAIN}"
+  echo "Create a Cloudflare API token with Zone.Zone:Read and Zone.DNS:Edit on ${zone}, then set GitHub secret CLOUDFLARE_DNS_API_TOKEN. The Worker deploy token cannot create _acme-challenge TXT records."
 }
 
 verify_cloudflare_dns() {
@@ -144,7 +145,7 @@ verify_cloudflare_dns() {
         "https://api.cloudflare.com/client/v4/zones?name=${zone}&per_page=1" || true
   )"
 
-  if ! HTTP_CODE="$code" BODY_FILE="$body" DOMAIN="$DOMAIN" ZONE="$zone" HINT="$(dns_token_hint)" python3 <<'PY'
+  if ! HTTP_CODE="$code" BODY_FILE="$body" DOMAIN="$DOMAIN" ZONE="$zone" HINT="$(dns_token_hint "$zone")" python3 <<'PY'
 import json
 import os
 import sys
@@ -202,8 +203,8 @@ issue_or_renew() {
 
   echo "Creating ${DOMAIN} via DNS-01."
   if ! "$lego_bin" "${common_args[@]}" run; then
-    echo "Let's Encrypt DNS-01 failed. If Cloudflare returned 403/10000, the token lacks Zone.DNS:Edit on ${DOMAIN}." >&2
-    dns_token_hint >&2
+    echo "Let's Encrypt DNS-01 failed. If Cloudflare returned 403/10000, the token lacks Zone.DNS:Edit on ${UDID_CERT_ZONE:-$DOMAIN}." >&2
+    dns_token_hint "${UDID_CERT_ZONE:-$DOMAIN}" >&2
     exit 1
   fi
 

--- a/scripts/renew-ios-udid-signing-cert.sh
+++ b/scripts/renew-ios-udid-signing-cert.sh
@@ -134,19 +134,24 @@ dns_token_hint() {
 }
 
 verify_cloudflare_dns() {
-  local body code
+  local body code zone
+  zone="${UDID_CERT_ZONE:-$DOMAIN}"
   body="$(mktemp)"
-  code="$(curl --proto '=https' --tlsv1.2 -sS -o "$body" -w '%{http_code}' \
-    -H "Authorization: Bearer ${CLOUDFLARE_DNS_API_TOKEN}" \
-    "https://api.cloudflare.com/client/v4/zones?name=${DOMAIN}&per_page=1" || true)"
+  code="$(
+    printf 'Authorization: Bearer %s\n' "$CLOUDFLARE_DNS_API_TOKEN" |
+      curl --proto '=https' --tlsv1.2 -sS -o "$body" -w '%{http_code}' \
+        -H @- \
+        "https://api.cloudflare.com/client/v4/zones?name=${zone}&per_page=1" || true
+  )"
 
-  if ! HTTP_CODE="$code" BODY_FILE="$body" DOMAIN="$DOMAIN" HINT="$(dns_token_hint)" python3 <<'PY'
+  if ! HTTP_CODE="$code" BODY_FILE="$body" DOMAIN="$DOMAIN" ZONE="$zone" HINT="$(dns_token_hint)" python3 <<'PY'
 import json
 import os
 import sys
 
 code = os.environ["HTTP_CODE"]
 domain = os.environ["DOMAIN"]
+zone = os.environ["ZONE"]
 hint = os.environ["HINT"]
 try:
     with open(os.environ["BODY_FILE"], encoding="utf-8") as fh:
@@ -158,12 +163,12 @@ err_txt = "; ".join(
     f"{item.get('code')}: {item.get('message')}" for item in errors if isinstance(item, dict)
 ) or "no Cloudflare error body"
 if code != "200":
-    print(f"Cloudflare zone lookup for {domain} failed: HTTP {code} ({err_txt}). {hint}", file=sys.stderr)
+    print(f"Cloudflare zone lookup for {zone} failed: HTTP {code} ({err_txt}). {hint}", file=sys.stderr)
     sys.exit(1)
 if not (data.get("result") or []):
-    print(f"Cloudflare token cannot see zone {domain}. Scope it to that zone. {hint}", file=sys.stderr)
+    print(f"Cloudflare token cannot see zone {zone} (cert domain {domain}). Set UDID_CERT_ZONE to the apex zone if needed. {hint}", file=sys.stderr)
     sys.exit(1)
-print(f"Cloudflare DNS token can read zone {domain}.")
+print(f"Cloudflare DNS token can read zone {zone}.")
 PY
   then
     rm -f "$body"

--- a/scripts/renew-ios-udid-signing-cert.sh
+++ b/scripts/renew-ios-udid-signing-cert.sh
@@ -111,10 +111,12 @@ require_issue_credentials() {
   if [[ -z "$PERSONAL_ACCESS_TOKEN" ]]; then
     PERSONAL_ACCESS_TOKEN="$GH_TOKEN"
   fi
-  export CLOUDFLARE_DNS_API_TOKEN CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID PERSONAL_ACCESS_TOKEN GH_TOKEN
+  # Lego reads CF_DNS_API_TOKEN or CLOUDFLARE_DNS_API_TOKEN; export both.
+  CF_DNS_API_TOKEN="$CLOUDFLARE_DNS_API_TOKEN"
+  export CLOUDFLARE_DNS_API_TOKEN CF_DNS_API_TOKEN CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID PERSONAL_ACCESS_TOKEN GH_TOKEN
 
   if [[ -z "${CLOUDFLARE_DNS_API_TOKEN}" ]]; then
-    echo "CLOUDFLARE_DNS_API_TOKEN is required for DNS-01 (Zone.DNS Edit on capgo.app)." >&2
+    echo "CLOUDFLARE_DNS_API_TOKEN is required for DNS-01 (Zone.Zone:Read and Zone.DNS:Edit on ${DOMAIN})." >&2
     exit 1
   fi
   if [[ -z "${CLOUDFLARE_API_TOKEN}" || -z "${CLOUDFLARE_ACCOUNT_ID}" ]]; then
@@ -127,8 +129,52 @@ require_issue_credentials() {
   fi
 }
 
+dns_token_hint() {
+  echo "Create a Cloudflare API token with Zone.Zone:Read and Zone.DNS:Edit on ${DOMAIN}, then set GitHub secret CLOUDFLARE_DNS_API_TOKEN. The Worker deploy token cannot create _acme-challenge TXT records."
+}
+
+verify_cloudflare_dns() {
+  local body code
+  body="$(mktemp)"
+  code="$(curl --proto '=https' --tlsv1.2 -sS -o "$body" -w '%{http_code}' \
+    -H "Authorization: Bearer ${CLOUDFLARE_DNS_API_TOKEN}" \
+    "https://api.cloudflare.com/client/v4/zones?name=${DOMAIN}&per_page=1" || true)"
+
+  if ! HTTP_CODE="$code" BODY_FILE="$body" DOMAIN="$DOMAIN" HINT="$(dns_token_hint)" python3 <<'PY'
+import json
+import os
+import sys
+
+code = os.environ["HTTP_CODE"]
+domain = os.environ["DOMAIN"]
+hint = os.environ["HINT"]
+try:
+    with open(os.environ["BODY_FILE"], encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception:
+    data = {}
+errors = data.get("errors") or []
+err_txt = "; ".join(
+    f"{item.get('code')}: {item.get('message')}" for item in errors if isinstance(item, dict)
+) or "no Cloudflare error body"
+if code != "200":
+    print(f"Cloudflare zone lookup for {domain} failed: HTTP {code} ({err_txt}). {hint}", file=sys.stderr)
+    sys.exit(1)
+if not (data.get("result") or []):
+    print(f"Cloudflare token cannot see zone {domain}. Scope it to that zone. {hint}", file=sys.stderr)
+    sys.exit(1)
+print(f"Cloudflare DNS token can read zone {domain}.")
+PY
+  then
+    rm -f "$body"
+    exit 1
+  fi
+  rm -f "$body"
+}
+
 issue_or_renew() {
   require_issue_credentials
+  verify_cloudflare_dns
 
   local work
   work="$(mktemp -d)"
@@ -150,7 +196,11 @@ issue_or_renew() {
   )
 
   echo "Creating ${DOMAIN} via DNS-01."
-  "$lego_bin" "${common_args[@]}" run
+  if ! "$lego_bin" "${common_args[@]}" run; then
+    echo "Let's Encrypt DNS-01 failed. If Cloudflare returned 403/10000, the token lacks Zone.DNS:Edit on ${DOMAIN}." >&2
+    dns_token_hint >&2
+    exit 1
+  fi
 
   if [[ ! -f "$cert_file" || ! -f "$key_file" ]]; then
     echo "lego did not write ${DOMAIN} certificate files." >&2


### PR DESCRIPTION
## Summary
- Deploy Web DNS-01 failed with Cloudflare `403 10000 Authentication error` because `CLOUDFLARE_DNS_API_TOKEN` is unset and the job falls back to the Worker deploy token, which cannot create `_acme-challenge` TXT records.
- Probe zone read before ACME and print how to set `CLOUDFLARE_DNS_API_TOKEN` (Zone.Zone:Read + Zone.DNS:Edit on `capgo.app`).

## Test plan
- [ ] Add GitHub secret `CLOUDFLARE_DNS_API_TOKEN` with Zone.Zone:Read and Zone.DNS:Edit on `capgo.app`
- [ ] Re-run Deploy Web `iOS UDID signing cert`
- [ ] Job creates the cert (or, without the secret, fails on the zone probe instead of mid-ACME)


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789384759&installation_model_id=430928&pr_number=964&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F964&signature=faf7b3c96a43c4c6b3661ed11f01d0903a04f51c8802b1834b0d98128c997105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

