### PR TITLE
fix(web): add schema.org @context to blog JSON-LD and throttle TOC replaceState

### DIFF
--- a/apps/web/src/components/SEO.astro
+++ b/apps/web/src/components/SEO.astro
@@ -3,6 +3,7 @@ import { baseDomain, structuredData } from '@/config/app'
 import { appName } from '@/constants'
 import m from '@/copy/messages'
 import { generateAlternateVersions } from '@/lib/alternateVersions'
+import { ensureLdJsonContext } from '@/lib/ldJson'
 
 const rawLocale = (Astro.locals.locale || 'en').toString().toLowerCase()
 // Paraglide message functions use a narrower locale union than the app router.
@@ -188,4 +189,4 @@ const titleFix = titleString || (imageUrl.split('/').pop() || '.').split('.')[0]
 <meta name="twitter:app:name:googleplay" content={appName} />
 
 <!-- @ts-ignore -->
-<script is:inline hid="seo-schema-graph" type="application/ld+json" set:html={JSON.stringify(ldJSON)} />
+<script is:inline hid="seo-schema-graph" type="application/ld+json" set:html={JSON.stringify(ensureLdJsonContext(ldJSON))} />

--- a/apps/web/src/lib/ldJson.ts
+++ b/apps/web/src/lib/ldJson.ts
@@ -25,6 +25,26 @@ export type LdJsonType = WithContext<Organization | Person | NewsArticle | WebPa
 // Type for graph items (Thing without @context requirement)
 export type GraphItem = Thing
 
+const SCHEMA_ORG_CONTEXT = 'https://schema.org' as const
+
+/**
+ * Ensure ld+json has schema.org @context before serialization.
+ * Handles standalone schemas, @graph bundles, and arrays.
+ */
+export function ensureLdJsonContext(data: unknown): unknown {
+  if (data == null || typeof data !== 'object') return data
+
+  if (Array.isArray(data)) return data.map((item) => ensureLdJsonContext(item))
+
+  const obj = data as Record<string, unknown>
+  if (obj['@context']) return data
+
+  return {
+    '@context': SCHEMA_ORG_CONTEXT,
+    ...obj,
+  }
+}
+
 /**
  * Create a complete Organization schema for Capgo
  */

