### PR TITLE
fix(web): prevent register page crash when Supabase config is not ready

### DIFF
--- a/apps/web/src/pages/register.astro
+++ b/apps/web/src/pages/register.astro
@@ -171,12 +171,20 @@ const content = {
 
   configReady
     .then((cfg) => {
-      if (!isSubmitting && submitButton && isSupabaseConfigured(cfg)) {
-        submitButton.disabled = false
+      if (isSupabaseConfigured(cfg)) {
+        if (!isSubmitting && submitButton) {
+          submitButton.disabled = false
+        }
+        return
+      }
+      if (!isSubmitting) {
+        showConfigError()
       }
     })
     .catch(() => {
-      // Keep submit disabled when remote config cannot be loaded.
+      if (!isSubmitting) {
+        showConfigError()
+      }
     })
 
   function showConfigError() {
@@ -210,7 +218,7 @@ const content = {
 
   form?.addEventListener('submit', async (e) => {
     e.preventDefault()
-    if (submitButton.disabled) return
+    if (isSubmitting || submitButton.disabled) return
 
     // Validate email format
     if (!isValidEmail(email.value.trim())) {
@@ -242,8 +250,12 @@ const content = {
       }).showToast()
     }
 
+    isSubmitting = true
+    submitButton.disabled = true
+
     const cfg = await configReady
     if (!isSupabaseConfigured(cfg)) {
+      isSubmitting = false
       return showConfigError()
     }
 
@@ -251,11 +263,24 @@ const content = {
     try {
       supabase = useSupabase()
     } catch {
+      isSubmitting = false
       return showConfigError()
     }
     const { data: deleted, error: errorDeleted } = await supabase.rpc('is_not_deleted', { email_check: email.value })
-    if (errorDeleted) console.error(errorDeleted)
+    if (errorDeleted) {
+      console.error(errorDeleted)
+      isSubmitting = false
+      submitButton.disabled = false
+      return Toastify({
+        text: 'Unable to verify account status. Please try again.',
+        style: {
+          background: '#e7000b',
+        },
+      }).showToast()
+    }
     if (!deleted) {
+      isSubmitting = false
+      submitButton.disabled = false
       return Toastify({
         text: 'Account is in error, please contact support at support@capgo.app',
         style: {
@@ -263,8 +288,6 @@ const content = {
         },
       }).showToast()
     }
-    isSubmitting = true
-    submitButton.disabled = true
     const registrationDevice = getRegistrationDevice(navigator.userAgent, navigator.maxTouchPoints)
     const { data: user, error } = await supabase.auth.signUp({
       email: email.value,

--- a/apps/web/src/pages/register.astro
+++ b/apps/web/src/pages/register.astro
@@ -152,7 +152,7 @@ const content = {
 
 <script>
   import { getRegistrationDevice } from '@/services/registration-device'
-  import { getRemoteConfig, useSupabase } from '@/services/supabase'
+  import { getRemoteConfig, isSupabaseConfigured, useSupabase } from '@/services/supabase'
   import Toastify from 'toastify-js'
 
   const form = document.getElementById('registerForm')
@@ -162,14 +162,38 @@ const content = {
   const password = document.getElementById('password') as HTMLInputElement
   const submitButton = form?.querySelector('button[type="submit"]') as HTMLButtonElement
 
+  const configReady = getRemoteConfig()
+  let isSubmitting = false
+
+  if (submitButton) {
+    submitButton.disabled = true
+  }
+
+  configReady
+    .then((cfg) => {
+      if (!isSubmitting && submitButton && isSupabaseConfigured(cfg)) {
+        submitButton.disabled = false
+      }
+    })
+    .catch(() => {
+      // Keep submit disabled when remote config cannot be loaded.
+    })
+
+  function showConfigError() {
+    return Toastify({
+      text: 'Unable to load registration service. Please refresh the page and try again.',
+      style: {
+        background: '#e7000b',
+      },
+    }).showToast()
+  }
+
   function getCaptchaId() {
     if (!(window as any).turnstile) {
       return undefined
     }
     return (window as any).turnstile.getResponse() as string
   }
-
-  getRemoteConfig()
 
   // Validation functions
   function isValidEmail(email: string): boolean {
@@ -218,7 +242,17 @@ const content = {
       }).showToast()
     }
 
-    const supabase = useSupabase()
+    const cfg = await configReady
+    if (!isSupabaseConfigured(cfg)) {
+      return showConfigError()
+    }
+
+    let supabase
+    try {
+      supabase = useSupabase()
+    } catch {
+      return showConfigError()
+    }
     const { data: deleted, error: errorDeleted } = await supabase.rpc('is_not_deleted', { email_check: email.value })
     if (errorDeleted) console.error(errorDeleted)
     if (!deleted) {
@@ -229,6 +263,7 @@ const content = {
         },
       }).showToast()
     }
+    isSubmitting = true
     submitButton.disabled = true
     const registrationDevice = getRegistrationDevice(navigator.userAgent, navigator.maxTouchPoints)
     const { data: user, error } = await supabase.auth.signUp({
@@ -244,6 +279,7 @@ const content = {
       },
     })
     if (error) {
+      isSubmitting = false
       submitButton.disabled = false
       console.error('Supabase signup error', error)
       return Toastify({
@@ -254,11 +290,13 @@ const content = {
       }).showToast()
     }
     if (error || !user) {
+      isSubmitting = false
       submitButton.disabled = false
       return
     }
     const session = await supabase.auth.getSession()
     if (session.error) {
+      isSubmitting = false
       submitButton.disabled = false
       console.error('Supabase session error', session.error)
       return Toastify({

--- a/apps/web/src/services/supabase.ts
+++ b/apps/web/src/services/supabase.ts
@@ -31,11 +31,15 @@ const getLocalConfig = (): CapgoConfig => {
 
 let config: CapgoConfig = getLocalConfig()
 
+const remoteConfigTimeoutMs = 10_000
+
 export async function getRemoteConfig() {
   const runtimeConfig = useRuntimeConfig()
   const localConfig = getLocalConfig()
   try {
-    const res = await fetch(`${runtimeConfig.public.baseApiUrl}/private/config`)
+    const res = await fetch(`${runtimeConfig.public.baseApiUrl}/private/config`, {
+      signal: AbortSignal.timeout(remoteConfigTimeoutMs),
+    })
     if (!res.ok) throw new Error('Failed to fetch config')
     const remoteConfig = await res.json() as CapgoConfig
     config = { ...localConfig, ...remoteConfig }

--- a/apps/web/src/services/supabase.ts
+++ b/apps/web/src/services/supabase.ts
@@ -10,11 +10,24 @@ interface CapgoConfig {
   supbaseId: string
 }
 
-const getLocalConfig = (): CapgoConfig => ({
-  supaHost: import.meta.env.VITE_SUPABASE_URL as string,
-  supaKey: import.meta.env.VITE_SUPABASE_ANON_KEY as string,
-  supbaseId: import.meta.env.VITE_SUPABASE_URL?.split('//')[1].split('.')[0].split(':')[0] as string,
-})
+export function parseSupabaseProjectId(supaHost?: string): string {
+  if (!supaHost) return ''
+  return supaHost.split('//')[1]?.split('.')[0]?.split(':')[0] || ''
+}
+
+export function isSupabaseConfigured(config: Pick<CapgoConfig, 'supaHost' | 'supaKey'>): boolean {
+  return Boolean(config.supaHost?.trim() && config.supaKey?.trim())
+}
+
+const getLocalConfig = (): CapgoConfig => {
+  const supaHost = (import.meta.env.VITE_SUPABASE_URL as string | undefined)?.trim() || ''
+  const supaKey = (import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined)?.trim() || ''
+  return {
+    supaHost,
+    supaKey,
+    supbaseId: parseSupabaseProjectId(supaHost),
+  }
+}
 
 let config: CapgoConfig = getLocalConfig()
 
@@ -34,6 +47,9 @@ export async function getRemoteConfig() {
 }
 
 export function useSupabase() {
+  if (!isSupabaseConfigured(config)) {
+    throw new Error('Supabase is not configured')
+  }
   const options = {
     auth: {
       autoRefreshToken: true,

--- a/apps/web/test/supabase-config.test.js
+++ b/apps/web/test/supabase-config.test.js
@@ -1,0 +1,18 @@
+import { expect, test } from 'bun:test'
+import { isSupabaseConfigured, parseSupabaseProjectId } from '../src/services/supabase'
+
+test('parseSupabaseProjectId returns empty string for missing url', () => {
+  expect(parseSupabaseProjectId()).toBe('')
+  expect(parseSupabaseProjectId('')).toBe('')
+})
+
+test('parseSupabaseProjectId extracts project id from supabase url', () => {
+  expect(parseSupabaseProjectId('https://abcdefgh.supabase.co')).toBe('abcdefgh')
+})
+
+test('isSupabaseConfigured requires host and key', () => {
+  expect(isSupabaseConfigured({ supaHost: 'https://x.supabase.co', supaKey: 'anon-key' })).toBe(true)
+  expect(isSupabaseConfigured({ supaHost: '', supaKey: 'anon-key' })).toBe(false)
+  expect(isSupabaseConfigured({ supaHost: 'https://x.supabase.co', supaKey: '' })).toBe(false)
+  expect(isSupabaseConfigured({ supaHost: '   ', supaKey: 'anon-key' })).toBe(false)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes an uncaught client exception on `/register/` when users submit before `/private/config` returns (or when that fetch fails).

**Error:** `supabaseUrl is required.`  
**PostHog issues:**
- https://eu.posthog.com/project/72308/error_tracking/019fccd6-f588-7c62-8b34-c2bfb2df6361
- https://eu.posthog.com/project/72308/error_tracking/019f8097-9dfa-73a1-9486-17c328d6c735

## Root cause

`register.astro` called `getRemoteConfig()` fire-and-forget, then `useSupabase()` on submit. In the browser bundle, `VITE_SUPABASE_URL` is undefined, so `createClient(undefined, …)` threw before remote config could populate module-level state.

## Changes

### `apps/web/src/pages/register.astro`
- Keep `const configReady = getRemoteConfig()` and `await configReady` before calling `useSupabase()`
- Disable the submit button until config is ready; re-enable only when `supaHost`/`supaKey` are present (unless mid-submit)
- If config is still missing after await, show a Toastify error and return — do not call `useSupabase()`

### `apps/web/src/services/supabase.ts`
- Make `getLocalConfig()` null-safe when `VITE_SUPABASE_URL` is missing/empty (no `.split` on undefined)
- In `useSupabase()`, throw `Supabase is not configured` when credentials are absent instead of calling `createClient` with undefined
- Export small helpers (`parseSupabaseProjectId`, `isSupabaseConfigured`) for reuse and testing

### `apps/web/test/supabase-config.test.js`
- Regression tests for project-id parsing and config readiness checks

## Test plan

- [x] `bun test apps/web/test/supabase-config.test.js`
- [ ] CI `ci:verify:web`
- [ ] Manual: load `/register/`, confirm submit stays disabled briefly, then works after config loads
- [ ] Manual: simulate failed `/private/config` (or throttle network) and confirm Toastify error instead of PostHog crash

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-357eba4a-7dd5-4907-a82e-bf4730c7b255?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-357eba4a-7dd5-4907-a82e-bf4730c7b255&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790117954&installation_model_id=430928&pr_number=985&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F985&signature=0570bd01fff624f752c17eee92bab2ff95409656af4ca915a375aea74f9f16df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Registration now waits for Supabase configuration before enabling submission.
  - Displays clear errors when configuration loading or initialization fails.
  - Prevents duplicate or premature form submissions during signup.
  - Re-enables the form reliably after signup or session failures.
  - Handles missing or blank configuration values more reliably.
  - Times out configuration requests after 10 seconds.
- **Tests**
  - Added coverage for configuration validation and project ID parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->