### PR TITLE
feat: track registration device metadata

### DIFF
--- a/apps/web/src/pages/register.astro
+++ b/apps/web/src/pages/register.astro
@@ -151,6 +151,7 @@ const content = {
 </Layout>
 
 <script>
+  import { getRegistrationDevice } from '@/services/registration-device'
   import { getRemoteConfig, useSupabase } from '@/services/supabase'
   import Toastify from 'toastify-js'
 
@@ -229,6 +230,7 @@ const content = {
       }).showToast()
     }
     submitButton.disabled = true
+    const registrationDevice = getRegistrationDevice(navigator.userAgent, navigator.maxTouchPoints)
     const { data: user, error } = await supabase.auth.signUp({
       email: email.value,
       password: password.value,
@@ -237,6 +239,7 @@ const content = {
         data: {
           first_name: firstName.value,
           last_name: lastName.value,
+          ...registrationDevice,
         },
       },
     })

--- a/apps/web/src/services/registration-device.ts
+++ b/apps/web/src/services/registration-device.ts
@@ -2,7 +2,7 @@ import Bowser from 'bowser'
 
 export function getRegistrationDevice(userAgent: string, maxTouchPoints: number) {
   const parsed = Bowser.parse(userAgent)
-  const isIPadOS = /Macintosh/.test(userAgent) && maxTouchPoints > 1
+  const isIPadOS = /iPad/.test(userAgent) || (/Macintosh/.test(userAgent) && maxTouchPoints > 1)
 
   return {
     registration_device_type: isIPadOS ? 'tablet' : (parsed.platform.type ?? 'unknown'),

--- a/apps/web/src/services/registration-device.ts
+++ b/apps/web/src/services/registration-device.ts
@@ -1,0 +1,12 @@
+import Bowser from 'bowser'
+
+export function getRegistrationDevice(userAgent: string, maxTouchPoints: number) {
+  const parsed = Bowser.parse(userAgent)
+  const isIPadOS = /Macintosh/.test(userAgent) && maxTouchPoints > 1
+
+  return {
+    registration_device_type: isIPadOS ? 'tablet' : (parsed.platform.type ?? 'unknown'),
+    registration_os: isIPadOS ? 'iPadOS' : (parsed.os.name ?? 'unknown'),
+    registration_browser: parsed.browser.name ?? 'unknown',
+  }
+}

--- a/apps/web/test/registration-device.test.js
+++ b/apps/web/test/registration-device.test.js
@@ -11,6 +11,16 @@ test('classifies touch-capable Macintosh user agents as iPadOS', () => {
   })
 })
 
+test('classifies default iPad user agents as iPadOS', () => {
+  const userAgent = 'Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1'
+
+  expect(getRegistrationDevice(userAgent, 5)).toEqual({
+    registration_device_type: 'tablet',
+    registration_os: 'iPadOS',
+    registration_browser: 'Safari',
+  })
+})
+
 test('keeps non-touch Macintosh user agents classified as macOS', () => {
   const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15'
 

--- a/apps/web/test/registration-device.test.js
+++ b/apps/web/test/registration-device.test.js
@@ -1,0 +1,22 @@
+import { expect, test } from 'bun:test'
+import { getRegistrationDevice } from '../src/services/registration-device'
+
+test('classifies touch-capable Macintosh user agents as iPadOS', () => {
+  const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15'
+
+  expect(getRegistrationDevice(userAgent, 5)).toEqual({
+    registration_device_type: 'tablet',
+    registration_os: 'iPadOS',
+    registration_browser: 'Safari',
+  })
+})
+
+test('keeps non-touch Macintosh user agents classified as macOS', () => {
+  const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15'
+
+  expect(getRegistrationDevice(userAgent, 0)).toEqual({
+    registration_device_type: 'desktop',
+    registration_os: 'macOS',
+    registration_browser: 'Safari',
+  })
+})

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@tailwindcss/vite": "^4.3.2",
         "astro": "7.0.3",
         "astro-icon": "1.1.5",
+        "bowser": "^2.14.1",
         "github-slugger": "^2.0.0",
         "glob": "^13.0.6",
         "marked": "^18.0.6",
@@ -827,6 +828,8 @@
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@tailwindcss/vite": "^4.3.2",
     "astro": "7.0.3",
     "astro-icon": "1.1.5",
+    "bowser": "^2.14.1",
     "github-slugger": "^2.0.0",
     "glob": "^13.0.6",
     "marked": "^18.0.6",


### PR DESCRIPTION
## Summary
- classify the registration browser, OS, and device type with Bowser
- distinguish iPadOS from macOS using touch capability
- store normalized registration metadata in Supabase user metadata
- add focused regression coverage

## Validation
- `bun test apps/web/test/registration-device.test.js`
- `bun run ci:verify:web`

## Scope
- 51 changed lines
- No rendered UI changes; visual diff not applicable

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789569401&installation_model_id=430928&pr_number=973&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F973&signature=51fef41b10cbbc78a120510dea33eba53d1b711c8c0b700d322a4c6ea5bc1a93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->