### PR TITLE
fix(web): escape blog heading ids for querySelector

### DIFF
--- a/apps/web/src/pages/blog/[slug].astro
+++ b/apps/web/src/pages/blog/[slug].astro
@@ -289,6 +289,9 @@ content['ldJSON'] = createNewsArticleLdJson(Astro.locals.runtimeConfig.public, {
 
 <script>
   document.addEventListener('DOMContentLoaded', () => {
+    // Heading slugs may start with a digit (e.g. "1-foo"); getElementById avoids invalid CSS selectors.
+    const getTocLink = (headingId: string) => document.getElementById(`${headingId}-link`)
+
     const observeArticleTitles = () => {
       const headings = document.querySelectorAll('h1,h2,h3,h4,h5,h6')
       let activeHeading = null
@@ -296,7 +299,7 @@ content['ldJSON'] = createNewsArticleLdJson(Astro.locals.runtimeConfig.public, {
       for (let i = 0; i < headings.length; i++) {
         const heading = headings[i]
         const tmp = heading.getAttribute('id')
-        if (tmp) document.querySelector(`#${tmp}-link`)?.classList.remove('text-white')
+        if (tmp) getTocLink(tmp)?.classList.remove('text-white')
         const rect = heading.getBoundingClientRect()
         if (rect.top <= 50) activeHeading = heading
         else if (rect.top > 50 && activeHeading) break
@@ -305,7 +308,7 @@ content['ldJSON'] = createNewsArticleLdJson(Astro.locals.runtimeConfig.public, {
       if (activeHeading) {
         const tmp = activeHeading.getAttribute('id')
         if (tmp) {
-          document.querySelector(`#${tmp}-link`)?.classList.add('text-white')
+          getTocLink(tmp)?.classList.add('text-white')
           history.replaceState(null, '', `#${tmp}`)
         }
       }

--- a/apps/web/test/blog-toc-link.test.js
+++ b/apps/web/test/blog-toc-link.test.js
@@ -1,0 +1,22 @@
+import { expect, test } from 'bun:test'
+
+// Blog TOC scroll used querySelector(`#${headingId}-link`). IDs that start with a digit
+// are invalid CSS selectors and throw DOMException (see PostHog error tracking).
+// Fix: use document.getElementById(`${headingId}-link`) instead.
+
+const POSTHOG_INVALID_SELECTORS = [
+  '#1-continuous-integrationcontinuous-deployment-cicd-link',
+  '#2021-android-guide-firebase-crashlytics---custom-crash--link',
+]
+
+test('posthog-reported blog toc selectors start with a digit after #', () => {
+  for (const selector of POSTHOG_INVALID_SELECTORS) {
+    expect(selector.startsWith('#')).toBe(true)
+    expect(/^\#[0-9]/.test(selector)).toBe(true)
+  }
+})
+
+test('toc link element ids match heading slug plus -link suffix', () => {
+  const headingId = '1-continuous-integrationcontinuous-deployment-cicd'
+  expect(`${headingId}-link`).toBe('1-continuous-integrationcontinuous-deployment-cicd-link')
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Blog TOC scroll highlighting used `document.querySelector('#${headingId}-link')`. When a heading slug starts with a digit, that selector is invalid CSS and throws:

```
DOMException: SyntaxError: Failed to execute 'querySelector' on 'Document': '#1-continuous-integrationcontinuous-deployment-cicd-link' is not a valid selector.
```

### PostHog evidence (last 7 days)

| Occurrences | Users | Selector | Page |
|-------------|-------|----------|------|
| 1770 | 113 | `#1-continuous-integrationcontinuous-deployment-cicd-link` | [/blog/cross-platform-messaging-apps/](https://capgo.app/blog/cross-platform-messaging-apps/) |
| 245 | — | `#2021-android-guide-firebase-crashlytics---custom-crash--link` | [/blog/app-store-age-ratings-guide/](https://capgo.app/blog/app-store-age-ratings-guide/) |

- [PostHog issue 019f408f](https://eu.posthog.com/project/72308/error_tracking/019f408f-b94c-7862-bd45-ebbceeee5d13)
- [PostHog issue 019f4609](https://eu.posthog.com/project/72308/error_tracking/019f4609-2927-7e12-b080-21cbdbb3a01e)

## Fix

In `apps/web/src/pages/blog/[slug].astro`, replace `querySelector('#…')` with `getElementById('…')` for TOC link lookup. `getElementById` does not require CSS escaping, so digit-leading heading ids work correctly.

Heading slugs and hash URLs are unchanged — no redirect or slug normalization needed.

## Tests

Added `apps/web/test/blog-toc-link.test.js` documenting the invalid selector pattern from PostHog.

```bash
cd apps/web && bun test test/blog-toc-link.test.js
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26c7125e-a5b1-47c7-909a-490d18806877?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26c7125e-a5b1-47c7-909a-490d18806877&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790104918&installation_model_id=430928&pr_number=982&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F982&signature=6f51e439c4a48a2aebc8ed206158e009917a883c50c0a2b9c78416e6ff9e3f6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed blog table-of-contents navigation for headings whose slugs begin with numbers.
  * Active-link highlighting now works reliably when selecting or removing TOC links.

* **Tests**
  * Added coverage for numeric heading slugs and table-of-contents link IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->