### PR TITLE
fix(i18n): sync current English scripts onto stale localized HTML

### DIFF
--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -550,7 +550,7 @@ try {
   assert(agedHitResponse.headers.get('X-Capgo-Translation-Scripts') === 'synced', 'A 10-minute HIT with a source-hash mismatch did not sync scripts')
   assert(agedHitBody.includes('getElementById(`${t}-link`)'), 'A 10-minute HIT did not receive the current English TOC helper')
   assert(!agedHitBody.includes('querySelector(`#${i}-link`)'), 'A 10-minute HIT kept the stale TOC querySelector')
-  assert(blogOriginFetches > fetchesBeforeAgedHit, 'A 10-minute HIT did not load the current English source')
+  assert(blogOriginFetches === fetchesBeforeAgedHit + 1, 'A 10-minute HIT loaded the English source more than once')
   const fetchesAfterAgedHit = blogOriginFetches
   const agedHitReuseResponse = await worker.fetch(new Request(agedHitUrl), blogEnv as any)
   assert(agedHitReuseResponse.headers.get('X-Capgo-Translation-Scripts') === 'synced', 'A repeated 10-minute HIT lost script sync')

--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -110,6 +110,20 @@ assert(
 )
 assert(!syncedFromEnglish.includes('Keep the English source article body'), 'Script sync leaked current English visible copy')
 
+const extraTranslatedInline = __translationWorkerTest.syncExecutableScriptsFromEnglish(
+  `<!doctype html><html lang="de"><body><h1>Bleibt Deutsch</h1><script>window.staleExtra=1</script></body></html>`,
+  `<!doctype html><html lang="en"><body><h1>English only</h1></body></html>`,
+)
+assert(extraTranslatedInline.includes('Bleibt Deutsch'), 'Extra-inline fixture wiped translated copy')
+assert(extraTranslatedInline.includes('window.staleExtra=1'), 'Script sync removed an unmatched translated inline script')
+
+const extraEnglishInline = __translationWorkerTest.syncExecutableScriptsFromEnglish(
+  `<!doctype html><html lang="de"><body><h1>Bleibt Deutsch</h1></body></html>`,
+  `<!doctype html><html lang="en"><body><h1>English only</h1><script>window.capgoNewInline=1</script></body></html>`,
+)
+assert(extraEnglishInline.includes('Bleibt Deutsch'), 'Extra English inline fixture wiped translated copy')
+assert(extraEnglishInline.includes('window.capgoNewInline=1'), 'Script sync did not insert an unmatched English inline script before </body>')
+
 const titleSegmentIndex = segments.findIndex((segment) => segment.text.includes('Capgo - Live Updates for Capacitor Apps'))
 assert(titleSegmentIndex >= 0, 'Parser did not collect the title segment')
 const emptyTitleTranslations = segments.map((segment, index) => (index === titleSegmentIndex ? '' : segment.text))
@@ -475,6 +489,24 @@ try {
   assert(freshBlogResponse.headers.get('X-Capgo-Translation-Cache') === 'HIT', 'A fresh localized blog did not report HIT')
   assert(freshBlogResponse.headers.get('X-Capgo-Translation-Scripts') !== 'synced', 'A fresh HIT synced scripts on the response path')
   assert(freshBlogBody.includes('querySelector(`#${i}-link`)'), 'A fresh HIT should keep cached scripts inside the source-check window')
+
+  const agedHitUrl = new URL('https://capgo.app/de/blog/aged-hit-script-sync/')
+  cacheEntries.set(
+    __translationWorkerTest.cacheKeyFor(agedHitUrl, 'de').url,
+    new Response(staleBlogHtml, {
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'X-Capgo-Translated-At': String(Date.now() - 10 * 60 * 1000),
+        'X-Capgo-Translation-Source-Hash': 'd'.repeat(64),
+      },
+    }),
+  )
+  const agedHitResponse = await worker.fetch(new Request(agedHitUrl), blogEnv as any)
+  const agedHitBody = await agedHitResponse.text()
+  assert(agedHitResponse.headers.get('X-Capgo-Translation-Cache') === 'HIT', 'A 10-minute HIT did not report HIT')
+  assert(agedHitResponse.headers.get('X-Capgo-Translation-Scripts') === 'synced', 'A 10-minute HIT with a source-hash mismatch did not sync scripts')
+  assert(agedHitBody.includes('getElementById(`${t}-link`)'), 'A 10-minute HIT did not receive the current English TOC helper')
+  assert(!agedHitBody.includes('querySelector(`#${i}-link`)'), 'A 10-minute HIT kept the stale TOC querySelector')
   await new Promise((resolve) => setTimeout(resolve, 25))
 
   const originalConsoleError = console.error

--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -60,7 +60,8 @@ const staleTocTranslated = `<!doctype html>
   <head>
     <title>App-Initialisierung</title>
     <script type="application/ld+json" id="seo-schema-graph">{"headline":"App-Initialisierung","inLanguage":"de"}</script>
-    <script src="https://aff.capgo.app/r/pixel.js"></script>
+    <script src="https://static.cloudflareinsights.com/beacon.min.js/v-stale" type="module"></script>
+    <script src="/_astro/page.old1234.js"></script>
   </head>
   <body>
     <h1>App-Initialisierung Schritt für Schritt</h1>
@@ -69,7 +70,6 @@ const staleTocTranslated = `<!doctype html>
       document.addEventListener("DOMContentLoaded",()=>{const l=()=>{const e=document.querySelectorAll("h1,h2,h3");for(const c of e){const i=c.getAttribute("id");i&&document.querySelector(\`#\${i}-link\`)?.classList.remove("text-white")}history.replaceState(null,"",window.location.hash)}});
     </script>
     <p>Übersetzter Anleitungstext bleibt erhalten.</p>
-    <script src="https://static.cloudflareinsights.com/beacon.min.js/v-stale" type="module"></script>
   </body>
 </html>`
 const currentEnglish = `<!doctype html>
@@ -77,7 +77,8 @@ const currentEnglish = `<!doctype html>
   <head>
     <title>App initialization</title>
     <script type="application/ld+json" id="seo-schema-graph">{"headline":"App initialization","inLanguage":"en"}</script>
-    <script src="https://aff.capgo.app/r/pixel.js"></script>
+    <script src="/_astro/extra.aaa111.js"></script>
+    <script src="/_astro/page.new5678.js"></script>
   </head>
   <body>
     <h1>Capacitor app initialization step by step</h1>
@@ -95,7 +96,18 @@ assert(syncedFromEnglish.includes('id="capgo-edge-language-selector-hash"'), 'Sc
 assert(syncedFromEnglish.includes('getElementById(`${t}-link`)'), 'Script sync did not copy the current English TOC helper')
 assert(syncedFromEnglish.includes('setTimeout(') && syncedFromEnglish.includes('150'), 'Script sync did not copy the current English replaceState debounce')
 assert(!syncedFromEnglish.includes('querySelector(`#${i}-link`)'), 'Script sync left the stale digit-leading TOC querySelector')
+assert(syncedFromEnglish.includes('src="/_astro/page.new5678.js"'), 'Script sync did not replace the stale hashed English script src')
+assert(!syncedFromEnglish.includes('src="/_astro/page.old1234.js"'), 'Script sync left the stale hashed English script src')
 assert(syncedFromEnglish.includes('https://static.cloudflareinsights.com/beacon.min.js/v-stale'), 'Script sync removed an unmatched third-party script from the translated page')
+assert(syncedFromEnglish.includes('src="/_astro/extra.aaa111.js"'), 'Script sync dropped a newly added English script')
+assert(
+  syncedFromEnglish.indexOf('src="/_astro/extra.aaa111.js"') < syncedFromEnglish.indexOf('src="/_astro/page.new5678.js"'),
+  'Script sync appended a new English head script after code that should follow it',
+)
+assert(
+  syncedFromEnglish.includes('https://static.cloudflareinsights.com/beacon.min.js/v-stale') && syncedFromEnglish.includes('src="/_astro/extra.aaa111.js"'),
+  'Script sync replaced an unmatched third-party script with a newly added English script',
+)
 assert(!syncedFromEnglish.includes('Keep the English source article body'), 'Script sync leaked current English visible copy')
 
 const titleSegmentIndex = segments.findIndex((segment) => segment.text.includes('Capgo - Live Updates for Capacitor Apps'))
@@ -446,6 +458,24 @@ try {
   const staleBlogHead = await worker.fetch(new Request(staleBlogUrl, { method: 'HEAD' }), blogEnv as any)
   assert((await staleBlogHead.text()) === '', 'A HEAD stale localized blog returned a body')
   assert(staleBlogHead.headers.get('X-Capgo-Translation-Cache') === 'STALE', 'A HEAD stale localized blog lost its cache state')
+
+  const freshBlogUrl = new URL('https://capgo.app/de/blog/fresh-hit-script-skip/')
+  cacheEntries.set(
+    __translationWorkerTest.cacheKeyFor(freshBlogUrl, 'de').url,
+    new Response(staleBlogHtml, {
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'X-Capgo-Translated-At': String(Date.now()),
+        'X-Capgo-Translation-Source-Hash': 'c'.repeat(64),
+      },
+    }),
+  )
+  const freshBlogResponse = await worker.fetch(new Request(freshBlogUrl), blogEnv as any)
+  const freshBlogBody = await freshBlogResponse.text()
+  assert(freshBlogResponse.headers.get('X-Capgo-Translation-Cache') === 'HIT', 'A fresh localized blog did not report HIT')
+  assert(freshBlogResponse.headers.get('X-Capgo-Translation-Scripts') !== 'synced', 'A fresh HIT synced scripts on the response path')
+  assert(freshBlogBody.includes('querySelector(`#${i}-link`)'), 'A fresh HIT should keep cached scripts inside the source-check window')
+  await new Promise((resolve) => setTimeout(resolve, 25))
 
   const originalConsoleError = console.error
   let enqueueFailureResponse: Response | null = null

--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -100,10 +100,11 @@ assert(syncedFromEnglish.includes('src="/_astro/page.new5678.js"'), 'Script sync
 assert(!syncedFromEnglish.includes('src="/_astro/page.old1234.js"'), 'Script sync left the stale hashed English script src')
 assert(syncedFromEnglish.includes('https://static.cloudflareinsights.com/beacon.min.js/v-stale'), 'Script sync removed an unmatched third-party script from the translated page')
 assert(syncedFromEnglish.includes('src="/_astro/extra.aaa111.js"'), 'Script sync dropped a newly added English script')
-assert(
-  syncedFromEnglish.indexOf('src="/_astro/extra.aaa111.js"') < syncedFromEnglish.indexOf('src="/_astro/page.new5678.js"'),
-  'Script sync appended a new English head script after code that should follow it',
-)
+const syncedHead = syncedFromEnglish.slice(0, syncedFromEnglish.indexOf('</head>'))
+const syncedHeadSrcs = [...syncedHead.matchAll(/<script\b[^>]*\bsrc="([^"]+)"/g)].map((match) => match[1])
+const extraHeadIndex = syncedHeadSrcs.indexOf('/_astro/extra.aaa111.js')
+const pageHeadIndex = syncedHeadSrcs.indexOf('/_astro/page.new5678.js')
+assert(extraHeadIndex >= 0 && pageHeadIndex === extraHeadIndex + 1, 'Script sync did not insert the new English head script immediately before page.new5678.js')
 assert(
   syncedFromEnglish.includes('https://static.cloudflareinsights.com/beacon.min.js/v-stale') && syncedFromEnglish.includes('src="/_astro/extra.aaa111.js"'),
   'Script sync replaced an unmatched third-party script with a newly added English script',
@@ -122,7 +123,27 @@ const extraEnglishInline = __translationWorkerTest.syncExecutableScriptsFromEngl
   `<!doctype html><html lang="en"><body><h1>English only</h1><script>window.capgoNewInline=1</script></body></html>`,
 )
 assert(extraEnglishInline.includes('Bleibt Deutsch'), 'Extra English inline fixture wiped translated copy')
-assert(extraEnglishInline.includes('window.capgoNewInline=1'), 'Script sync did not insert an unmatched English inline script before </body>')
+assert(
+  extraEnglishInline.includes('window.capgoNewInline=1') && extraEnglishInline.indexOf('window.capgoNewInline=1') < extraEnglishInline.indexOf('</body>'),
+  'Script sync did not insert an unmatched English inline script before </body>',
+)
+
+const extraBeforeEnglishInline = __translationWorkerTest.syncExecutableScriptsFromEnglish(
+  `<!doctype html><html lang="de"><body><h1>Bleibt Deutsch</h1><script>window.staleExtra=1</script><script type="module">document.querySelector(\`#\${i}-link\`)</script></body></html>`,
+  `<!doctype html><html lang="en"><body><h1>English only</h1><script type="module">document.getElementById(\`\${t}-link\`)</script></body></html>`,
+)
+assert(extraBeforeEnglishInline.includes('Bleibt Deutsch'), 'Preceding inline fixture wiped translated copy')
+assert(extraBeforeEnglishInline.includes('window.staleExtra=1'), 'Script sync replaced an unmatched translated inline that precedes the English TOC script')
+assert(extraBeforeEnglishInline.includes('getElementById(`${t}-link`)'), 'Script sync did not pair the English TOC script past a preceding unmatched inline')
+assert(!extraBeforeEnglishInline.includes('querySelector(`#${i}-link`)'), 'Script sync left the stale TOC script after a preceding unmatched inline')
+
+const sameTypeExtraBeforeEnglishInline = __translationWorkerTest.syncExecutableScriptsFromEnglish(
+  `<!doctype html><html lang="de"><body><h1>Bleibt Deutsch</h1><script>window.staleExtra=1</script><script>document.querySelector(\`#\${i}-link\`)</script></body></html>`,
+  `<!doctype html><html lang="en"><body><h1>English only</h1><script>document.getElementById(\`\${t}-link\`)</script></body></html>`,
+)
+assert(sameTypeExtraBeforeEnglishInline.includes('window.staleExtra=1'), 'Same-type leftover pairing dropped the unmatched translated inline')
+assert(sameTypeExtraBeforeEnglishInline.includes('getElementById(`${t}-link`)'), 'Same-type leftover pairing did not update the matching TOC script')
+assert(!sameTypeExtraBeforeEnglishInline.includes('querySelector(`#${i}-link`)'), 'Same-type leftover pairing left the stale TOC script')
 
 const titleSegmentIndex = segments.findIndex((segment) => segment.text.includes('Capgo - Live Updates for Capacitor Apps'))
 assert(titleSegmentIndex >= 0, 'Parser did not collect the title segment')
@@ -446,10 +467,14 @@ try {
       },
     }),
   )
+  let blogOriginFetches = 0
   const blogEnv = {
     ...env,
     WEB: {
-      fetch: async () => new Response(currentBlogHtml, { headers: { 'Content-Type': 'text/html; charset=utf-8' } }),
+      fetch: async () => {
+        blogOriginFetches += 1
+        return new Response(currentBlogHtml, { headers: { 'Content-Type': 'text/html; charset=utf-8' } })
+      },
     },
     DOCS: {
       fetch: async () => {
@@ -484,11 +509,28 @@ try {
       },
     }),
   )
-  const freshBlogResponse = await worker.fetch(new Request(freshBlogUrl), blogEnv as any)
+  cacheEntries.set(__translationWorkerTest.sourceCheckKeyFor(freshBlogUrl, 'de').url, new Response('already-checked'))
+  let freshOriginFetches = 0
+  const freshBlogEnv = {
+    ...env,
+    WEB: {
+      fetch: async () => {
+        freshOriginFetches += 1
+        throw new Error('A fresh HIT unexpectedly fetched the English origin')
+      },
+    },
+    DOCS: {
+      fetch: async () => {
+        throw new Error('A fresh HIT unexpectedly used the docs origin')
+      },
+    },
+  }
+  const freshBlogResponse = await worker.fetch(new Request(freshBlogUrl), freshBlogEnv as any)
   const freshBlogBody = await freshBlogResponse.text()
   assert(freshBlogResponse.headers.get('X-Capgo-Translation-Cache') === 'HIT', 'A fresh localized blog did not report HIT')
   assert(freshBlogResponse.headers.get('X-Capgo-Translation-Scripts') !== 'synced', 'A fresh HIT synced scripts on the response path')
   assert(freshBlogBody.includes('querySelector(`#${i}-link`)'), 'A fresh HIT should keep cached scripts inside the source-check window')
+  assert(freshOriginFetches === 0, 'A fresh HIT fetched the English origin on the response path')
 
   const agedHitUrl = new URL('https://capgo.app/de/blog/aged-hit-script-sync/')
   cacheEntries.set(
@@ -501,12 +543,18 @@ try {
       },
     }),
   )
+  const fetchesBeforeAgedHit = blogOriginFetches
   const agedHitResponse = await worker.fetch(new Request(agedHitUrl), blogEnv as any)
   const agedHitBody = await agedHitResponse.text()
   assert(agedHitResponse.headers.get('X-Capgo-Translation-Cache') === 'HIT', 'A 10-minute HIT did not report HIT')
   assert(agedHitResponse.headers.get('X-Capgo-Translation-Scripts') === 'synced', 'A 10-minute HIT with a source-hash mismatch did not sync scripts')
   assert(agedHitBody.includes('getElementById(`${t}-link`)'), 'A 10-minute HIT did not receive the current English TOC helper')
   assert(!agedHitBody.includes('querySelector(`#${i}-link`)'), 'A 10-minute HIT kept the stale TOC querySelector')
+  assert(blogOriginFetches > fetchesBeforeAgedHit, 'A 10-minute HIT did not load the current English source')
+  const fetchesAfterAgedHit = blogOriginFetches
+  const agedHitReuseResponse = await worker.fetch(new Request(agedHitUrl), blogEnv as any)
+  assert(agedHitReuseResponse.headers.get('X-Capgo-Translation-Scripts') === 'synced', 'A repeated 10-minute HIT lost script sync')
+  assert(blogOriginFetches === fetchesAfterAgedHit, 'A repeated 10-minute HIT did not reuse the cached English source')
   await new Promise((resolve) => setTimeout(resolve, 25))
 
   const originalConsoleError = console.error

--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -555,6 +555,26 @@ try {
   const agedHitReuseResponse = await worker.fetch(new Request(agedHitUrl), blogEnv as any)
   assert(agedHitReuseResponse.headers.get('X-Capgo-Translation-Scripts') === 'synced', 'A repeated 10-minute HIT lost script sync')
   assert(blogOriginFetches === fetchesAfterAgedHit, 'A repeated 10-minute HIT did not reuse the cached English source')
+
+  const jsonHitUrl = new URL('https://capgo.app/de/blog/json-hit-skip-script-sync/')
+  cacheEntries.set(__translationWorkerTest.sourceCheckKeyFor(jsonHitUrl, 'de').url, new Response('already-checked'))
+  cacheEntries.set(
+    __translationWorkerTest.cacheKeyFor(jsonHitUrl, 'de').url,
+    new Response('{"ok":true}', {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Capgo-Translated-At': String(Date.now() - 10 * 60 * 1000),
+        'X-Capgo-Translation-Source-Hash': 'e'.repeat(64),
+      },
+    }),
+  )
+  const fetchesBeforeJsonHit = blogOriginFetches
+  const jsonHitResponse = await worker.fetch(new Request(jsonHitUrl), blogEnv as any)
+  const jsonHitBody = await jsonHitResponse.text()
+  assert(jsonHitResponse.headers.get('X-Capgo-Translation-Cache') === 'HIT', 'A cached JSON HIT did not report HIT')
+  assert(jsonHitResponse.headers.get('X-Capgo-Translation-Scripts') !== 'synced', 'A cached JSON HIT entered HTML script sync')
+  assert(jsonHitBody === '{"ok":true}', 'A cached JSON HIT was rewritten as HTML')
+  assert(fetchesBeforeJsonHit === blogOriginFetches, 'A cached JSON HIT fetched the English origin')
   await new Promise((resolve) => setTimeout(resolve, 25))
 
   const originalConsoleError = console.error

--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -55,6 +55,49 @@ const rendered = __translationWorkerTest.renderTranslatedHtml(parts, segments, t
 assert(rendered.includes('FR: Ship mobile updates instantly to every user'), 'Renderer did not write translated body text')
 assert(rendered.includes('current < total'), 'Renderer changed skipped script content')
 
+const staleTocTranslated = `<!doctype html>
+<html lang="de">
+  <head>
+    <title>App-Initialisierung</title>
+    <script type="application/ld+json" id="seo-schema-graph">{"headline":"App-Initialisierung","inLanguage":"de"}</script>
+    <script src="https://aff.capgo.app/r/pixel.js"></script>
+  </head>
+  <body>
+    <h1>App-Initialisierung Schritt für Schritt</h1>
+    <script id="capgo-edge-language-selector-hash">(() => { /* keep worker script */ })();</script>
+    <script type="module">
+      document.addEventListener("DOMContentLoaded",()=>{const l=()=>{const e=document.querySelectorAll("h1,h2,h3");for(const c of e){const i=c.getAttribute("id");i&&document.querySelector(\`#\${i}-link\`)?.classList.remove("text-white")}history.replaceState(null,"",window.location.hash)}});
+    </script>
+    <p>Übersetzter Anleitungstext bleibt erhalten.</p>
+    <script src="https://static.cloudflareinsights.com/beacon.min.js/v-stale" type="module"></script>
+  </body>
+</html>`
+const currentEnglish = `<!doctype html>
+<html lang="en">
+  <head>
+    <title>App initialization</title>
+    <script type="application/ld+json" id="seo-schema-graph">{"headline":"App initialization","inLanguage":"en"}</script>
+    <script src="https://aff.capgo.app/r/pixel.js"></script>
+  </head>
+  <body>
+    <h1>Capacitor app initialization step by step</h1>
+    <script type="module">
+      document.addEventListener("DOMContentLoaded",()=>{const r=t=>document.getElementById(\`\${t}-link\`);let l=window.location.hash,i;const d=t=>{t!==l&&(i&&clearTimeout(i),i=setTimeout(()=>{history.replaceState(null,"",t)},150))}});
+    </script>
+    <p>Keep the English source article body out of the localized page.</p>
+  </body>
+</html>`
+const syncedFromEnglish = __translationWorkerTest.syncExecutableScriptsFromEnglish(staleTocTranslated, currentEnglish)
+assert(syncedFromEnglish.includes('App-Initialisierung Schritt für Schritt'), 'Script sync wiped translated visible copy')
+assert(syncedFromEnglish.includes('Übersetzter Anleitungstext bleibt erhalten.'), 'Script sync wiped translated body copy')
+assert(syncedFromEnglish.includes('"headline":"App-Initialisierung"'), 'Script sync replaced locale-specific JSON-LD')
+assert(syncedFromEnglish.includes('id="capgo-edge-language-selector-hash"'), 'Script sync dropped the worker-owned language selector script')
+assert(syncedFromEnglish.includes('getElementById(`${t}-link`)'), 'Script sync did not copy the current English TOC helper')
+assert(syncedFromEnglish.includes('setTimeout(') && syncedFromEnglish.includes('150'), 'Script sync did not copy the current English replaceState debounce')
+assert(!syncedFromEnglish.includes('querySelector(`#${i}-link`)'), 'Script sync left the stale digit-leading TOC querySelector')
+assert(syncedFromEnglish.includes('https://static.cloudflareinsights.com/beacon.min.js/v-stale'), 'Script sync removed an unmatched third-party script from the translated page')
+assert(!syncedFromEnglish.includes('Keep the English source article body'), 'Script sync leaked current English visible copy')
+
 const titleSegmentIndex = segments.findIndex((segment) => segment.text.includes('Capgo - Live Updates for Capacitor Apps'))
 assert(titleSegmentIndex >= 0, 'Parser did not collect the title segment')
 const emptyTitleTranslations = segments.map((segment, index) => (index === titleSegmentIndex ? '' : segment.text))
@@ -88,19 +131,10 @@ assert(
   __translationWorkerTest.applyFrenchArticleElision('la haute disponibilité et le héros') === 'la haute disponibilité et le héros',
   'French elision must not touch aspirate-h words',
 )
-assert(
-  __translationWorkerTest.polishTranslatedText('French', 'Évitez la attente.') === 'Évitez l\u2019attente.',
-  'French polish path did not apply article elision',
-)
-assert(
-  __translationWorkerTest.polishTranslatedText('Spanish', 'Évitez la attente.') === 'Évitez la attente.',
-  'Non-French polish path should leave text unchanged',
-)
+assert(__translationWorkerTest.polishTranslatedText('French', 'Évitez la attente.') === 'Évitez l\u2019attente.', 'French polish path did not apply article elision')
+assert(__translationWorkerTest.polishTranslatedText('Spanish', 'Évitez la attente.') === 'Évitez la attente.', 'Non-French polish path should leave text unchanged')
 const heroHeadlineContext = __translationWorkerTest.resolveTranslationContexts(['Skip the wait. Ship the fix.'])[0]
-assert(
-  typeof heroHeadlineContext === 'string' && heroHeadlineContext.toLowerCase().includes('hotfix'),
-  'Missing marketing context override for live update hero headline',
-)
+assert(typeof heroHeadlineContext === 'string' && heroHeadlineContext.toLowerCase().includes('hotfix'), 'Missing marketing context override for live update hero headline')
 
 const localizedMeta = __translationWorkerTest.expandShortMetaDescriptions(
   '<head><meta name="description" content="短い説明"><meta property="og:description" content="短い説明"></head>',
@@ -349,6 +383,69 @@ try {
   assert(translatedResponse.headers.get('X-Capgo-Translation-Cache') === 'HIT', 'A completed cache-miss translation was not cached')
   assert(translatedHtml.includes('Leggi le nostre guide'), 'A completed cache-miss translation did not contain the translated document')
   assert(translatedHtml.includes('Chi siamo'), 'A completed cache-miss translation did not keep context-backed About copy')
+
+  const staleBlogUrl = new URL('https://capgo.app/de/blog/capacitor-app-initialization-step-by-step-guide/')
+  const staleBlogCacheKey = __translationWorkerTest.cacheKeyFor(staleBlogUrl, 'de')
+  const staleBlogHtml = `<!doctype html>
+<html lang="de">
+  <head>
+    <title>App-Initialisierung</title>
+    <script type="application/ld+json" id="seo-schema-graph">{"headline":"App-Initialisierung"}</script>
+  </head>
+  <body>
+    <h1>App-Initialisierung Schritt für Schritt</h1>
+    <script type="module">document.querySelector(\`#\${i}-link\`);history.replaceState(null,"",window.location.hash);</script>
+    <p>Übersetzter Anleitungstext bleibt erhalten.</p>
+  </body>
+</html>`
+  const currentBlogHtml = `<!doctype html>
+<html lang="en">
+  <head>
+    <title>App initialization</title>
+    <script type="application/ld+json" id="seo-schema-graph">{"headline":"App initialization"}</script>
+  </head>
+  <body>
+    <h1>Capacitor app initialization step by step</h1>
+    <script type="module">const r=t=>document.getElementById(\`\${t}-link\`);setTimeout(()=>history.replaceState(null,"",t),150);</script>
+    <p>English source copy must stay off the localized response.</p>
+  </body>
+</html>`
+  cacheEntries.set(
+    staleBlogCacheKey.url,
+    new Response(staleBlogHtml, {
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'X-Capgo-Translated-At': String(Date.now() - 48 * 60 * 60 * 1000),
+        'X-Capgo-Translation-Source-Hash': 'b'.repeat(64),
+      },
+    }),
+  )
+  const blogEnv = {
+    ...env,
+    WEB: {
+      fetch: async () => new Response(currentBlogHtml, { headers: { 'Content-Type': 'text/html; charset=utf-8' } }),
+    },
+    DOCS: {
+      fetch: async () => {
+        throw new Error('The blog request unexpectedly used the docs origin')
+      },
+    },
+  }
+  const staleBlogResponse = await worker.fetch(new Request(staleBlogUrl), blogEnv as any)
+  const staleBlogBody = await staleBlogResponse.text()
+  assert(staleBlogResponse.status === 200, 'A stale localized blog was not served successfully')
+  assert(staleBlogResponse.headers.get('X-Capgo-Translation-Cache') === 'STALE', 'A stale localized blog did not report STALE')
+  assert(staleBlogResponse.headers.get('X-Capgo-Translation-Scripts') === 'synced', 'A stale localized blog did not sync current English scripts')
+  assert(staleBlogBody.includes('App-Initialisierung Schritt für Schritt'), 'Script sync on STALE wipe translated heading')
+  assert(staleBlogBody.includes('Übersetzter Anleitungstext bleibt erhalten.'), 'Script sync on STALE wipe translated paragraph')
+  assert(staleBlogBody.includes('"headline":"App-Initialisierung"'), 'Script sync on STALE replaced translated JSON-LD')
+  assert(staleBlogBody.includes('getElementById(`${t}-link`)'), 'STALE localized blog did not receive the current English TOC helper')
+  assert(staleBlogBody.includes('150'), 'STALE localized blog did not receive the current English replaceState debounce')
+  assert(!staleBlogBody.includes('querySelector(`#${i}-link`)'), 'STALE localized blog kept the stale TOC querySelector')
+  assert(!staleBlogBody.includes('English source copy must stay off the localized response.'), 'STALE script sync leaked current English copy')
+  const staleBlogHead = await worker.fetch(new Request(staleBlogUrl, { method: 'HEAD' }), blogEnv as any)
+  assert((await staleBlogHead.text()) === '', 'A HEAD stale localized blog returned a body')
+  assert(staleBlogHead.headers.get('X-Capgo-Translation-Cache') === 'STALE', 'A HEAD stale localized blog lost its cache state')
 
   const originalConsoleError = console.error
   let enqueueFailureResponse: Response | null = null

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -1084,9 +1084,13 @@ function groupScriptIndexesByType(scripts: HtmlScript[], indexes: number[]): Map
   return groups
 }
 
+function executableScriptBody(script: HtmlScript): string {
+  return script.outerHtml.replace(/^<script\b[^>]*>/i, '').replace(/<\/script>\s*$/i, '')
+}
+
 function scriptTokenOverlap(left: HtmlScript, right: HtmlScript): number {
-  const leftTokens = new Set(left.outerHtml.match(/[A-Za-z_$][\w$]{3,}/g) ?? [])
-  const rightTokens = new Set(right.outerHtml.match(/[A-Za-z_$][\w$]{3,}/g) ?? [])
+  const leftTokens = new Set(executableScriptBody(left).match(/[A-Za-z_$][\w$]{3,}/g) ?? [])
+  const rightTokens = new Set(executableScriptBody(right).match(/[A-Za-z_$][\w$]{3,}/g) ?? [])
   if (leftTokens.size === 0 || rightTokens.size === 0) return 0
   let shared = 0
   for (const token of leftTokens) {
@@ -2622,20 +2626,35 @@ async function writeCachedEnglishSourceHtmlSafely(requestUrl: URL, sourceHtml: s
   }
 }
 
-async function loadCurrentEnglishSourceHtml(env: Env, requestUrl: URL, locale: Locale): Promise<string | null> {
-  const cached = await readCachedEnglishSourceHtml(requestUrl)
-  if (cached) return cached
+const inflightEnglishSourceHtml = new Map<string, Promise<string | null>>()
 
-  const renderRequest = new Request(requestUrl.toString(), {
-    method: 'GET',
-    headers: {
-      Accept: 'text/html',
-    },
-  })
-  const source = await loadSourceHtml(renderRequest, env, requestUrl, locale)
-  if (source.type !== 'html') return null
-  await writeCachedEnglishSourceHtmlSafely(requestUrl, source.sourceHtml)
-  return source.sourceHtml
+async function loadCurrentEnglishSourceHtml(env: Env, requestUrl: URL, locale: Locale): Promise<string | null> {
+  const cacheKey = englishSourceHtmlKeyFor(requestUrl).url
+  const inflight = inflightEnglishSourceHtml.get(cacheKey)
+  if (inflight) return inflight
+
+  const load = (async () => {
+    const cached = await readCachedEnglishSourceHtml(requestUrl)
+    if (cached) return cached
+
+    const renderRequest = new Request(requestUrl.toString(), {
+      method: 'GET',
+      headers: {
+        Accept: 'text/html',
+      },
+    })
+    const source = await loadSourceHtml(renderRequest, env, requestUrl, locale)
+    if (source.type !== 'html') return null
+    await writeCachedEnglishSourceHtmlSafely(requestUrl, source.sourceHtml)
+    return source.sourceHtml
+  })()
+
+  inflightEnglishSourceHtml.set(cacheKey, load)
+  try {
+    return await load
+  } finally {
+    inflightEnglishSourceHtml.delete(cacheKey)
+  }
 }
 
 async function checkTranslatedSourceFreshnessSafely(env: Env, requestUrl: URL, locale: Locale, translatedResponse: Response, priority: boolean): Promise<void> {

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -1095,6 +1095,41 @@ function scriptTokenOverlap(left: HtmlScript, right: HtmlScript): number {
   return shared / Math.min(leftTokens.size, rightTokens.size)
 }
 
+function pairInlineScriptsByIndex(translatedGroup: number[], englishGroup: number[], takePair: (translatedIndex: number, englishIndex: number) => void): void {
+  for (let index = 0; index < englishGroup.length; index += 1) {
+    takePair(translatedGroup[index], englishGroup[index])
+  }
+}
+
+function findBestOverlappingInlineIndex(translatedScripts: HtmlScript[], englishScript: HtmlScript, translatedGroup: number[], usedTranslated: Set<number>): number | undefined {
+  let bestIndex: number | undefined
+  let bestScore = 0.3
+  for (const translatedIndex of translatedGroup) {
+    if (usedTranslated.has(translatedIndex)) continue
+    const score = scriptTokenOverlap(translatedScripts[translatedIndex], englishScript)
+    if (score <= bestScore) continue
+    bestScore = score
+    bestIndex = translatedIndex
+  }
+  return bestIndex
+}
+
+function pairInlineScriptsByOverlap(
+  translatedScripts: HtmlScript[],
+  englishScripts: HtmlScript[],
+  translatedGroup: number[],
+  englishGroup: number[],
+  takePair: (translatedIndex: number, englishIndex: number) => void,
+): void {
+  const usedTranslated = new Set<number>()
+  for (const englishIndex of englishGroup) {
+    const bestIndex = findBestOverlappingInlineIndex(translatedScripts, englishScripts[englishIndex], translatedGroup, usedTranslated)
+    if (bestIndex === undefined) continue
+    usedTranslated.add(bestIndex)
+    takePair(bestIndex, englishIndex)
+  }
+}
+
 function pairRemainingInlineScripts(
   translatedScripts: HtmlScript[],
   englishScripts: HtmlScript[],
@@ -1110,27 +1145,10 @@ function pairRemainingInlineScripts(
   for (const [type, englishGroup] of englishByType) {
     const translatedGroup = translatedByType.get(type) ?? []
     if (translatedGroup.length === englishGroup.length) {
-      for (let index = 0; index < englishGroup.length; index += 1) {
-        takePair(translatedGroup[index], englishGroup[index])
-      }
+      pairInlineScriptsByIndex(translatedGroup, englishGroup, takePair)
       continue
     }
-
-    const usedTranslated = new Set<number>()
-    for (const englishIndex of englishGroup) {
-      let bestIndex: number | undefined
-      let bestScore = 0.3
-      for (const translatedIndex of translatedGroup) {
-        if (usedTranslated.has(translatedIndex)) continue
-        const score = scriptTokenOverlap(translatedScripts[translatedIndex], englishScripts[englishIndex])
-        if (score <= bestScore) continue
-        bestScore = score
-        bestIndex = translatedIndex
-      }
-      if (bestIndex === undefined) continue
-      usedTranslated.add(bestIndex)
-      takePair(bestIndex, englishIndex)
-    }
+    pairInlineScriptsByOverlap(translatedScripts, englishScripts, translatedGroup, englishGroup, takePair)
   }
 }
 

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -1073,6 +1073,67 @@ function unusedScriptIndexes(scripts: HtmlScript[], used: Set<number>, include: 
   return indexes
 }
 
+function groupScriptIndexesByType(scripts: HtmlScript[], indexes: number[]): Map<string, number[]> {
+  const groups = new Map<string, number[]>()
+  for (const index of indexes) {
+    const type = scripts[index].type
+    const list = groups.get(type)
+    if (list) list.push(index)
+    else groups.set(type, [index])
+  }
+  return groups
+}
+
+function scriptTokenOverlap(left: HtmlScript, right: HtmlScript): number {
+  const leftTokens = new Set(left.outerHtml.match(/[A-Za-z_$][\w$]{3,}/g) ?? [])
+  const rightTokens = new Set(right.outerHtml.match(/[A-Za-z_$][\w$]{3,}/g) ?? [])
+  if (leftTokens.size === 0 || rightTokens.size === 0) return 0
+  let shared = 0
+  for (const token of leftTokens) {
+    if (rightTokens.has(token)) shared += 1
+  }
+  return shared / Math.min(leftTokens.size, rightTokens.size)
+}
+
+function pairRemainingInlineScripts(
+  translatedScripts: HtmlScript[],
+  englishScripts: HtmlScript[],
+  translatedUsed: Set<number>,
+  englishUsed: Set<number>,
+  takePair: (translatedIndex: number, englishIndex: number) => void,
+): void {
+  const remainingTranslated = unusedScriptIndexes(translatedScripts, translatedUsed, (script) => !script.external)
+  const remainingEnglish = unusedScriptIndexes(englishScripts, englishUsed, (script) => !script.external)
+  const translatedByType = groupScriptIndexesByType(translatedScripts, remainingTranslated)
+  const englishByType = groupScriptIndexesByType(englishScripts, remainingEnglish)
+
+  for (const [type, englishGroup] of englishByType) {
+    const translatedGroup = translatedByType.get(type) ?? []
+    if (translatedGroup.length === englishGroup.length) {
+      for (let index = 0; index < englishGroup.length; index += 1) {
+        takePair(translatedGroup[index], englishGroup[index])
+      }
+      continue
+    }
+
+    const usedTranslated = new Set<number>()
+    for (const englishIndex of englishGroup) {
+      let bestIndex: number | undefined
+      let bestScore = 0.3
+      for (const translatedIndex of translatedGroup) {
+        if (usedTranslated.has(translatedIndex)) continue
+        const score = scriptTokenOverlap(translatedScripts[translatedIndex], englishScripts[englishIndex])
+        if (score <= bestScore) continue
+        bestScore = score
+        bestIndex = translatedIndex
+      }
+      if (bestIndex === undefined) continue
+      usedTranslated.add(bestIndex)
+      takePair(bestIndex, englishIndex)
+    }
+  }
+}
+
 function groupExtraEnglishScripts(extras: HtmlScript[], englishScripts: HtmlScript[], pairedEnglish: Set<HtmlScript>): ScriptInsertionGroup[] {
   const paired = (script: HtmlScript): boolean => pairedEnglish.has(script)
   const groups = new Map<string, ScriptInsertionGroup>()
@@ -1151,12 +1212,7 @@ function syncExecutableScriptsFromEnglish(translatedHtml: string, englishHtml: s
     takePair(translatedIndex, englishIndex)
   }
 
-  const remainingTranslatedInline = unusedScriptIndexes(translatedScripts, translatedUsed, (script) => !script.external)
-  const remainingEnglishInline = unusedScriptIndexes(englishScripts, englishUsed, (script) => !script.external)
-  const inlineShared = Math.min(remainingTranslatedInline.length, remainingEnglishInline.length)
-  for (let index = 0; index < inlineShared; index += 1) {
-    takePair(remainingTranslatedInline[index], remainingEnglishInline[index])
-  }
+  pairRemainingInlineScripts(translatedScripts, englishScripts, translatedUsed, englishUsed, takePair)
 
   const replacements = pairs
     .filter((pair) => pair.translated.outerHtml !== pair.english.outerHtml)
@@ -3009,6 +3065,7 @@ export const __translationWorkerTest = {
   bodyTranslationStats,
   buildBatches,
   cacheKeyFor,
+  sourceCheckKeyFor,
   collectSegments,
   renderTranslatedHtml,
   expandShortMetaDescriptions,

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -1070,9 +1070,11 @@ function unusedScriptIndexes(scripts: HtmlScript[], used: Set<number>, include: 
   return indexes
 }
 
-function insertSyncedEnglishScripts(html: string, extras: HtmlScript[], englishScripts: HtmlScript[], pairedEnglish: Set<HtmlScript>): string {
-  if (extras.length === 0) return html
-
+function groupExtraEnglishScripts(
+  extras: HtmlScript[],
+  englishScripts: HtmlScript[],
+  pairedEnglish: Set<HtmlScript>,
+): Array<{ marker?: string; mode: 'after' | 'before' | 'body'; html: string[] }> {
   const paired = (script: HtmlScript): boolean => pairedEnglish.has(script)
   const groups = new Map<string, { marker?: string; mode: 'after' | 'before' | 'body'; html: string[] }>()
 
@@ -1087,10 +1089,14 @@ function insertSyncedEnglishScripts(html: string, extras: HtmlScript[], englishS
     groups.set(key, anchor ? { ...anchor, html: [extra.outerHtml] } : { mode: 'body', html: [extra.outerHtml] })
   }
 
+  return [...groups.values()]
+}
+
+function applyAnchoredScriptInsertions(html: string, groups: Array<{ marker?: string; mode: 'after' | 'before' | 'body'; html: string[] }>): string {
   let rewritten = html
   const placements: Array<{ index: number; value: string }> = []
 
-  for (const group of groups.values()) {
+  for (const group of groups) {
     const value = group.html.join('\n')
     const found = group.marker ? rewritten.indexOf(group.marker) : -1
     if (!group.marker || found === -1) {
@@ -1108,6 +1114,11 @@ function insertSyncedEnglishScripts(html: string, extras: HtmlScript[], englishS
     rewritten = `${rewritten.slice(0, placement.index)}\n${placement.value}${rewritten.slice(placement.index)}`
   }
   return rewritten
+}
+
+function insertSyncedEnglishScripts(html: string, extras: HtmlScript[], englishScripts: HtmlScript[], pairedEnglish: Set<HtmlScript>): string {
+  if (extras.length === 0) return html
+  return applyAnchoredScriptInsertions(html, groupExtraEnglishScripts(extras, englishScripts, pairedEnglish))
 }
 
 function syncExecutableScriptsFromEnglish(translatedHtml: string, englishHtml: string): string {

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -525,6 +525,14 @@ function cacheKeyFor(requestUrl: URL, locale: Locale): Request {
   return new Request(cacheUrl.toString(), { method: 'GET' })
 }
 
+function englishSourceHtmlKeyFor(requestUrl: URL): Request {
+  const cacheUrl = new URL(requestUrl)
+  cacheUrl.pathname = withTrailingSlash(stripLocalePrefix(cacheUrl.pathname))
+  applyNormalizedTranslationSearch(cacheUrl, requestUrl)
+  cacheUrl.searchParams.set('__capgo_translation_english_source', TRANSLATION_CACHE_VERSION)
+  return new Request(cacheUrl.toString(), { method: 'GET' })
+}
+
 function pendingKeyFor(requestUrl: URL, locale: Locale): Request {
   const pendingUrl = new URL(requestUrl)
   pendingUrl.pathname = localizedPath(pendingUrl.pathname, locale)
@@ -1019,6 +1027,22 @@ function syncableScripts(html: string): HtmlScript[] {
   return collectHtmlScripts(html).filter((script) => script.executable && !script.workerOwned)
 }
 
+function normalizeScriptSrc(src: string): string {
+  try {
+    const url = new URL(src, 'https://capgo.app')
+    const pathname = url.pathname.replace(/\/([^/]+)\.[A-Za-z0-9_-]{6,}\.((?:m)?js)$/i, '/$1.$2')
+    return `${url.origin}${pathname}`
+  } catch {
+    return src
+  }
+}
+
+function scriptIdentityKey(script: HtmlScript): string | null {
+  if (script.id) return `id:${script.id}`
+  if (script.src) return `src:${normalizeScriptSrc(script.src)}`
+  return null
+}
+
 function applyHtmlRangeReplacements(html: string, replacements: Array<{ start: number; end: number; value: string }>): string {
   const ordered = [...replacements].sort((left, right) => right.start - left.start)
   let rewritten = html
@@ -1028,33 +1052,122 @@ function applyHtmlRangeReplacements(html: string, replacements: Array<{ start: n
   return rewritten
 }
 
+function insertSyncedEnglishScripts(html: string, extras: HtmlScript[], englishScripts: HtmlScript[], pairedEnglish: Set<HtmlScript>): string {
+  if (extras.length === 0) return html
+
+  const paired = (script: HtmlScript): boolean => pairedEnglish.has(script)
+  const groups = new Map<string, { marker: string; mode: 'after' | 'before'; html: string[] } | { mode: 'body'; html: string[] }>()
+
+  for (const extra of extras) {
+    const englishIndex = englishScripts.indexOf(extra)
+    let marker: string | null = null
+    let mode: 'after' | 'before' | 'body' = 'body'
+
+    for (let index = englishIndex - 1; index >= 0; index -= 1) {
+      if (!paired(englishScripts[index])) continue
+      marker = englishScripts[index].outerHtml
+      mode = 'after'
+      break
+    }
+
+    if (!marker) {
+      for (let index = englishIndex + 1; index < englishScripts.length; index += 1) {
+        if (!paired(englishScripts[index])) continue
+        marker = englishScripts[index].outerHtml
+        mode = 'before'
+        break
+      }
+    }
+
+    const key = marker ? `${mode}:${marker}` : 'body'
+    const existing = groups.get(key)
+    if (existing) {
+      existing.html.push(extra.outerHtml)
+      continue
+    }
+    groups.set(key, marker ? { marker, mode, html: [extra.outerHtml] } : { mode: 'body', html: [extra.outerHtml] })
+  }
+
+  let rewritten = html
+  const placements: Array<{ index: number; value: string }> = []
+
+  for (const group of groups.values()) {
+    const value = group.html.join('\n')
+    if (group.mode === 'body') {
+      rewritten = insertBeforeClosingTag(rewritten, 'body', value)
+      continue
+    }
+
+    const found = rewritten.indexOf(group.marker)
+    if (found === -1) {
+      rewritten = insertBeforeClosingTag(rewritten, 'body', value)
+      continue
+    }
+
+    placements.push({
+      index: group.mode === 'after' ? found + group.marker.length : found,
+      value,
+    })
+  }
+
+  placements.sort((left, right) => right.index - left.index)
+  for (const placement of placements) {
+    rewritten = `${rewritten.slice(0, placement.index)}\n${placement.value}${rewritten.slice(placement.index)}`
+  }
+  return rewritten
+}
+
 function syncExecutableScriptsFromEnglish(translatedHtml: string, englishHtml: string): string {
   const translatedScripts = syncableScripts(translatedHtml)
   const englishScripts = syncableScripts(englishHtml)
-  const replacements: Array<{ start: number; end: number; value: string }> = []
-  const extraEnglish: string[] = []
+  const translatedUsed = new Set<number>()
+  const englishUsed = new Set<number>()
+  const pairs: Array<{ translated: HtmlScript; english: HtmlScript }> = []
 
-  for (const kind of ['inline', 'external'] as const) {
-    const wantsExternal = kind === 'external'
-    const translatedGroup = translatedScripts.filter((script) => script.external === wantsExternal)
-    const englishGroup = englishScripts.filter((script) => script.external === wantsExternal)
-    const sharedCount = Math.min(translatedGroup.length, englishGroup.length)
-
-    for (let index = 0; index < sharedCount; index += 1) {
-      if (translatedGroup[index].outerHtml === englishGroup[index].outerHtml) continue
-      replacements.push({
-        start: translatedGroup[index].start,
-        end: translatedGroup[index].end,
-        value: englishGroup[index].outerHtml,
-      })
-    }
-
-    extraEnglish.push(...englishGroup.slice(sharedCount).map((script) => script.outerHtml))
+  const takePair = (translatedIndex: number, englishIndex: number): void => {
+    if (translatedUsed.has(translatedIndex) || englishUsed.has(englishIndex)) return
+    translatedUsed.add(translatedIndex)
+    englishUsed.add(englishIndex)
+    pairs.push({ translated: translatedScripts[translatedIndex], english: englishScripts[englishIndex] })
   }
 
-  let rewritten = applyHtmlRangeReplacements(translatedHtml, replacements)
-  if (extraEnglish.length > 0) rewritten = insertBeforeClosingTag(rewritten, 'body', extraEnglish.join('\n'))
-  return rewritten
+  const translatedByKey = new Map<string, number[]>()
+  for (const [index, script] of translatedScripts.entries()) {
+    const key = scriptIdentityKey(script)
+    if (!key) continue
+    const list = translatedByKey.get(key)
+    if (list) list.push(index)
+    else translatedByKey.set(key, [index])
+  }
+
+  for (const [englishIndex, script] of englishScripts.entries()) {
+    const key = scriptIdentityKey(script)
+    if (!key) continue
+    const translatedIndex = translatedByKey.get(key)?.find((index) => !translatedUsed.has(index))
+    if (translatedIndex === undefined) continue
+    takePair(translatedIndex, englishIndex)
+  }
+
+  const remainingTranslatedInline: number[] = []
+  const remainingEnglishInline: number[] = []
+  for (const [index, script] of translatedScripts.entries()) {
+    if (!script.external && !translatedUsed.has(index)) remainingTranslatedInline.push(index)
+  }
+  for (const [index, script] of englishScripts.entries()) {
+    if (!script.external && !englishUsed.has(index)) remainingEnglishInline.push(index)
+  }
+
+  const inlineShared = Math.min(remainingTranslatedInline.length, remainingEnglishInline.length)
+  for (let index = 0; index < inlineShared; index += 1) {
+    takePair(remainingTranslatedInline[index], remainingEnglishInline[index])
+  }
+
+  const replacements = pairs
+    .filter((pair) => pair.translated.outerHtml !== pair.english.outerHtml)
+    .map((pair) => ({ start: pair.translated.start, end: pair.translated.end, value: pair.english.outerHtml }))
+  const rewritten = applyHtmlRangeReplacements(translatedHtml, replacements)
+  const extras = englishScripts.filter((_, index) => !englishUsed.has(index))
+  return insertSyncedEnglishScripts(rewritten, extras, englishScripts, new Set(pairs.map((pair) => pair.english)))
 }
 
 function collectSegments(html: string): { parts: HtmlPart[]; segments: Segment[] } {
@@ -2405,6 +2518,44 @@ async function checkTranslatedSourceFreshness(env: Env, requestUrl: URL, locale:
     }),
   )
 
+  const englishHtml = await loadCurrentEnglishSourceHtml(env, requestUrl, locale)
+  if (!englishHtml) return
+
+  const currentSourceHash = await translationSourceHash(locale, englishHtml)
+  if (knownSourceHash === currentSourceHash) return
+
+  await enqueueTranslation(env, requestUrl, locale, 'stale', priority, currentSourceHash)
+}
+
+async function readCachedEnglishSourceHtml(requestUrl: URL): Promise<string | null> {
+  try {
+    const cached = await caches.default.match(englishSourceHtmlKeyFor(requestUrl))
+    return cached ? await cached.text() : null
+  } catch {
+    return null
+  }
+}
+
+async function writeCachedEnglishSourceHtmlSafely(requestUrl: URL, sourceHtml: string): Promise<void> {
+  try {
+    await caches.default.put(
+      englishSourceHtmlKeyFor(requestUrl),
+      new Response(sourceHtml, {
+        headers: {
+          'Content-Type': 'text/html; charset=utf-8',
+          'Cache-Control': `public, max-age=${TRANSLATION_SOURCE_CHECK_SECONDS}`,
+        },
+      }),
+    )
+  } catch (error) {
+    console.error('Failed to cache current English source HTML', { pathname: requestUrl.pathname, error: errorMessage(error) })
+  }
+}
+
+async function loadCurrentEnglishSourceHtml(env: Env, requestUrl: URL, locale: Locale): Promise<string | null> {
+  const cached = await readCachedEnglishSourceHtml(requestUrl)
+  if (cached) return cached
+
   const renderRequest = new Request(requestUrl.toString(), {
     method: 'GET',
     headers: {
@@ -2412,12 +2563,9 @@ async function checkTranslatedSourceFreshness(env: Env, requestUrl: URL, locale:
     },
   })
   const source = await loadSourceHtml(renderRequest, env, requestUrl, locale)
-  if (source.type !== 'html') return
-
-  const currentSourceHash = await translationSourceHash(locale, source.sourceHtml)
-  if (knownSourceHash === currentSourceHash) return
-
-  await enqueueTranslation(env, requestUrl, locale, 'stale', priority, currentSourceHash)
+  if (source.type !== 'html') return null
+  await writeCachedEnglishSourceHtmlSafely(requestUrl, source.sourceHtml)
+  return source.sourceHtml
 }
 
 async function checkTranslatedSourceFreshnessSafely(env: Env, requestUrl: URL, locale: Locale, translatedResponse: Response, priority: boolean): Promise<void> {
@@ -2432,27 +2580,24 @@ function scheduleTranslatedSourceCheck(ctx: WorkerExecutionContext | undefined, 
   scheduleTranslationBackgroundTask(ctx, checkTranslatedSourceFreshnessSafely(env, new URL(requestUrl), locale, translatedResponse, priority))
 }
 
-async function serveTranslatedCachedPage(
-  request: Request,
-  env: Env,
-  requestUrl: URL,
-  locale: Locale,
-  translatedResponse: Response,
-  cacheState: 'HIT' | 'STALE',
-  isHead: boolean,
-): Promise<Response> {
+async function serveTranslatedCachedPage(env: Env, requestUrl: URL, locale: Locale, translatedResponse: Response, cacheState: 'HIT' | 'STALE', isHead: boolean): Promise<Response> {
   if (isHead) return withResponseHeaders(translatedResponse, cacheState, true)
 
   const status = translatedResponse.status
   const statusText = translatedResponse.statusText
   const responseHeaders = new Headers(translatedResponse.headers)
+  const translatedAt = readTranslatedAt(translatedResponse)
+  const knownSourceHash = readTranslationSourceHash(translatedResponse)
   const translatedHtml = await translatedResponse.text()
 
+  if (cacheState === 'HIT' && Date.now() - translatedAt < TRANSLATION_SOURCE_CHECK_SECONDS * 1000) {
+    return withResponseHeaders(new Response(translatedHtml, { status, statusText, headers: responseHeaders }), cacheState, false)
+  }
+
   try {
-    const renderRequest = request.method === 'GET' ? request : new Request(request, { method: 'GET' })
-    const source = await loadSourceHtml(renderRequest, env, requestUrl, locale)
-    if (source.type === 'html') {
-      let syncedHtml = syncExecutableScriptsFromEnglish(translatedHtml, source.sourceHtml)
+    const englishHtml = await loadCurrentEnglishSourceHtml(env, requestUrl, locale)
+    if (englishHtml && knownSourceHash !== (await translationSourceHash(locale, englishHtml))) {
+      let syncedHtml = syncExecutableScriptsFromEnglish(translatedHtml, englishHtml)
       if (!syncedHtml.includes('capgo-edge-language-selector-hash')) {
         syncedHtml = insertBeforeClosingTag(syncedHtml, 'body', languageSelectorHashScript())
       }
@@ -2533,7 +2678,7 @@ async function serveTranslated(request: Request, env: Env, requestUrl: URL, loca
     } else {
       scheduleTranslatedSourceCheck(ctx, env, requestUrl, locale, cachedResponse, priority)
     }
-    return await serveTranslatedCachedPage(request, env, requestUrl, locale, cachedResponse, isStale ? 'STALE' : 'HIT', isHead)
+    return await serveTranslatedCachedPage(env, requestUrl, locale, cachedResponse, isStale ? 'STALE' : 'HIT', isHead)
   }
 
   const storedResponse = await readStoredTranslatedResponse(env, requestUrl, locale)
@@ -2546,7 +2691,7 @@ async function serveTranslated(request: Request, env: Env, requestUrl: URL, loca
     } else {
       scheduleTranslatedSourceCheck(ctx, env, requestUrl, locale, storedResponse, priority)
     }
-    return await serveTranslatedCachedPage(request, env, requestUrl, locale, storedResponse, isStale ? 'STALE' : 'HIT', isHead)
+    return await serveTranslatedCachedPage(env, requestUrl, locale, storedResponse, isStale ? 'STALE' : 'HIT', isHead)
   }
 
   const enqueued = await enqueueTranslationSafely(env, requestUrl, locale, 'miss', priority)

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -166,7 +166,10 @@ const TRANSLATION_RETRY_SECONDS = 5
 const TRANSLATION_COORDINATOR_PENDING_MS = 15 * 60 * 1000
 const TRANSLATION_CACHE_VERSION = '2026-08-12-message-context-fr-elision-v1'
 const TRANSLATION_SOURCE_HASH_HEADER = 'X-Capgo-Translation-Source-Hash'
+const TRANSLATION_SCRIPTS_HEADER = 'X-Capgo-Translation-Scripts'
 const CLIENT_NO_STORE = 'no-store, max-age=0, must-revalidate'
+const EXECUTABLE_SCRIPT_TYPES = new Set(['', 'module', 'text/javascript', 'application/javascript', 'text/ecmascript', 'application/ecmascript'])
+const WORKER_OWNED_SCRIPT_IDS = new Set(['capgo-edge-language-selector-hash'])
 const MAX_HTML_BYTES = 1_500_000
 const MAX_BATCH_CHARS = 1_500
 const MAX_BATCH_ITEMS = 12
@@ -946,6 +949,112 @@ function findClosingTag(html: string, startIndex: number, tagName: string): { in
   }
 
   return null
+}
+
+type HtmlScript = {
+  start: number
+  end: number
+  outerHtml: string
+  id: string | null
+  src: string | null
+  type: string
+  executable: boolean
+  workerOwned: boolean
+  external: boolean
+}
+
+function normalizeScriptType(type: string | null): string {
+  return (type ?? '').trim().toLowerCase()
+}
+
+function isExecutableScriptType(type: string): boolean {
+  return EXECUTABLE_SCRIPT_TYPES.has(type)
+}
+
+function collectHtmlScripts(html: string): HtmlScript[] {
+  const scripts: HtmlScript[] = []
+  let cursor = 0
+
+  while (cursor < html.length) {
+    const nextTag = findNextHtmlTag(html, cursor)
+    if (!nextTag) break
+
+    if (tagNameOf(nextTag.tag) !== 'script' || isClosingTag(nextTag.tag)) {
+      cursor = nextTag.end
+      continue
+    }
+
+    const type = normalizeScriptType(readAttributeValue(nextTag.tag, 'type'))
+    const id = readAttributeValue(nextTag.tag, 'id')
+    const src = readAttributeValue(nextTag.tag, 'src')
+    let end = nextTag.end
+
+    if (!isSelfClosingTag(nextTag.tag, 'script')) {
+      const closing = findClosingTag(html, nextTag.end, 'script')
+      if (!closing) {
+        cursor = nextTag.end
+        continue
+      }
+      end = closing.end
+    }
+
+    scripts.push({
+      start: nextTag.index,
+      end,
+      outerHtml: html.slice(nextTag.index, end),
+      id,
+      src,
+      type,
+      executable: isExecutableScriptType(type),
+      workerOwned: Boolean(id && WORKER_OWNED_SCRIPT_IDS.has(id)),
+      external: Boolean(src),
+    })
+    cursor = end
+  }
+
+  return scripts
+}
+
+function syncableScripts(html: string): HtmlScript[] {
+  return collectHtmlScripts(html).filter((script) => script.executable && !script.workerOwned)
+}
+
+function applyHtmlRangeReplacements(html: string, replacements: Array<{ start: number; end: number; value: string }>): string {
+  const ordered = [...replacements].sort((left, right) => right.start - left.start)
+  let rewritten = html
+  for (const replacement of ordered) {
+    rewritten = `${rewritten.slice(0, replacement.start)}${replacement.value}${rewritten.slice(replacement.end)}`
+  }
+  return rewritten
+}
+
+function syncExecutableScriptsFromEnglish(translatedHtml: string, englishHtml: string): string {
+  const translatedScripts = syncableScripts(translatedHtml)
+  const englishScripts = syncableScripts(englishHtml)
+  const replacements: Array<{ start: number; end: number; value: string }> = []
+  const extraEnglish: string[] = []
+
+  for (const kind of ['inline', 'external'] as const) {
+    const wantsExternal = kind === 'external'
+    const translatedGroup = translatedScripts.filter((script) => script.external === wantsExternal)
+    const englishGroup = englishScripts.filter((script) => script.external === wantsExternal)
+    const sharedCount = Math.min(translatedGroup.length, englishGroup.length)
+
+    for (let index = 0; index < sharedCount; index += 1) {
+      if (translatedGroup[index].outerHtml === englishGroup[index].outerHtml) continue
+      replacements.push({
+        start: translatedGroup[index].start,
+        end: translatedGroup[index].end,
+        value: englishGroup[index].outerHtml,
+      })
+    }
+
+    extraEnglish.push(...englishGroup.slice(sharedCount).map((script) => script.outerHtml))
+  }
+
+  let rewritten = applyHtmlRangeReplacements(translatedHtml, replacements)
+  if (extraEnglish.length > 0) rewritten = insertBeforeClosingTag(rewritten, 'body', extraEnglish.join('\n'))
+  return rewritten
 }
 
 function collectSegments(html: string): { parts: HtmlPart[]; segments: Segment[] } {
@@ -2323,6 +2432,44 @@ function scheduleTranslatedSourceCheck(ctx: WorkerExecutionContext | undefined, 
   scheduleTranslationBackgroundTask(ctx, checkTranslatedSourceFreshnessSafely(env, new URL(requestUrl), locale, translatedResponse, priority))
 }
 
+async function serveTranslatedCachedPage(
+  request: Request,
+  env: Env,
+  requestUrl: URL,
+  locale: Locale,
+  translatedResponse: Response,
+  cacheState: 'HIT' | 'STALE',
+  isHead: boolean,
+): Promise<Response> {
+  if (isHead) return withResponseHeaders(translatedResponse, cacheState, true)
+
+  const status = translatedResponse.status
+  const statusText = translatedResponse.statusText
+  const responseHeaders = new Headers(translatedResponse.headers)
+  const translatedHtml = await translatedResponse.text()
+
+  try {
+    const renderRequest = request.method === 'GET' ? request : new Request(request, { method: 'GET' })
+    const source = await loadSourceHtml(renderRequest, env, requestUrl, locale)
+    if (source.type === 'html') {
+      let syncedHtml = syncExecutableScriptsFromEnglish(translatedHtml, source.sourceHtml)
+      if (!syncedHtml.includes('capgo-edge-language-selector-hash')) {
+        syncedHtml = insertBeforeClosingTag(syncedHtml, 'body', languageSelectorHashScript())
+      }
+      if (syncedHtml !== translatedHtml) responseHeaders.set(TRANSLATION_SCRIPTS_HEADER, 'synced')
+      return withResponseHeaders(new Response(syncedHtml, { status, statusText, headers: responseHeaders }), cacheState, false)
+    }
+  } catch (error) {
+    console.error('Failed to sync executable scripts from current English source', {
+      pathname: requestUrl.pathname,
+      locale,
+      error: errorMessage(error),
+    })
+  }
+
+  return withResponseHeaders(new Response(translatedHtml, { status, statusText, headers: responseHeaders }), cacheState, false)
+}
+
 async function processTranslationJob(job: TranslationJob, env: Env): Promise<void> {
   if (job.cacheVersion !== TRANSLATION_CACHE_VERSION || !isSupportedLocale(job.locale)) return
 
@@ -2386,7 +2533,7 @@ async function serveTranslated(request: Request, env: Env, requestUrl: URL, loca
     } else {
       scheduleTranslatedSourceCheck(ctx, env, requestUrl, locale, cachedResponse, priority)
     }
-    return withResponseHeaders(cachedResponse, isStale ? 'STALE' : 'HIT', isHead)
+    return await serveTranslatedCachedPage(request, env, requestUrl, locale, cachedResponse, isStale ? 'STALE' : 'HIT', isHead)
   }
 
   const storedResponse = await readStoredTranslatedResponse(env, requestUrl, locale)
@@ -2399,7 +2546,7 @@ async function serveTranslated(request: Request, env: Env, requestUrl: URL, loca
     } else {
       scheduleTranslatedSourceCheck(ctx, env, requestUrl, locale, storedResponse, priority)
     }
-    return withResponseHeaders(storedResponse, isStale ? 'STALE' : 'HIT', isHead)
+    return await serveTranslatedCachedPage(request, env, requestUrl, locale, storedResponse, isStale ? 'STALE' : 'HIT', isHead)
   }
 
   const enqueued = await enqueueTranslationSafely(env, requestUrl, locale, 'miss', priority)
@@ -2720,11 +2867,13 @@ export const __translationWorkerTest = {
   polishTranslatedText,
   bodyTranslationStats,
   buildBatches,
+  cacheKeyFor,
   collectSegments,
   renderTranslatedHtml,
   expandShortMetaDescriptions,
   rewriteMetadataAndLinks,
   resolveTranslationContexts,
+  syncExecutableScriptsFromEnglish,
 }
 
 export default {

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -2652,6 +2652,7 @@ function scheduleTranslatedSourceCheck(ctx: WorkerExecutionContext | undefined, 
 
 async function serveTranslatedCachedPage(env: Env, requestUrl: URL, locale: Locale, translatedResponse: Response, cacheState: 'HIT' | 'STALE', isHead: boolean): Promise<Response> {
   if (isHead) return withResponseHeaders(translatedResponse, cacheState, true)
+  if (!isHtmlResponse(translatedResponse)) return withResponseHeaders(translatedResponse, cacheState, false)
 
   const status = translatedResponse.status
   const statusText = translatedResponse.statusText

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -1030,7 +1030,7 @@ function syncableScripts(html: string): HtmlScript[] {
 function normalizeScriptSrc(src: string): string {
   try {
     const url = new URL(src, 'https://capgo.app')
-    const pathname = url.pathname.replace(/\/([^/]+)\.[A-Za-z0-9_-]{6,}\.((?:m)?js)$/i, '/$1.$2')
+    const pathname = url.pathname.replace(/\/([^/]+)\.[a-z0-9_-]{6,}\.((?:m)?js)$/i, '/$1.$2')
     return `${url.origin}${pathname}`
   } catch {
     return src
@@ -1052,40 +1052,39 @@ function applyHtmlRangeReplacements(html: string, replacements: Array<{ start: n
   return rewritten
 }
 
+function findPairedScriptAnchor(englishScripts: HtmlScript[], englishIndex: number, paired: (script: HtmlScript) => boolean): { marker: string; mode: 'after' | 'before' } | null {
+  for (let index = englishIndex - 1; index >= 0; index -= 1) {
+    if (paired(englishScripts[index])) return { marker: englishScripts[index].outerHtml, mode: 'after' }
+  }
+  for (let index = englishIndex + 1; index < englishScripts.length; index += 1) {
+    if (paired(englishScripts[index])) return { marker: englishScripts[index].outerHtml, mode: 'before' }
+  }
+  return null
+}
+
+function unusedScriptIndexes(scripts: HtmlScript[], used: Set<number>, include: (script: HtmlScript) => boolean): number[] {
+  const indexes: number[] = []
+  for (const [index, script] of scripts.entries()) {
+    if (!used.has(index) && include(script)) indexes.push(index)
+  }
+  return indexes
+}
+
 function insertSyncedEnglishScripts(html: string, extras: HtmlScript[], englishScripts: HtmlScript[], pairedEnglish: Set<HtmlScript>): string {
   if (extras.length === 0) return html
 
   const paired = (script: HtmlScript): boolean => pairedEnglish.has(script)
-  const groups = new Map<string, { marker: string; mode: 'after' | 'before'; html: string[] } | { mode: 'body'; html: string[] }>()
+  const groups = new Map<string, { marker?: string; mode: 'after' | 'before' | 'body'; html: string[] }>()
 
   for (const extra of extras) {
-    const englishIndex = englishScripts.indexOf(extra)
-    let marker: string | null = null
-    let mode: 'after' | 'before' | 'body' = 'body'
-
-    for (let index = englishIndex - 1; index >= 0; index -= 1) {
-      if (!paired(englishScripts[index])) continue
-      marker = englishScripts[index].outerHtml
-      mode = 'after'
-      break
-    }
-
-    if (!marker) {
-      for (let index = englishIndex + 1; index < englishScripts.length; index += 1) {
-        if (!paired(englishScripts[index])) continue
-        marker = englishScripts[index].outerHtml
-        mode = 'before'
-        break
-      }
-    }
-
-    const key = marker ? `${mode}:${marker}` : 'body'
+    const anchor = findPairedScriptAnchor(englishScripts, englishScripts.indexOf(extra), paired)
+    const key = anchor ? `${anchor.mode}:${anchor.marker}` : 'body'
     const existing = groups.get(key)
     if (existing) {
       existing.html.push(extra.outerHtml)
       continue
     }
-    groups.set(key, marker ? { marker, mode, html: [extra.outerHtml] } : { mode: 'body', html: [extra.outerHtml] })
+    groups.set(key, anchor ? { ...anchor, html: [extra.outerHtml] } : { mode: 'body', html: [extra.outerHtml] })
   }
 
   let rewritten = html
@@ -1093,17 +1092,11 @@ function insertSyncedEnglishScripts(html: string, extras: HtmlScript[], englishS
 
   for (const group of groups.values()) {
     const value = group.html.join('\n')
-    if (group.mode === 'body') {
+    const found = group.marker ? rewritten.indexOf(group.marker) : -1
+    if (!group.marker || found === -1) {
       rewritten = insertBeforeClosingTag(rewritten, 'body', value)
       continue
     }
-
-    const found = rewritten.indexOf(group.marker)
-    if (found === -1) {
-      rewritten = insertBeforeClosingTag(rewritten, 'body', value)
-      continue
-    }
-
     placements.push({
       index: group.mode === 'after' ? found + group.marker.length : found,
       value,
@@ -1148,15 +1141,8 @@ function syncExecutableScriptsFromEnglish(translatedHtml: string, englishHtml: s
     takePair(translatedIndex, englishIndex)
   }
 
-  const remainingTranslatedInline: number[] = []
-  const remainingEnglishInline: number[] = []
-  for (const [index, script] of translatedScripts.entries()) {
-    if (!script.external && !translatedUsed.has(index)) remainingTranslatedInline.push(index)
-  }
-  for (const [index, script] of englishScripts.entries()) {
-    if (!script.external && !englishUsed.has(index)) remainingEnglishInline.push(index)
-  }
-
+  const remainingTranslatedInline = unusedScriptIndexes(translatedScripts, translatedUsed, (script) => !script.external)
+  const remainingEnglishInline = unusedScriptIndexes(englishScripts, englishUsed, (script) => !script.external)
   const inlineShared = Math.min(remainingTranslatedInline.length, remainingEnglishInline.length)
   for (let index = 0; index < inlineShared; index += 1) {
     takePair(remainingTranslatedInline[index], remainingEnglishInline[index])

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -971,6 +971,9 @@ type HtmlScript = {
   external: boolean
 }
 
+type ScriptInsertionMode = 'after' | 'before' | 'body'
+type ScriptInsertionGroup = { marker?: string; mode: ScriptInsertionMode; html: string[] }
+
 function normalizeScriptType(type: string | null): string {
   return (type ?? '').trim().toLowerCase()
 }
@@ -1070,13 +1073,9 @@ function unusedScriptIndexes(scripts: HtmlScript[], used: Set<number>, include: 
   return indexes
 }
 
-function groupExtraEnglishScripts(
-  extras: HtmlScript[],
-  englishScripts: HtmlScript[],
-  pairedEnglish: Set<HtmlScript>,
-): Array<{ marker?: string; mode: 'after' | 'before' | 'body'; html: string[] }> {
+function groupExtraEnglishScripts(extras: HtmlScript[], englishScripts: HtmlScript[], pairedEnglish: Set<HtmlScript>): ScriptInsertionGroup[] {
   const paired = (script: HtmlScript): boolean => pairedEnglish.has(script)
-  const groups = new Map<string, { marker?: string; mode: 'after' | 'before' | 'body'; html: string[] }>()
+  const groups = new Map<string, ScriptInsertionGroup>()
 
   for (const extra of extras) {
     const anchor = findPairedScriptAnchor(englishScripts, englishScripts.indexOf(extra), paired)
@@ -1092,7 +1091,7 @@ function groupExtraEnglishScripts(
   return [...groups.values()]
 }
 
-function applyAnchoredScriptInsertions(html: string, groups: Array<{ marker?: string; mode: 'after' | 'before' | 'body'; html: string[] }>): string {
+function applyAnchoredScriptInsertions(html: string, groups: ScriptInsertionGroup[]): string {
   let rewritten = html
   const placements: Array<{ index: number; value: string }> = []
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Localized blog pages keep serving **stale Capgo TOC JavaScript** after English source fixes land. The translation worker caches full translated HTML snapshots. `<script>` bodies are skipped for text translation (`SKIP_TEXT_TAGS`) but stay frozen from the English HTML at translation time. `serveTranslated` then returns HIT/STALE HTML with the old scripts until a full retranslate finishes.

That is why `/de/` and `/ko/` still throw Capgo-owned TOC `SyntaxError`s after Website #982/#983 merged and EN is fixed live.

### PostHog (Landing Capgo project 72308)

Digit-leading TOC `querySelector` / `replaceState` storms continue on localized blogs:

- https://eu.posthog.com/project/72308/error_tracking/019f408f-b94c-7862-bd45-ebbceeee5d13
- https://eu.posthog.com/project/72308/error_tracking/019f4609-2927-7e12-b080-21cbdbb3a01e
- https://eu.posthog.com/project/72308/error_tracking/019fed9c-0ca6-7323-aa67-ac6ed1d533ab
- https://eu.posthog.com/project/72308/error_tracking/019e98ff-42a6-71b2-891c-8ae2ce75f942 (`replaceState`; Capgo TOC also fires `replaceState`)

### Live verification (2026-08-23)

- EN `https://capgo.app/blog/capacitor-app-initialization-step-by-step-guide/` TOC uses `getElementById(\`${t}-link\`)` + 150ms `replaceState` debounce (#982/#983).
- DE `https://capgo.app/de/blog/capacitor-app-initialization-step-by-step-guide/` and KO `https://capgo.app/ko/blog/payment-data-security-for-app-store-approval/` still ship the old inline TOC: `document.querySelector(\`#${i}-link\`)` and undebounced `history.replaceState`.
- Localized responses include `X-Capgo-Translation-Cache: STALE`.

### Fix

In `apps/translation-worker`, HIT/STALE responses now fetch the current English source for the same path and rewrite **executable** `<script>` tags (inline JS, `type="module"`, external `src`) from that EN document onto the cached translation.

- Translated visible copy and locale-specific JSON-LD (`application/ld+json`) stay as-is.
- Worker-owned `capgo-edge-language-selector-hash` is preserved.
- Unmatched third-party scripts (for example a Cloudflare beacon present only on the cached page) are left in place so index matching cannot swap TOC onto the wrong tag.
- Background retranslation on STALE / source-hash mismatch is unchanged.
- This is durable serve-time sync, not a one-shot cache-version bump.

`X-Capgo-Translation-Scripts: synced` is set when the outgoing HTML scripts were rewritten.

### Tests

`apps/translation-worker/scripts/verify-parser.ts` covers:

- Unit: German heading/body/JSON-LD stay locale; TOC body matches current EN (`getElementById` + debounce); old `querySelector(\`#${…}-link\`)` is gone.
- Serve path: a STALE cached DE blog is rewritten from current EN on GET; HEAD stays empty.

## Out of scope

- No re-PR of #982/#983 blog `[slug].astro` TOC/JSON-LD.
- No Zaraz/Turnstile/Bing/extension changes.
- Do not merge until reviewed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05f8c4c7-0bd6-45d8-9a68-cc66c85f209d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05f8c4c7-0bd6-45d8-9a68-cc66c85f209d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790118905&installation_model_id=430928&pr_number=987&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F987&signature=c5304c396989442541d59aa617e9112967f42792dd7b5b2895a4fcd8b22adf85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cached translated pages to synchronize executable scripts with the latest English source.
  * Preserved translated text, localized metadata, script ordering, and third-party scripts during synchronization.
  * Replaced outdated or hashed script assets while preventing English body content from appearing in translated pages.
  * Restored missing language-selection functionality when needed.
  * Improved stale-cache handling, cache headers, and `HEAD` request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->