### PR TITLE
fix(web): guard Header cookie reads against SecurityError

### DIFF
--- a/apps/web/src/components/Header.astro
+++ b/apps/web/src/components/Header.astro
@@ -839,8 +839,12 @@ const locale = Astro.locals.locale
   const websitePaidUserCookieName = 'capgo_paid_user'
   let previousHeaderPaidAccess: boolean | undefined
 
-  function hasWebsitePaidUserCookie() {
-    return document.cookie.split(';').some((cookie) => cookie.trim() === `${websitePaidUserCookieName}=1`)
+  function safeHasWebsitePaidUserCookie(): boolean {
+    try {
+      return document.cookie.split(';').some((cookie) => cookie.trim() === `${websitePaidUserCookieName}=1`)
+    } catch {
+      return false
+    }
   }
 
   function announceHeaderAuthLinks(hasPaidAccess: boolean) {
@@ -851,16 +855,20 @@ const locale = Astro.locals.locale
   }
 
   function syncHeaderAuthLinks() {
-    const hasPaidAccess = hasWebsitePaidUserCookie()
-    document.querySelectorAll('[data-guest-auth-link]').forEach((element) => {
-      if (hasPaidAccess) element.setAttribute('hidden', '')
-      else element.removeAttribute('hidden')
-    })
-    document.querySelectorAll('[data-console-auth-link]').forEach((element) => {
-      if (hasPaidAccess) element.removeAttribute('hidden')
-      else element.setAttribute('hidden', '')
-    })
-    announceHeaderAuthLinks(hasPaidAccess)
+    try {
+      const hasPaidAccess = safeHasWebsitePaidUserCookie()
+      document.querySelectorAll('[data-guest-auth-link]').forEach((element) => {
+        if (hasPaidAccess) element.setAttribute('hidden', '')
+        else element.removeAttribute('hidden')
+      })
+      document.querySelectorAll('[data-console-auth-link]').forEach((element) => {
+        if (hasPaidAccess) element.removeAttribute('hidden')
+        else element.setAttribute('hidden', '')
+      })
+      announceHeaderAuthLinks(hasPaidAccess)
+    } catch {
+      // Best-effort: restricted browsing contexts can block cookie/DOM access.
+    }
   }
 
   menuToggle?.addEventListener('click', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens the marketing site header client script against `SecurityError` when `document.cookie` is unreadable in restricted browsing contexts (sandboxed/opaque documents, strict privacy modes).

PostHog error tracking showed uncaught exceptions on `https://capgo.app/` from cookie/storage access in homepage sessions:
- https://eu.posthog.com/project/72308/error_tracking/019eda5c-7246-71c0-8d7e-8d36b3bbc1cb (`SecurityError: Failed to read the 'localStorage' property…`)

Capgo-owned path: `apps/web/src/components/Header.astro` called `document.cookie` unsafely in `hasWebsitePaidUserCookie()`, invoked from `syncHeaderAuthLinks()` on init and on `focus` / `visibilitychange`.

## Changes

- Add `safeHasWebsitePaidUserCookie()` — wraps cookie read in `try/catch`; returns `false` on any throw (including `SecurityError`).
- Wrap `syncHeaderAuthLinks()` in `try/catch` so guest/console link sync stays best-effort and never throws.
- Menu, submenu, and `matchMedia` behavior unchanged when cookies are readable.

## Testing

- `bun x astro check` in `apps/web` (pending CI)
- No visual/layout changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfad753c-cedb-4c78-9a94-c72976dec9dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfad753c-cedb-4c78-9a94-c72976dec9dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790117941&installation_model_id=430928&pr_number=984&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F984&signature=6dfc38ec99524f31b5fb536c9829c803118d924875ea20232962f4932ddc0450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

