### PR TITLE
fix(ci): do not reuse Worker token for UDID DNS-01

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -54,7 +54,7 @@ jobs:
           IOS_UDID_PROFILE_SIGNING_CHAIN_PEM: ${{ secrets.IOS_UDID_PROFILE_SIGNING_CHAIN_PEM }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_DNS_API_TOKEN: ${{ secrets.CLOUDFLARE_DNS_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_DNS_API_TOKEN: ${{ secrets.CLOUDFLARE_DNS_API_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: bash scripts/renew-ios-udid-signing-cert.sh issue
 

--- a/scripts/renew-ios-udid-signing-cert.sh
+++ b/scripts/renew-ios-udid-signing-cert.sh
@@ -131,7 +131,7 @@ require_issue_credentials() {
 
 dns_token_hint() {
   local zone="${1:-$DOMAIN}"
-  echo "Create a Cloudflare API token with Zone.Zone:Read and Zone.DNS:Edit on ${zone}, then set GitHub secret CLOUDFLARE_DNS_API_TOKEN. The Worker deploy token cannot create _acme-challenge TXT records."
+  echo "Create a Cloudflare API token with Zone.Zone:Read and Zone.DNS:Edit on ${zone} under My Profile → API Tokens, then set GitHub org/repo secret CLOUDFLARE_DNS_API_TOKEN to that value. Do not reuse CLOUDFLARE_API_TOKEN (Worker deploy)."
 }
 
 verify_cloudflare_dns() {
@@ -177,9 +177,15 @@ def err_txt(body):
 
 
 if token == worker:
-    print("CLOUDFLARE_DNS_API_TOKEN is the same value as CLOUDFLARE_API_TOKEN (Worker deploy token).")
-else:
-    print("CLOUDFLARE_DNS_API_TOKEN is distinct from CLOUDFLARE_API_TOKEN.")
+    print(
+        "CLOUDFLARE_DNS_API_TOKEN is the same value as CLOUDFLARE_API_TOKEN (Worker deploy token). "
+        "GitHub is not using the DNS token. Set org/repo secret CLOUDFLARE_DNS_API_TOKEN to the "
+        "My Profile token (Zone.Zone:Read + Zone.DNS:Edit). Empty DNS secrets used to fall back "
+        "to the Worker token.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+print("CLOUDFLARE_DNS_API_TOKEN is distinct from CLOUDFLARE_API_TOKEN.")
 
 verify_code, verify_body = cf("GET", "https://api.cloudflare.com/client/v4/user/tokens/verify")
 status = (verify_body.get("result") or {}).get("status")


### PR DESCRIPTION
## Summary
- Deploy Web set `CLOUDFLARE_DNS_API_TOKEN` from `secrets.CLOUDFLARE_DNS_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN`. When the DNS secret was empty, the job used the Worker token (`#worker:edit`, `#zone:read`, no `#dns:edit`) and Cloudflare 403'd `_acme-challenge` TXT creates.
- Require a distinct DNS secret and fail if the two values match.

## Test plan
- [ ] Set Cap-go **org** (or website repo) secret `CLOUDFLARE_DNS_API_TOKEN` to the **My Profile** token (Zone.Zone:Read + Zone.DNS:Edit), not the Worker token
- [ ] Re-run Deploy Web after this lands
- [ ] Logs show `CLOUDFLARE_DNS_API_TOKEN is distinct from CLOUDFLARE_API_TOKEN` and TXT probe succeeds
- [ ] Without the DNS secret, the job fails at credential check instead of silently using the Worker token


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789391429&installation_model_id=430928&pr_number=968&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F968&signature=67657a57a8d8f06735725b77cae9e67ed97dc0d2d25238bec45023253e10b2b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