--- a/apps/web/src/pages/blog/[slug].astro
+++ b/apps/web/src/pages/blog/[slug].astro
@@ -292,6 +292,20 @@ content['ldJSON'] = createNewsArticleLdJson(Astro.locals.runtimeConfig.public, {
     // Heading slugs may start with a digit (e.g. "1-foo"); getElementById avoids invalid CSS selectors.
     const getTocLink = (headingId: string) => document.getElementById(`${headingId}-link`)
 
+    let currentTocHash = window.location.hash
+    let hashUpdateTimer: ReturnType<typeof setTimeout> | undefined
+
+    const scheduleHashUpdate = (hash: string) => {
+      if (hash === currentTocHash) return
+      if (hashUpdateTimer) clearTimeout(hashUpdateTimer)
+      hashUpdateTimer = setTimeout(() => {
+        hashUpdateTimer = undefined
+        if (hash === currentTocHash) return
+        currentTocHash = hash
+        history.replaceState(null, '', hash)
+      }, 150)
+    }
+
     const observeArticleTitles = () => {
       const headings = document.querySelectorAll('h1,h2,h3,h4,h5,h6')
       let activeHeading = null
@@ -309,7 +323,7 @@ content['ldJSON'] = createNewsArticleLdJson(Astro.locals.runtimeConfig.public, {
         const tmp = activeHeading.getAttribute('id')
         if (tmp) {
           getTocLink(tmp)?.classList.add('text-white')
-          history.replaceState(null, '', `#${tmp}`)
+          scheduleHashUpdate(`#${tmp}`)
         }
       }
     }

--- a/apps/web/test/ld-json-context.test.js
+++ b/apps/web/test/ld-json-context.test.js
@@ -1,0 +1,54 @@
+import { expect, test } from 'bun:test'
+import { createLdJsonGraph, createNewsArticleLdJson, ensureLdJsonContext } from '../src/lib/ldJson.ts'
+
+const mockConfig = {
+  brand: 'Capgo',
+  blog_title: 'Capgo Blog',
+  blog_description: 'Capgo blog',
+  blog_keywords: 'capacitor',
+  baseUrl: 'https://capgo.app',
+  baseApiUrl: 'https://api.capgo.app',
+}
+
+const articleOptions = {
+  title: 'Test Article',
+  description: 'Test description',
+  url: 'https://capgo.app/blog/test-article/',
+  datePublished: '2024-01-01T00:00:00.000Z',
+  dateModified: '2024-01-02T00:00:00.000Z',
+  author: 'Capgo',
+}
+
+test('createNewsArticleLdJson returns NewsArticle without @context', () => {
+  const article = createNewsArticleLdJson(mockConfig, articleOptions)
+  expect(article['@context']).toBeUndefined()
+  expect(article['@type']).toBe('NewsArticle')
+})
+
+test('ensureLdJsonContext adds schema.org @context to standalone schemas', () => {
+  const article = createNewsArticleLdJson(mockConfig, articleOptions)
+  const normalized = ensureLdJsonContext(article)
+
+  expect(normalized['@context']).toBe('https://schema.org')
+  expect(normalized['@type']).toBe('NewsArticle')
+})
+
+test('ensureLdJsonContext preserves existing @context on graph ld+json', () => {
+  const graph = createLdJsonGraph(
+    mockConfig,
+    { '@type': 'WebPage', name: 'Test' },
+    { includeOrganization: true },
+  )
+
+  const normalized = ensureLdJsonContext(graph)
+  expect(normalized['@context']).toBe('https://schema.org')
+  expect(normalized['@graph']).toBeDefined()
+})
+
+test('serialized blog ld+json includes @context', () => {
+  const article = createNewsArticleLdJson(mockConfig, articleOptions)
+  const json = JSON.stringify(ensureLdJsonContext(article))
+
+  expect(json).toContain('"@context":"https://schema.org"')
+  expect(json).toContain('"@type":"NewsArticle"')
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two PostHog easy wins on the marketing site.

### Win 1: Missing `@context` on blog JSON-LD

**PostHog issue:** [TypeError `undefined is not an object (evaluating 'r["@context"].toLowerCase')`](https://eu.posthog.com/project/72308/error_tracking/019f3d57-35e9-7891-b95a-8e15e3753fe2) (~122 occurrences / 83 users / 14d on blog posts, e.g. `/blog/linear-gradient-react-native/`).

Live HTML confirmed the bug: `<script type="application/ld+json">` for `NewsArticle` had `@type` but **no** `@context`. Third-party/Safari parsers call `@context.toLowerCase()` and throw; PostHog captures it on the page.

**Fix:** Added `ensureLdJsonContext()` in `apps/web/src/lib/ldJson.ts` and applied it centrally in `SEO.astro` before `JSON.stringify`, so all ld+json emitted via SEO gets `https://schema.org` context — not only blog `NewsArticle`, but also standalone schemas like plugin pages that bypass `createLdJsonGraph`.

### Win 2: Debounce blog TOC `history.replaceState`

Blog scroll handler called `history.replaceState(null, '', `#${tmp}`)` on every scroll frame. That spams the History API (Safari limits ~100/10s).

**Fix:** Only call `replaceState` when the hash actually changed, debounced at 150ms via `scheduleHashUpdate()`.

## Testing

- `bun test apps/web/test/ld-json-context.test.js` — verifies `ensureLdJsonContext` adds `@context` to standalone schemas and preserves existing graph context
- Existing `apps/web/test/blog-toc-link.test.js` still passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46075093-84df-49b8-8e3e-bee4f4c1e21f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46075093-84df-49b8-8e3e-bee4f4c1e21f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790108757&installation_model_id=430928&pr_number=983&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F983&signature=cd5f9bf6d7e590a049da9ec561279470f60c9c600c03c33af59e44fa54816d17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved structured data output by consistently including the appropriate schema context in JSON-LD metadata.
  - Preserved existing schema context and supported nested structured data and graph-based schemas.
  - Smoothed blog table-of-contents navigation by reducing rapid URL hash updates and skipping duplicate changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->