### PR TITLE
fix(web): catch clipboard copy on security-scanner

### DIFF
--- a/apps/web/src/pages/security-scanner.astro
+++ b/apps/web/src/pages/security-scanner.astro
@@ -48,7 +48,7 @@ const content = { title, description, image: `${Astro.locals.runtimeConfig.publi
           </p>
 
           <!-- CLI Command -->
-          <div class="mx-auto mt-10 max-w-md">
+          <div class="relative mx-auto mt-10 max-w-md">
             <div class="flex items-center gap-3 rounded-lg bg-linear-to-r from-slate-800 to-slate-900 px-6 py-4">
               <span class="text-slate-400">$</span>
               <code class="text-cyan-400">bunx @capgo/capgo-sec scan</code>
@@ -62,6 +62,7 @@ const content = { title, description, image: `${Astro.locals.runtimeConfig.publi
                 </svg>
               </button>
             </div>
+            <p data-scanner-copy-status class="pointer-events-none absolute inset-x-0 top-full mt-2 text-sm text-slate-400" aria-live="polite"></p>
           </div>
 
           <!-- Features Pills -->
@@ -324,9 +325,12 @@ const content = { title, description, image: `${Astro.locals.runtimeConfig.publi
     helper.select()
 
     const legacyCopy = Reflect.get(document, 'execCommand')
-    const copied = typeof legacyCopy === 'function' ? legacyCopy.call(document, 'copy') : false
-
-    helper.remove()
+    let copied = false
+    try {
+      copied = typeof legacyCopy === 'function' ? legacyCopy.call(document, 'copy') : false
+    } finally {
+      helper.remove()
+    }
     if (!copied) {
       throw new Error('Copy failed')
     }
@@ -347,7 +351,12 @@ const content = { title, description, image: `${Astro.locals.runtimeConfig.publi
 
   document.querySelectorAll<HTMLButtonElement>('[data-scanner-copy]').forEach((button) => {
     let resetTimer: number | undefined
-    const originalHtml = button.innerHTML
+    const status = document.querySelector<HTMLElement>('[data-scanner-copy-status]')
+
+    const setStatus = (message: string): void => {
+      if (status) status.textContent = message
+      button.setAttribute('aria-label', message || 'Copy command')
+    }
 
     button.addEventListener('click', async () => {
       const value = button.getAttribute('data-scanner-copy')
@@ -355,17 +364,14 @@ const content = { title, description, image: `${Astro.locals.runtimeConfig.publi
 
       try {
         await copyScannerText(value)
-        button.textContent = 'Copied'
-        button.setAttribute('aria-label', 'Copied')
+        setStatus('Copied')
       } catch {
-        button.textContent = 'Copy failed'
-        button.setAttribute('aria-label', 'Copy failed')
+        setStatus('Copy failed')
       }
 
       if (resetTimer) window.clearTimeout(resetTimer)
       resetTimer = window.setTimeout(() => {
-        button.innerHTML = originalHtml
-        button.setAttribute('aria-label', 'Copy command')
+        setStatus('')
       }, 1600)
     })
   })

--- a/apps/web/src/pages/security-scanner.astro
+++ b/apps/web/src/pages/security-scanner.astro
@@ -52,12 +52,7 @@ const content = { title, description, image: `${Astro.locals.runtimeConfig.publi
             <div class="flex items-center gap-3 rounded-lg bg-linear-to-r from-slate-800 to-slate-900 px-6 py-4">
               <span class="text-slate-400">$</span>
               <code class="text-cyan-400">bunx @capgo/capgo-sec scan</code>
-              <button
-                type="button"
-                data-scanner-copy="bunx @capgo/capgo-sec scan"
-                class="ml-auto text-slate-400 transition hover:text-white"
-                aria-label="Copy command"
-              >
+              <button type="button" data-scanner-copy="bunx @capgo/capgo-sec scan" class="ml-auto text-slate-400 transition hover:text-white" aria-label="Copy command">
                 <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path
                     stroke-linecap="round"

--- a/apps/web/src/pages/security-scanner.astro
+++ b/apps/web/src/pages/security-scanner.astro
@@ -52,8 +52,13 @@ const content = { title, description, image: `${Astro.locals.runtimeConfig.publi
             <div class="flex items-center gap-3 rounded-lg bg-linear-to-r from-slate-800 to-slate-900 px-6 py-4">
               <span class="text-slate-400">$</span>
               <code class="text-cyan-400">bunx @capgo/capgo-sec scan</code>
-              <button onclick="navigator.clipboard.writeText('bunx @capgo/capgo-sec scan')" class="ml-auto text-slate-400 transition hover:text-white">
-                <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <button
+                type="button"
+                data-scanner-copy="bunx @capgo/capgo-sec scan"
+                class="ml-auto text-slate-400 transition hover:text-white"
+                aria-label="Copy command"
+              >
+                <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path
                     stroke-linecap="round"
                     stroke-linejoin="round"
@@ -312,3 +317,61 @@ const content = { title, description, image: `${Astro.locals.runtimeConfig.publi
     </p>
   </section>
 </Layout>
+
+<script>
+  function fallbackCopyText(value: string): void {
+    const helper = document.createElement('textarea')
+    helper.value = value
+    helper.setAttribute('readonly', 'true')
+    helper.style.position = 'absolute'
+    helper.style.opacity = '0'
+    document.body.append(helper)
+    helper.select()
+
+    const legacyCopy = Reflect.get(document, 'execCommand')
+    const copied = typeof legacyCopy === 'function' ? legacyCopy.call(document, 'copy') : false
+
+    helper.remove()
+    if (!copied) {
+      throw new Error('Copy failed')
+    }
+  }
+
+  async function copyScannerText(value: string): Promise<void> {
+    if (!navigator.clipboard?.writeText) {
+      fallbackCopyText(value)
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(value)
+    } catch {
+      fallbackCopyText(value)
+    }
+  }
+
+  document.querySelectorAll<HTMLButtonElement>('[data-scanner-copy]').forEach((button) => {
+    let resetTimer: number | undefined
+    const originalHtml = button.innerHTML
+
+    button.addEventListener('click', async () => {
+      const value = button.getAttribute('data-scanner-copy')
+      if (!value) return
+
+      try {
+        await copyScannerText(value)
+        button.textContent = 'Copied'
+        button.setAttribute('aria-label', 'Copied')
+      } catch {
+        button.textContent = 'Copy failed'
+        button.setAttribute('aria-label', 'Copy failed')
+      }
+
+      if (resetTimer) window.clearTimeout(resetTimer)
+      resetTimer = window.setTimeout(() => {
+        button.innerHTML = originalHtml
+        button.setAttribute('aria-label', 'Copy command')
+      }, 1600)
+    })
+  })
+</script>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Capgo-owned marketing page `apps/web/src/pages/security-scanner.astro` (live: https://capgo.app/security-scanner/) used an unguarded inline handler:

```html
<button onclick="navigator.clipboard.writeText('bunx @capgo/capgo-sec scan')" ...>
```

`navigator.clipboard.writeText` returns a Promise and rejects with `NotAllowedError` / `SecurityError` when permission is denied (non-secure contexts, blocked permissions, some mobile browsers). Inline `onclick=` does not catch that rejection, so the page throws an uncaught promise / DOMException.

Related PostHog SecurityError context on Landing Capgo (project 72308), even though this fingerprint is localStorage on `/`:

https://eu.posthog.com/project/72308/error_tracking/019eda5c-7246-71c0-8d7e-8d36b3bbc1cb

## Fix

- Remove the raw `onclick="navigator.clipboard.writeText(...)"`.
- Match sibling pages (`skills.astro`, `tools/ios-udid-finder/result.astro`): click listener, `navigator.clipboard?.writeText` feature detect, `try/catch`, `document.execCommand('copy')` fallback with `try/finally` cleanup.
- Keep the copy icon in place. Brief **Copied** / **Copy failed** feedback goes to an `aria-live="polite"` status under the command, so the button width does not shift.
- Scanned `apps/web/src/pages` for other raw `onclick="navigator.clipboard..."` — this was the only hit.

## Out of scope

- Header cookie guards (PR #984)
- Blog TOC / JSON-LD (PR #982 / #983)
- No merge

## Visual

Local headless check on `http://localhost:3000/security-scanner/`: no `onclick`, SVG stays after click, status announces **Copied**, clipboard gets `bunx @capgo/capgo-sec scan`, forced `NotAllowedError` does not become an uncaught pageerror.

Before:

![Security scanner CLI copy button before click](https://cursor.com/artifacts/c/art-23e8a889-eac2-4a4d-823b-bfedea93193e)

After click (Copied under the command, icon unchanged):

![Security scanner CLI copy button with Copied status](https://cursor.com/artifacts/c/art-eab16948-c625-411d-893e-edec5f52ce61)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f49dfcd4-9fa3-4672-bd0f-05924a8ca5a8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f49dfcd4-9fa3-4672-bd0f-05924a8ca5a8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790118680&installation_model_id=430928&pr_number=986&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F986&signature=274c3e4c992cd6f04588643c183ec2e41763cdc50bbd574726c96b533441b44c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved the scanner command copy control with clearer success and failure feedback.
  * Added compatibility support for browsers without the modern Clipboard API.
  * Added live status updates that reset automatically after copying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->