### PR TITLE
fix(web): accept iOS UDID callback without Safari cookies

### DIFF
--- a/apps/web/src/lib/tools/api.ts
+++ b/apps/web/src/lib/tools/api.ts
@@ -1,6 +1,6 @@
 import { defaultLocale, locales } from '../../services/locale'
 import { ToolInputError, createAndroidKeystoreBundle, createIosCertificateBundle, normalizeAndroidKeystoreInput, normalizeIosCertificateInput } from './signing'
-import { createUdidMobileconfig, decodePayload, encodePayload, extractPlistXml, parseUdidDevicePayload, signMobileconfig } from './udid'
+import { createUdidMobileconfig, decodePayload, encodePayload, extractPlistXmlFromDeviceBody, parseUdidDevicePayload, signMobileconfig } from './udid'
 
 export interface ToolApiEnv {
   IOS_UDID_PROFILE_SIGNING_CERT_PEM?: string
@@ -270,12 +270,12 @@ async function handleUdidCallback(request: Request): Promise<Response> {
     return redirect(routeLocale && routeLocale !== defaultLocale ? `/${routeLocale}/tools/ios-udid-finder/` : '/tools/ios-udid-finder/')
   }
 
-  const rawBody = new TextDecoder('latin1').decode(new Uint8Array(await request.arrayBuffer()))
-  const plistXml = extractPlistXml(rawBody)
+  const rawBytes = new Uint8Array(await request.arrayBuffer())
+  const plistXml = extractPlistXmlFromDeviceBody(rawBytes)
   if (!plistXml) {
     console.warn('udid_callback_reject', {
       reason: 'no_plist',
-      bodyLength: rawBody.length,
+      bodyLength: rawBytes.byteLength,
       contentType: request.headers.get('content-type') ?? '',
     })
     return webJson({ error: 'The device response did not include a plist payload.' }, 400)

--- a/apps/web/src/lib/tools/api.ts
+++ b/apps/web/src/lib/tools/api.ts
@@ -18,7 +18,6 @@ const NO_STORE_HEADERS = {
 }
 
 const UDID_RESULT_COOKIE = 'ios_udid_payload'
-const UDID_CHALLENGE_COOKIE = 'ios_udid_challenge'
 const UDID_RESULT_PATH = '/tools/ios-udid-finder/result/'
 const UDID_RESULT_API_PATH = '/api/tools/ios-udid-finder/result'
 const UDID_CALLBACK_PATH = '/api/tools/ios-udid-finder/callback'
@@ -170,8 +169,8 @@ function appendCookie(headers: Headers, name: string, value: string, path: strin
   headers.append('Set-Cookie', `${name}=${value}; Max-Age=${maxAge}; Path=${path}; SameSite=Lax${secure ? '; Secure' : ''}${httpOnly ? '; HttpOnly' : ''}`)
 }
 
-function hasMatchingChallenge(expectedChallenge: string, cookieChallenge: string | null, payloadChallenge: string | undefined): boolean {
-  return Boolean(expectedChallenge) && Boolean(cookieChallenge) && Boolean(payloadChallenge) && expectedChallenge === cookieChallenge && payloadChallenge === expectedChallenge
+function hasMatchingChallenge(expectedChallenge: string, payloadChallenge: string | undefined): boolean {
+  return Boolean(expectedChallenge) && Boolean(payloadChallenge) && expectedChallenge === payloadChallenge
 }
 
 function normalizeLocale(locale: string | null): string | null {
@@ -248,14 +247,11 @@ async function handleUdidProfile(request: Request, env: ToolApiEnv): Promise<Res
       chainPem: env.IOS_UDID_PROFILE_SIGNING_CHAIN_PEM,
     })
 
-    const secure = baseUrl.protocol === 'https:'
     const headers = new Headers({
       'Cache-Control': 'no-store',
       'Content-Disposition': 'attachment; filename="capgo-udid.mobileconfig"',
       'Content-Type': 'application/x-apple-aspen-config',
     })
-    appendCookie(headers, UDID_CHALLENGE_COOKIE, challenge, UDID_CALLBACK_PATH, 300, secure, true)
-
     return new Response(signedProfile ?? profile, {
       status: 200,
       headers,
@@ -274,27 +270,36 @@ async function handleUdidCallback(request: Request): Promise<Response> {
     return redirect(routeLocale && routeLocale !== defaultLocale ? `/${routeLocale}/tools/ios-udid-finder/` : '/tools/ios-udid-finder/')
   }
 
-  const rawBody = await request.text()
+  const rawBody = new TextDecoder('latin1').decode(new Uint8Array(await request.arrayBuffer()))
   const plistXml = extractPlistXml(rawBody)
   if (!plistXml) {
+    console.warn('udid_callback_reject', {
+      reason: 'no_plist',
+      bodyLength: rawBody.length,
+      contentType: request.headers.get('content-type') ?? '',
+    })
     return webJson({ error: 'The device response did not include a plist payload.' }, 400)
   }
 
   const payload = parseUdidDevicePayload(plistXml)
   const expectedChallenge = requestUrl.searchParams.get('challenge') ?? ''
-  const cookieChallenge = getCookie(request, UDID_CHALLENGE_COOKIE)
 
-  if (!hasMatchingChallenge(expectedChallenge, cookieChallenge, payload.challenge)) {
+  if (!hasMatchingChallenge(expectedChallenge, payload.challenge)) {
+    console.warn('udid_callback_reject', {
+      reason: 'challenge_mismatch',
+      hasUrlChallenge: Boolean(expectedChallenge),
+      hasPayloadChallenge: Boolean(payload.challenge),
+    })
     return webJson({ error: 'The device response challenge did not match the active UDID session.' }, 400)
   }
 
+  const encodedPayload = encodePayload(payload)
   const secure = requestUrl.protocol === 'https:'
   const headers = new Headers({
     ...NO_STORE_HEADERS,
-    Location: getUdidResultPath(routeLocale),
+    Location: `${getUdidResultPath(routeLocale)}?p=${encodedPayload}`,
   })
-  appendCookie(headers, UDID_RESULT_COOKIE, encodePayload(payload), UDID_RESULT_API_PATH, 300, secure, true)
-  appendCookie(headers, UDID_CHALLENGE_COOKIE, '', UDID_CALLBACK_PATH, 0, secure, true)
+  appendCookie(headers, UDID_RESULT_COOKIE, encodedPayload, UDID_RESULT_API_PATH, 300, secure, true)
 
   return new Response(null, {
     status: 302,

--- a/apps/web/src/lib/tools/udid.ts
+++ b/apps/web/src/lib/tools/udid.ts
@@ -150,11 +150,6 @@ export async function signMobileconfig(profileXml: string, credentials?: UdidSig
   }
 }
 
-export function extractPlistXml(rawBody: string): string | null {
-  const match = rawBody.match(/<plist[\s\S]*<\/plist>/i)
-  return match ? match[0] : null
-}
-
 export function extractPlistXmlFromDeviceBody(rawBytes: Uint8Array): string | null {
   const latin1 = new TextDecoder('latin1').decode(rawBytes)
   const match = latin1.match(/<plist[\s\S]*<\/plist>/i)

--- a/apps/web/src/lib/tools/udid.ts
+++ b/apps/web/src/lib/tools/udid.ts
@@ -164,7 +164,7 @@ export function parseUdidDevicePayload(plistXml: string): UdidDevicePayload {
   const matcher = /<key>([\s\S]*?)<\/key>\s*(?:<string>([\s\S]*?)<\/string>|<integer>([\s\S]*?)<\/integer>|<data>([\s\S]*?)<\/data>|<(true|false)\s*\/>)/gi
 
   for (const match of plistXml.matchAll(matcher)) {
-    const key = decodeXml((match[1] || '').trim())
+    const key = decodeXml((match[1] || '').trim()).toUpperCase()
     const stringValue = match[2] ?? match[3] ?? match[4] ?? match[5] ?? ''
     values[key] = decodeXml(stringValue.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1').trim())
   }

--- a/apps/web/src/lib/tools/udid.ts
+++ b/apps/web/src/lib/tools/udid.ts
@@ -155,6 +155,13 @@ export function extractPlistXml(rawBody: string): string | null {
   return match ? match[0] : null
 }
 
+export function extractPlistXmlFromDeviceBody(rawBytes: Uint8Array): string | null {
+  const latin1 = new TextDecoder('latin1').decode(rawBytes)
+  const match = latin1.match(/<plist[\s\S]*<\/plist>/i)
+  if (!match || match.index == null) return null
+  return new TextDecoder('utf-8').decode(rawBytes.subarray(match.index, match.index + match[0].length))
+}
+
 function decodeXml(value: string): string {
   return value.replaceAll('&lt;', '<').replaceAll('&gt;', '>').replaceAll('&quot;', '"').replaceAll('&apos;', "'").replaceAll('&amp;', '&')
 }

--- a/apps/web/src/pages/tools/ios-udid-finder/result.astro
+++ b/apps/web/src/pages/tools/ios-udid-finder/result.astro
@@ -127,10 +127,16 @@ const signingDocsHref = getRelativeLocaleUrl(Astro.locals.locale, 'docs/builder/
     if (!value) return null
 
     try {
-      const json = atob(value.replaceAll('-', '+').replaceAll('_', '/'))
-      const parsed = JSON.parse(json) as Record<string, unknown>
+      const bytes = Uint8Array.from(atob(value.replaceAll('-', '+').replaceAll('_', '/')), (char) => char.charCodeAt(0))
+      const parsed = JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>
       if (!parsed || typeof parsed !== 'object' || typeof parsed.udid !== 'string' || !parsed.udid) {
         return null
+      }
+
+      const url = new URL(window.location.href)
+      if (url.searchParams.has('p')) {
+        url.searchParams.delete('p')
+        window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`)
       }
 
       return {

--- a/apps/web/src/pages/tools/ios-udid-finder/result.astro
+++ b/apps/web/src/pages/tools/ios-udid-finder/result.astro
@@ -89,7 +89,8 @@ const signingDocsHref = getRelativeLocaleUrl(Astro.locals.locale, 'docs/builder/
 
     const button = document.createElement('button')
     button.type = 'button'
-    button.className = 'inline-flex items-center justify-center rounded-2xl border border-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-fuchsia-300/60 hover:bg-white/5'
+    button.className =
+      'inline-flex items-center justify-center rounded-2xl border border-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-fuchsia-300/60 hover:bg-white/5'
     button.dataset.copyValue = value
     button.textContent = 'Copy'
 
@@ -105,9 +106,7 @@ const signingDocsHref = getRelativeLocaleUrl(Astro.locals.locale, 'docs/builder/
 
     rowsRoot.replaceChildren()
 
-    const rows = fields
-      .map(([label, key]) => [label, payload?.[key] ?? ''] as const)
-      .filter(([, value]) => Boolean(value))
+    const rows = fields.map(([label, key]) => [label, payload?.[key] ?? ''] as const).filter(([, value]) => Boolean(value))
 
     if (payload?.udid && rows.length > 0) {
       document.title = 'iOS UDID Finder Result | Device Identifier Received'
@@ -123,7 +122,35 @@ const signingDocsHref = getRelativeLocaleUrl(Astro.locals.locale, 'docs/builder/
     emptyState.classList.remove('hidden')
   }
 
+  function payloadFromQuery(): Record<string, string> | null {
+    const value = new URLSearchParams(window.location.search).get('p')
+    if (!value) return null
+
+    try {
+      const json = atob(value.replaceAll('-', '+').replaceAll('_', '/'))
+      const parsed = JSON.parse(json) as Record<string, unknown>
+      if (!parsed || typeof parsed !== 'object' || typeof parsed.udid !== 'string' || !parsed.udid) {
+        return null
+      }
+
+      return {
+        udid: String(parsed.udid ?? ''),
+        deviceName: String(parsed.deviceName ?? ''),
+        product: String(parsed.product ?? ''),
+        version: String(parsed.version ?? ''),
+        serial: String(parsed.serial ?? ''),
+        imei: String(parsed.imei ?? ''),
+        meid: String(parsed.meid ?? ''),
+      }
+    } catch {
+      return null
+    }
+  }
+
   async function loadPayload(): Promise<Record<string, string> | null> {
+    const fromQuery = payloadFromQuery()
+    if (fromQuery) return fromQuery
+
     try {
       const response = await fetch(UDID_RESULT_ENDPOINT, {
         credentials: 'same-origin',
@@ -135,7 +162,7 @@ const signingDocsHref = getRelativeLocaleUrl(Astro.locals.locale, 'docs/builder/
       const data = await response.json()
       if (!data || typeof data !== 'object' || !('payload' in data)) return null
       const payload = data.payload
-      return payload && typeof payload === 'object' ? payload as Record<string, string> : null
+      return payload && typeof payload === 'object' ? (payload as Record<string, string>) : null
     } catch {
       return null
     }
@@ -174,29 +201,26 @@ const signingDocsHref = getRelativeLocaleUrl(Astro.locals.locale, 'docs/builder/
 
   function bindCopyButtons(): void {
     document.querySelectorAll<HTMLButtonElement>('[data-copy-value]').forEach((button) => {
-      button.addEventListener(
-        'click',
-        async () => {
-          const value = button.dataset.copyValue
-          if (!value) return
+      button.addEventListener('click', async () => {
+        const value = button.dataset.copyValue
+        if (!value) return
 
-          const original = button.textContent || 'Copy'
+        const original = button.textContent || 'Copy'
 
-          try {
-            await copyText(value)
-            button.textContent = 'Copied'
-            announceCopyStatus('Value copied to clipboard.')
-          } catch {
-            button.textContent = 'Copy failed'
-            announceCopyStatus('Copy to clipboard failed.')
-          }
+        try {
+          await copyText(value)
+          button.textContent = 'Copied'
+          announceCopyStatus('Value copied to clipboard.')
+        } catch {
+          button.textContent = 'Copy failed'
+          announceCopyStatus('Copy to clipboard failed.')
+        }
 
-          window.setTimeout(() => {
-            button.textContent = original
-            announceCopyStatus('')
-          }, 1600)
-        },
-      )
+        window.setTimeout(() => {
+          button.textContent = original
+          announceCopyStatus('')
+        }, 1600)
+      })
     })
   }
 

--- a/apps/web/src/pages/tools/ios-udid-finder/result.astro
+++ b/apps/web/src/pages/tools/ios-udid-finder/result.astro
@@ -21,7 +21,7 @@ const signingDocsHref = getRelativeLocaleUrl(Astro.locals.locale, 'docs/builder/
         <p class="text-sm font-semibold tracking-[0.25em] text-fuchsia-300 uppercase">Device response</p>
         <h1 class="mt-3 text-4xl font-bold text-white">iOS UDID Finder result</h1>
         <p id="copy-status" class="sr-only" aria-live="polite"></p>
-        <p id="result-description" class="mt-4 text-sm leading-7 text-slate-300">
+        <p id="result-description" class="mt-4 text-sm leading-7 text-slate-300" aria-live="polite">
           Waiting for a device response. If you just installed the profile, this page will populate automatically after the redirect completes.
         </p>
         <div id="result-rows" class="mt-8 space-y-4"></div>


### PR DESCRIPTION
## Summary
- iOS Settings POSTs the device identity to `/api/tools/ios-udid-finder/callback` and does not send Safari cookies, so requiring `ios_udid_challenge` always returned 400 after a successful profile install.
- Match the URL `challenge` against the plist `CHALLENGE` only, keep the signed CMS body readable as latin1, and pass the encoded payload on the result redirect so the page still renders when Settings and Safari do not share cookies.

## Test plan
- [ ] After web deploy, open `/tools/ios-udid-finder/` on a real iPhone
- [ ] Download and install the Capgo Device Identifier profile
- [ ] Confirm install no longer shows `Profile Installation Failed` / HTTP 400
- [ ] Confirm the result page shows UDID and device details


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789476269&installation_model_id=430928&pr_number=970&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F970&signature=424ef07d43037486f9dd63b968f5fabff2447b5d4f2584ac68034bf2807d0c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS UDID detection for device responses with varied formatting.
  * Fixed challenge validation to reliably match submitted device data.
  * Improved handling of missing or invalid device information.
* **Enhancements**
  * Results now load more reliably after device callbacks.
  * Device details are normalized for consistent display.
  * Browser navigation is cleaned up after results are received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->