### PR TITLE
fix(blog): classify origin from git history instead of author allowlist

### DIFF
--- a/apps/web/src/content.config.ts
+++ b/apps/web/src/content.config.ts
@@ -23,7 +23,7 @@ const blog = defineCollection({
       keywords: z.string().optional(),
       tag: z.string(),
       published: z.boolean().optional(),
-      /** Team editorial posts (`human`) show writer/reviewer/editor credits; pipeline posts (`ai`) keep the author byline. */
+      /** `human` = person-authored in git history (shows editorial byline); `ai` = import pipeline (shows author byline, listed under /articles). */
       origin: z.enum(['human', 'ai']).default('ai'),
       locale: localeSchema,
       next_blog: z.string().optional().nullable(),

--- a/apps/web/src/content/blog/en/5-security-best-practices-for-mobile-app-live-updates.md
+++ b/apps/web/src/content/blog/en/5-security-best-practices-for-mobile-app-live-updates.md
@@ -13,7 +13,7 @@ keywords: mobile app security, live updates, data integrity, OTA updates, encryp
 tag: Development, Mobile, Updates
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/alternative-to-appflow.md
+++ b/apps/web/src/content/blog/en/alternative-to-appflow.md
@@ -16,7 +16,7 @@ keywords: Ionic Appflow, mobile app development, live updates, OTA updates, cont
 tag: Alternatives
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/alternative-to-expo.md
+++ b/apps/web/src/content/blog/en/alternative-to-expo.md
@@ -15,7 +15,7 @@ keywords: Expo alternative, EAS Update, EAS Build, live updates, OTA updates, Ca
 tag: Alternatives
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/alternative-to-voltbuilder.md
+++ b/apps/web/src/content/blog/en/alternative-to-voltbuilder.md
@@ -16,7 +16,7 @@ keywords: Voltbuilder, mobile app development, live updates, OTA updates, contin
 tag: Alternatives
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/android-16kb-page-size-capacitor-plugins.md
+++ b/apps/web/src/content/blog/en/android-16kb-page-size-capacitor-plugins.md
@@ -13,7 +13,7 @@ keywords: Capacitor, Android 16KB page size, plugins, troubleshooting, app crash
 tag: Development, Mobile, Capacitor
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/angular-mobile-app-capacitor.md
+++ b/apps/web/src/content/blog/en/angular-mobile-app-capacitor.md
@@ -15,7 +15,7 @@ keywords: Angular, mobile app development, live updates, OTA updates, continuous
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
 ---
 

--- a/apps/web/src/content/blog/en/app-infrastructure.md
+++ b/apps/web/src/content/blog/en/app-infrastructure.md
@@ -13,6 +13,7 @@ keywords: 'app infrastructure, capacitor, live updates, electron, ci/cd'
 tag: 'Mobile, Updates, CI/CD'
 published: true
 locale: en
+origin: ai
 next_blog: ''
 ---
 You've shipped a polished Capacitor app. The React screens are stable, the Electron desktop build works, and early adoption is climbing. Then the first serious incident arrives. It isn't a problem in the component code. Users are loading a stale JavaScript bundle, an Electron update has left some installations unusable, or a critical fix is waiting through an App Store review process while support handles the fallout.

--- a/apps/web/src/content/blog/en/app-store-age-ratings-guide.md
+++ b/apps/web/src/content/blog/en/app-store-age-ratings-guide.md
@@ -13,7 +13,7 @@ keywords: age ratings, app store, google play, content ratings, IARC, parental c
 tag: Development, App Store, Best Practices
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/app-store-vs-direct-updates-what-developers-need-to-know.md
+++ b/apps/web/src/content/blog/en/app-store-vs-direct-updates-what-developers-need-to-know.md
@@ -13,7 +13,7 @@ keywords: App Store updates, OTA updates, mobile app development, update strateg
 tag: Development, Mobile, Updates
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/app-troubleshooting.md
+++ b/apps/web/src/content/blog/en/app-troubleshooting.md
@@ -13,6 +13,7 @@ keywords: 'app troubleshooting, CapacitorJS, live updates, mobile debugging, Ele
 tag: 'Mobile, Updates, Capacitor'
 published: true
 locale: en
+origin: ai
 next_blog: ''
 ---
 Thursday evening, your CapacitorJS shopping app starts showing blank dashboards for Android 14 users. iOS customers are browsing normally. Electron desktop users haven't reported anything. The on-call engineer assumes a WebView regression, opens Android Studio, and spends hours comparing rendering behavior across devices. The eventual cause isn't a rendering bug at all. A staging API key reached production after a CDN cache invalidation failed to reach mobile clients.

--- a/apps/web/src/content/blog/en/appcenter-migration.md
+++ b/apps/web/src/content/blog/en/appcenter-migration.md
@@ -15,7 +15,7 @@ keywords: App Center, migration, live updates, OTA updates, continuous integrati
 tag: Migration
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: automatic-build-and-release-with-github-actions
 ---
 ## Migration Summary

--- a/apps/web/src/content/blog/en/automate-capgo-live-updates-from-lovable-github-actions.md
+++ b/apps/web/src/content/blog/en/automate-capgo-live-updates-from-lovable-github-actions.md
@@ -15,7 +15,7 @@ keywords: Lovable, Lovable.dev, Capgo, GitHub Actions, live updates, OTA, CI/CD,
 tag: CI/CD
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: automatic-build-and-release-with-github-actions
 ---
 

--- a/apps/web/src/content/blog/en/automatic-build-and-release-with-github-actions.md
+++ b/apps/web/src/content/blog/en/automatic-build-and-release-with-github-actions.md
@@ -15,7 +15,7 @@ keywords: Github actions, CI/CD, automatic build, automatic release, mobile app 
 tag: CI/CD
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: automatic-capacitor-ios-build-github-action
 ---
 This tutorial focuses on the GitHub hosting, but you can adapt it with little tweak to any other CI/CD platform.

--- a/apps/web/src/content/blog/en/automatic-build-and-release-with-gitlab.md
+++ b/apps/web/src/content/blog/en/automatic-build-and-release-with-gitlab.md
@@ -15,7 +15,7 @@ keywords: Gitlab, CI/CD, automatic build, automatic release, mobile app updates
 tag: CI/CD
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 This tutorial focuses on the GitLab CI, but you can adapt it with a little tweak to any other CI/CD platform.

--- a/apps/web/src/content/blog/en/automatic-capacitor-android-build-github-action.md
+++ b/apps/web/src/content/blog/en/automatic-capacitor-android-build-github-action.md
@@ -15,7 +15,7 @@ keywords: Fastlane, CI/CD, Android, automatic build, automatic release, mobile a
 tag: CI/CD
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: automatic-capacitor-ios-build-github-action
 ---
 

--- a/apps/web/src/content/blog/en/automatic-capacitor-ios-build-codemagic.md
+++ b/apps/web/src/content/blog/en/automatic-capacitor-ios-build-codemagic.md
@@ -15,7 +15,7 @@ keywords: Codemagic, CI/CD, iOS, automatic build, automatic release, mobile app 
 tag: CI/CD
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: automatic-capacitor-android-build-codemagic
 ---
 

--- a/apps/web/src/content/blog/en/automatic-capacitor-ios-build-github-action-with-match.md
+++ b/apps/web/src/content/blog/en/automatic-capacitor-ios-build-github-action-with-match.md
@@ -15,7 +15,7 @@ keywords: Fastlane, CI/CD, iOS, automatic build, automatic release, mobile app u
 tag: CI/CD
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: automatic-capacitor-android-build-github-action
 ---
 

--- a/apps/web/src/content/blog/en/automatic-capacitor-ios-build-github-action.md
+++ b/apps/web/src/content/blog/en/automatic-capacitor-ios-build-github-action.md
@@ -15,7 +15,7 @@ keywords: Fastlane, CI/CD, iOS, automatic build, automatic release, mobile app u
 tag: CI/CD
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: automatic-capacitor-android-build-github-action
 ---
 

--- a/apps/web/src/content/blog/en/basic-js-css-config-for-native-app-look.md
+++ b/apps/web/src/content/blog/en/basic-js-css-config-for-native-app-look.md
@@ -15,7 +15,7 @@ keywords: tailwind css, css, mobile design, mobile app development
 tag: Web Development
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/best-capacitor-ota-updates.md
+++ b/apps/web/src/content/blog/en/best-capacitor-ota-updates.md
@@ -13,6 +13,7 @@ keywords: best Capacitor OTA updates
 tag: Mobile
 published: true
 locale: en
+origin: ai
 next_blog: ''
 ---
 Capacitor OTA updates can fix web-layer bugs without waiting for a store review. The hard part is choosing a service that keeps releases small, safe, and easy to watch. Here are six named options, with [Capgo](<https://capgo.app>) first for teams that want one command, channel control, rollback, analytics, and CI/CD support.

--- a/apps/web/src/content/blog/en/best-codepush-alternatives-for-capacitor-ionic-cordova.md
+++ b/apps/web/src/content/blog/en/best-codepush-alternatives-for-capacitor-ionic-cordova.md
@@ -13,7 +13,7 @@ keywords: CodePush alternative, App Center replacement, Capacitor CodePush alter
 tag: Alternatives, Migration, Updates
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: appcenter-migration
 ---
 

--- a/apps/web/src/content/blog/en/best-ionic-live-update-service.md
+++ b/apps/web/src/content/blog/en/best-ionic-live-update-service.md
@@ -13,6 +13,7 @@ keywords: ''
 tag: 'Mobile, Updates, Security'
 published: true
 locale: en
+origin: ai
 next_blog: ''
 ---
 Picking an Ionic live update service is really a release design task. OTA updates can fix web-layer bugs without a new store build, but they can't replace native releases. I use the workflow below to define the update boundary, compare services, set up Capgo, and add safe rollout rules.

--- a/apps/web/src/content/blog/en/best-live-update-tools-for-capacitor-apps.md
+++ b/apps/web/src/content/blog/en/best-live-update-tools-for-capacitor-apps.md
@@ -13,7 +13,7 @@ keywords: Capacitor live update tools, best Capacitor OTA updates, Capgo, Capawe
 tag: Development, Mobile, Updates
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: best-codepush-alternatives-for-capacitor-ionic-cordova
 ---
 

--- a/apps/web/src/content/blog/en/birth-of-capgo-revolutionizing-capacitor-app-updates.md
+++ b/apps/web/src/content/blog/en/birth-of-capgo-revolutionizing-capacitor-app-updates.md
@@ -18,7 +18,7 @@ keywords: >-
 tag: Development
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/build-ios-app-from-windows-capacitor-capgo-build.md
+++ b/apps/web/src/content/blog/en/build-ios-app-from-windows-capacitor-capgo-build.md
@@ -16,7 +16,7 @@ keywords: Windows, iOS, Capacitor, Capgo Build, cloud build, TestFlight, App Sto
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/building-a-native-mobile-app-with-nextjs-and-capacitor.md
+++ b/apps/web/src/content/blog/en/building-a-native-mobile-app-with-nextjs-and-capacitor.md
@@ -16,7 +16,7 @@ keywords: Next.js 15, Capacitor 8, convert web app to mobile, iOS, Android, mobi
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
 ---
 

--- a/apps/web/src/content/blog/en/building-a-native-mobile-app-with-nuxt-and-capacitor.md
+++ b/apps/web/src/content/blog/en/building-a-native-mobile-app-with-nuxt-and-capacitor.md
@@ -16,7 +16,7 @@ keywords: Nuxt 4, Capacitor 8, convert web app to mobile, iOS, Android, mobile a
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
 ---
 

--- a/apps/web/src/content/blog/en/capacitor-ai-mobile-apps.md
+++ b/apps/web/src/content/blog/en/capacitor-ai-mobile-apps.md
@@ -17,7 +17,7 @@ keywords: Capacitor, Capgo, AI mobile apps, LLM apps, live updates, OTA updates,
 tag: Development, Mobile, Technology
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/capacitor-comprehensive-guide.md
+++ b/apps/web/src/content/blog/en/capacitor-comprehensive-guide.md
@@ -17,7 +17,7 @@ keywords: mobile app development, live updates, OTA updates, continuous integrat
 tag: Guides
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/capacitor-edge-to-edge-display-native-config.md
+++ b/apps/web/src/content/blog/en/capacitor-edge-to-edge-display-native-config.md
@@ -13,7 +13,7 @@ keywords: Capacitor, edge-to-edge, Android 15, adjustMarginsForEdgeToEdge, mobil
 tag: Development, Mobile, Configuration
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/capgo-price-reduction.md
+++ b/apps/web/src/content/blog/en/capgo-price-reduction.md
@@ -13,7 +13,7 @@ keywords: capgo, price reduction, live updates, mobile app development, capacito
 tag: News
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/comparing-react-native-vs-capacitor.md
+++ b/apps/web/src/content/blog/en/comparing-react-native-vs-capacitor.md
@@ -16,7 +16,7 @@ keywords: React Native, Capacitor, mobile app development, live updates, OTA upd
 tag: Alternatives
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/compliance-checks-in-cicd-for-capacitor-apps.md
+++ b/apps/web/src/content/blog/en/compliance-checks-in-cicd-for-capacitor-apps.md
@@ -13,7 +13,7 @@ keywords: CI/CD, compliance checks, Capacitor apps, mobile security, automated t
 tag: Development, Mobile, Updates
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/cordova-hybrid-app-development.md
+++ b/apps/web/src/content/blog/en/cordova-hybrid-app-development.md
@@ -21,7 +21,7 @@ keywords: >-
 tag: Capacitor
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/create-offline-screen-in-vue-angular-react.md
+++ b/apps/web/src/content/blog/en/create-offline-screen-in-vue-angular-react.md
@@ -16,7 +16,7 @@ keywords: Vue, Angular, React, offline screen, network API, Capacitor, mobile ap
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/create-react-mobile-apps-with-capacitor.md
+++ b/apps/web/src/content/blog/en/create-react-mobile-apps-with-capacitor.md
@@ -14,7 +14,7 @@ keywords: React, Capacitor, mobile app development, live updates, OTA updates, c
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
 ---
 

--- a/apps/web/src/content/blog/en/creating-mobile-apps-with-react-and-capacitor.md
+++ b/apps/web/src/content/blog/en/creating-mobile-apps-with-react-and-capacitor.md
@@ -15,7 +15,7 @@ keywords: React, Capacitor, mobile app development, live updates, OTA updates, c
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: implementing-live-updates-in-your-react-capacitor-app
 ---
 

--- a/apps/web/src/content/blog/en/creating-mobile-apps-with-sveltekit-and-capacitor.md
+++ b/apps/web/src/content/blog/en/creating-mobile-apps-with-sveltekit-and-capacitor.md
@@ -15,7 +15,7 @@ keywords: SvelteKit, Capacitor, mobile app development, live updates, OTA update
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: updating-your-capacitor-apps-seamlessly-with-capacitor-updater
 ---
 

--- a/apps/web/src/content/blog/en/cross-platform-mobile-app-development-guide-2024.md
+++ b/apps/web/src/content/blog/en/cross-platform-mobile-app-development-guide-2024.md
@@ -19,7 +19,7 @@ keywords: >-
 tag: Mobile
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: top-cross-platform-frameworks-compared-2024
 ---
 

--- a/apps/web/src/content/blog/en/cross-platform-uiux-best-practices-for-capacitor-apps.md
+++ b/apps/web/src/content/blog/en/cross-platform-uiux-best-practices-for-capacitor-apps.md
@@ -13,7 +13,7 @@ keywords: Capacitor, UI/UX design, cross-platform apps, mobile development, resp
 tag: Development, Mobile, Updates
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/developing-cross-platform-apps-with-capacitorjs.md.md
+++ b/apps/web/src/content/blog/en/developing-cross-platform-apps-with-capacitorjs.md.md
@@ -15,7 +15,7 @@ keywords: Capacitor, cross-platform, PWA, mobile app development, live updates, 
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/do-apple-allow-live-updates.md
+++ b/apps/web/src/content/blog/en/do-apple-allow-live-updates.md
@@ -15,7 +15,7 @@ keywords: Apple, live updates, OTA updates, continuous integration, mobile app u
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
 ---
 

--- a/apps/web/src/content/blog/en/do-capgo-work-for-cordova.md
+++ b/apps/web/src/content/blog/en/do-capgo-work-for-cordova.md
@@ -13,7 +13,7 @@ keywords: Cordova, mobile app development, live updates, OTA updates, continuous
 tag: Migration
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/do-google-allow-live-updates.md
+++ b/apps/web/src/content/blog/en/do-google-allow-live-updates.md
@@ -15,7 +15,7 @@ keywords: Google, live updates, OTA updates, continuous integration, mobile app 
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
 ---
 

--- a/apps/web/src/content/blog/en/enable-ios-developer-mode-ios16.md
+++ b/apps/web/src/content/blog/en/enable-ios-developer-mode-ios16.md
@@ -15,7 +15,7 @@ keywords: iOS, Developer Mode, mobile app development, live updates, OTA updates
 tag: iOS
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/first-time-app-review-guide.md
+++ b/apps/web/src/content/blog/en/first-time-app-review-guide.md
@@ -13,7 +13,7 @@ keywords: app store review, play store review, app submission, privacy policy, t
 tag: Development, App Store, Best Practices
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/fix-capacitor-plugin-build-errors-with-agp-9.md
+++ b/apps/web/src/content/blog/en/fix-capacitor-plugin-build-errors-with-agp-9.md
@@ -13,7 +13,7 @@ keywords: Capacitor plugin build error, AGP 9, Android Gradle Plugin 9, proguard
 tag: Development, Android, Updates
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/how-capgo-channel-switching-works.md
+++ b/apps/web/src/content/blog/en/how-capgo-channel-switching-works.md
@@ -13,7 +13,7 @@ keywords: channels, channel surfing, OTA updates, capacitor, capgo, live updates
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/how-capgo-is-born.md
+++ b/apps/web/src/content/blog/en/how-capgo-is-born.md
@@ -13,7 +13,7 @@ keywords: mobile app development, live updates, OTA updates, continuous integrat
 tag: Story
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/how-easy-is-it-to-make-web-app-into-mobile-app-with-capacitor.md
+++ b/apps/web/src/content/blog/en/how-easy-is-it-to-make-web-app-into-mobile-app-with-capacitor.md
@@ -16,7 +16,7 @@ keywords: Capacitor, web app to mobile app, app store review, Google Play closed
 tag: Tutorial, Mobile, App Store
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: transform-pwa-to-native-app-with-capacitor
 ---
 

--- a/apps/web/src/content/blog/en/how-live-updates-for-capacitor-work.md
+++ b/apps/web/src/content/blog/en/how-live-updates-for-capacitor-work.md
@@ -13,7 +13,7 @@ keywords: 'Capgo live updates, OTA updates, Capacitor updates, mobile app develo
 tag: 'Development, Mobile, Updates'
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/how-to-build-capacitor-app-in-xcode-cloud.md
+++ b/apps/web/src/content/blog/en/how-to-build-capacitor-app-in-xcode-cloud.md
@@ -13,7 +13,7 @@ keywords: Xcode Cloud, Capacitor, mobile app development, live updates, OTA upda
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 ---
 
 ## Prerequisites

--- a/apps/web/src/content/blog/en/how-to-bypass-app-store-review.md
+++ b/apps/web/src/content/blog/en/how-to-bypass-app-store-review.md
@@ -15,7 +15,7 @@ keywords: Apple App Store, Google Play, Capacitor, Capgo, OTA updates, live upda
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: app-store-vs-direct-updates-what-developers-need-to-know
 ---
 

--- a/apps/web/src/content/blog/en/how-to-keep-capgo-updates-lean-and-fast.md
+++ b/apps/web/src/content/blog/en/how-to-keep-capgo-updates-lean-and-fast.md
@@ -16,7 +16,7 @@ keywords: Capgo, live updates, OTA updates, delta updates, channels, Capacitor, 
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: staging-environments-with-capgo-channels
 ---
 

--- a/apps/web/src/content/blog/en/how-to-make-revenue-with-capacitor-iap.md
+++ b/apps/web/src/content/blog/en/how-to-make-revenue-with-capacitor-iap.md
@@ -13,7 +13,7 @@ keywords: Capacitor revenue, in-app purchases, subscriptions, mobile app monetiz
 tag: Mobile, IAP, Monetization
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/how-to-migrate-your-capacitor-app-to-spm.md
+++ b/apps/web/src/content/blog/en/how-to-migrate-your-capacitor-app-to-spm.md
@@ -14,7 +14,7 @@ keywords: Swift Package Manager, SPM, CocoaPods, Capacitor app, iOS app, Xcode, 
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/how-to-pass-app-store-review-iap.md
+++ b/apps/web/src/content/blog/en/how-to-pass-app-store-review-iap.md
@@ -13,7 +13,7 @@ keywords: app store review, in-app purchases, iOS review, Android review, subscr
 tag: Mobile, IAP, App Store, Google Play
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/how-to-release-major-version-in-capgo.md
+++ b/apps/web/src/content/blog/en/how-to-release-major-version-in-capgo.md
@@ -15,7 +15,7 @@ keywords: mobile app development, live updates, OTA updates, continuous integrat
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: how-to-send-specific-version-to-users
 ---
 

--- a/apps/web/src/content/blog/en/how-to-segment-users-by-plan-and-channels.md
+++ b/apps/web/src/content/blog/en/how-to-segment-users-by-plan-and-channels.md
@@ -13,7 +13,7 @@ keywords: channels, feature flags, a/b testing, capacitor, capgo
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/how-to-send-specific-version-to-users.md
+++ b/apps/web/src/content/blog/en/how-to-send-specific-version-to-users.md
@@ -17,7 +17,7 @@ keywords: >-
 tag: Alternatives
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/how-to-track-ota-update-success-in-capacitor-apps.md
+++ b/apps/web/src/content/blog/en/how-to-track-ota-update-success-in-capacitor-apps.md
@@ -13,7 +13,7 @@ keywords: OTA updates, app tracking, user adoption, version management, error mo
 tag: Development, Mobile, Updates
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/how-version-work-in-capgo.md
+++ b/apps/web/src/content/blog/en/how-version-work-in-capgo.md
@@ -15,7 +15,7 @@ keywords: mobile app development, live updates, OTA updates, continuous integrat
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: how-to-release-major-version-in-capgo
 ---
 

--- a/apps/web/src/content/blog/en/how-your-usage-is-counted.md
+++ b/apps/web/src/content/blog/en/how-your-usage-is-counted.md
@@ -15,7 +15,7 @@ keywords: mobile app development, live updates, OTA updates, continuous integrat
 tag: Solution
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/in-app-purchases-capacitor.md
+++ b/apps/web/src/content/blog/en/in-app-purchases-capacitor.md
@@ -15,7 +15,7 @@ keywords: Capacitor, in-app purchases, RevenueCat, mobile app development, live 
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/integrate-universal-links-capacitor-nextjs.md
+++ b/apps/web/src/content/blog/en/integrate-universal-links-capacitor-nextjs.md
@@ -15,7 +15,7 @@ keywords: Capacitor, Universal Links, Next.js, mobile app development, live upda
 tag: DeepLinking
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/introducing-capgo-cloud-build.md
+++ b/apps/web/src/content/blog/en/introducing-capgo-cloud-build.md
@@ -15,7 +15,7 @@ keywords: cloud build, native build, capacitor, iOS build, Android build, CI/CD,
 tag: Product
 published: true
 locale: en
-origin: ai
+origin: human
 ---
 
 We're excited to announce **Capgo Cloud Build** - a new way to build your Capacitor apps for iOS and Android directly in the cloud, without the need for local development environments or CI/CD infrastructure.

--- a/apps/web/src/content/blog/en/introducing-end-to-end-security-to-capacitor-updater-with-code-signing.md
+++ b/apps/web/src/content/blog/en/introducing-end-to-end-security-to-capacitor-updater-with-code-signing.md
@@ -15,7 +15,7 @@ keywords: E2E, code signing, RSA, AES, mobile app development, live updates, OTA
 tag: Solution
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/ionic-capacitor-push-notifications-firebase.md
+++ b/apps/web/src/content/blog/en/ionic-capacitor-push-notifications-firebase.md
@@ -15,7 +15,7 @@ keywords: Ionic, Capacitor, push notifications, Firebase, mobile app development
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/ios-spm-vs-cocoapods-capacitor-migration-guide.md
+++ b/apps/web/src/content/blog/en/ios-spm-vs-cocoapods-capacitor-migration-guide.md
@@ -14,7 +14,7 @@ keywords: Swift Package Manager, SPM, CocoaPods, Capacitor, iOS, migration, depe
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/live-updates-for-flutter-app.md
+++ b/apps/web/src/content/blog/en/live-updates-for-flutter-app.md
@@ -15,7 +15,7 @@ keywords: Flutter, mobile app development, live updates, OTA updates, continuous
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
 ---
 

--- a/apps/web/src/content/blog/en/manage-dev-and-prod-build-with-github-actions.md
+++ b/apps/web/src/content/blog/en/manage-dev-and-prod-build-with-github-actions.md
@@ -15,7 +15,7 @@ keywords: GitHub Actions, CI/CD, mobile app development, live updates, OTA updat
 tag: CI/CD
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: how-to-send-specific-version-to-users
 ---
 This tutorial focuses on the GitHub hosting, but you can adapt it with a little tweak to any other CI/CD platform.

--- a/apps/web/src/content/blog/en/migrating-cordova-to-capacitor.md
+++ b/apps/web/src/content/blog/en/migrating-cordova-to-capacitor.md
@@ -15,7 +15,7 @@ keywords: Cordova, Capacitor, migration, mobile app development, live updates, O
 tag: Migration
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/moving-from-microsoft-app-center-to-capgo.md
+++ b/apps/web/src/content/blog/en/moving-from-microsoft-app-center-to-capgo.md
@@ -15,7 +15,7 @@ keywords: Microsoft, App Center, mobile app development, live updates, OTA updat
 tag: Alternatives
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 Microsoft recently announced that they will be [discontinuing support for apps running on Apache Cordova](https://devblogs.microsoft.com/appcenter/announcing-apache-cordova-retirement/) in their cloud product, App Center. This has prompted businesses and teams using App Center to seek alternatives, and I am thrilled to say that the [Capgo](https://capgo.app/) platform is a fantastic option for those looking for full support for Capacitor apps.

--- a/apps/web/src/content/blog/en/nextjs-mobile-app-capacitor-from-scratch.md
+++ b/apps/web/src/content/blog/en/nextjs-mobile-app-capacitor-from-scratch.md
@@ -16,7 +16,7 @@ keywords: Next.js 15, Capacitor 8, mobile app from scratch, iOS development, And
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
 ---
 

--- a/apps/web/src/content/blog/en/nuxt-mobile-app-capacitor-from-scratch.md
+++ b/apps/web/src/content/blog/en/nuxt-mobile-app-capacitor-from-scratch.md
@@ -16,7 +16,7 @@ keywords: Nuxt 4, Capacitor 8, mobile app from scratch, iOS development, Android
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
 ---
 

--- a/apps/web/src/content/blog/en/open-source-updater.md
+++ b/apps/web/src/content/blog/en/open-source-updater.md
@@ -13,7 +13,7 @@ keywords: 'open source updater, Capacitor live updates, Electron auto update, OT
 tag: 'Mobile, Updates, Security'
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 Open source now sits in the center of commercial software, not at the edges. A 2024 Synopsys and Open Source Security and Risk Analysis summary found that **96%** of commercial codebases contained open source software, and **77%** of the code in those codebases was open source, while the Linux Foundation's 2022 study put typical open source content at roughly **70% to 90%** of a software codebase ([Intel's overview of open source consumption](https://www.intel.com/content/www/us/en/developer/articles/guide/the-careful-consumption-of-open-source-software.html)). If your product ships to phones, desktops, or devices, an **open source updater** isn't a convenience feature. It's part of the delivery system that keeps those dependencies, bundles, and runtime assets safe enough to run in production.

--- a/apps/web/src/content/blog/en/optimise-your-images-for-updates.md
+++ b/apps/web/src/content/blog/en/optimise-your-images-for-updates.md
@@ -15,7 +15,7 @@ keywords: mobile app development, live updates, OTA updates, continuous integrat
 tag: Optimisation
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/self-hosted-live-updates.md
+++ b/apps/web/src/content/blog/en/self-hosted-live-updates.md
@@ -15,7 +15,7 @@ keywords: mobile app development, live updates, OTA updates, continuous integrat
 tag: Solution
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/setup-stripe-payment-in-us-capacitor.md
+++ b/apps/web/src/content/blog/en/setup-stripe-payment-in-us-capacitor.md
@@ -13,7 +13,7 @@ keywords: capacitor, stripe, payment links, app store guidelines, iOS, digital g
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 ---
 
 # Implementing Stripe Payment Links in Capacitor Apps Following New Apple Guidelines

--- a/apps/web/src/content/blog/en/setup-supabase-with-capacitor-social-login.md
+++ b/apps/web/src/content/blog/en/setup-supabase-with-capacitor-social-login.md
@@ -14,7 +14,7 @@ keywords: Supabase, Capacitor, social login, authentication, Google, Apple, Face
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/staging-environments-with-capgo-channels.md
+++ b/apps/web/src/content/blog/en/staging-environments-with-capgo-channels.md
@@ -15,7 +15,7 @@ keywords: mobile app environments, staging, Capgo channels, TestFlight, Capacito
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: staging-ota-updates-best-practices
 ---
 

--- a/apps/web/src/content/blog/en/transform-base44-app-to-mobile-with-capacitor.md
+++ b/apps/web/src/content/blog/en/transform-base44-app-to-mobile-with-capacitor.md
@@ -15,7 +15,7 @@ keywords: Base44, Capacitor, mobile app development, React, export project, nati
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: transform-lovable-dev-app-to-mobile-with-capacitor
 ---
 

--- a/apps/web/src/content/blog/en/transform-bolt-new-app-to-mobile-with-capacitor.md
+++ b/apps/web/src/content/blog/en/transform-bolt-new-app-to-mobile-with-capacitor.md
@@ -15,7 +15,7 @@ keywords: Bolt.new, Capacitor, mobile app development, React, Vue, export projec
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: building-a-native-mobile-app-with-nextjs-and-capacitor
 ---
 

--- a/apps/web/src/content/blog/en/transform-lovable-dev-app-to-mobile-with-capacitor.md
+++ b/apps/web/src/content/blog/en/transform-lovable-dev-app-to-mobile-with-capacitor.md
@@ -15,7 +15,7 @@ keywords: Lovable, Lovable.dev, Capacitor, mobile app development, React, Vite, 
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: building-a-native-mobile-app-with-nextjs-and-capacitor
 ---
 

--- a/apps/web/src/content/blog/en/transform-pwa-to-native-app-with-capacitor.md
+++ b/apps/web/src/content/blog/en/transform-pwa-to-native-app-with-capacitor.md
@@ -16,7 +16,7 @@ keywords: PWA, Capacitor, native mobile app, iOS, Android, web-to-app migration,
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: building-a-native-mobile-app-with-nextjs-and-capacitor
 ---
 

--- a/apps/web/src/content/blog/en/turn-every-pr-into-installable-preview.md
+++ b/apps/web/src/content/blog/en/turn-every-pr-into-installable-preview.md
@@ -13,7 +13,7 @@ keywords: pr preview, pull request, OTA updates, capacitor, capgo, live updates,
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/turn-off-android-talkback.md
+++ b/apps/web/src/content/blog/en/turn-off-android-talkback.md
@@ -15,7 +15,7 @@ keywords: Android, TalkBack, screen reader, visually impaired, mobile app develo
 tag: Android
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/update-your-capacitor-apps-seamlessly-using-capacitor-updater.md
+++ b/apps/web/src/content/blog/en/update-your-capacitor-apps-seamlessly-using-capacitor-updater.md
@@ -15,7 +15,7 @@ keywords: Capacitor, mobile app development, live updates, OTA updates, continuo
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/updating-from-capacitor-4-to-capacitor-5.md
+++ b/apps/web/src/content/blog/en/updating-from-capacitor-4-to-capacitor-5.md
@@ -15,7 +15,7 @@ keywords: Capacitor, mobile app development, live updates, OTA updates, continuo
 tag: Capacitor
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/vue-mobile-app-capacitor.md
+++ b/apps/web/src/content/blog/en/vue-mobile-app-capacitor.md
@@ -15,7 +15,7 @@ keywords: Vue, Capacitor, mobile app development, live updates, OTA updates, con
 tag: Tutorial
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: update-your-capacitor-apps-seamlessly-using-capacitor-updater
 ---
 

--- a/apps/web/src/content/blog/en/why-app-reviews-ratings-matter.md
+++ b/apps/web/src/content/blog/en/why-app-reviews-ratings-matter.md
@@ -13,7 +13,7 @@ keywords: app reviews, app ratings, app store optimization, ASO, user reviews, a
 tag: Marketing, ASO, Best Practices
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/apps/web/src/content/blog/en/xcode-26-requirement-for-capacitor-apps.md
+++ b/apps/web/src/content/blog/en/xcode-26-requirement-for-capacitor-apps.md
@@ -13,7 +13,7 @@ keywords: Apple, Xcode 26, iOS 26 SDK, Capacitor, App Store Connect, Capgo Build
 tag: Development, Mobile, Cloud
 published: true
 locale: en
-origin: ai
+origin: human
 next_blog: ''
 ---
 

--- a/scripts/backfill-blog-origin.mjs
+++ b/scripts/backfill-blog-origin.mjs
@@ -8,7 +8,7 @@
  * Run: bun run scripts/backfill-blog-origin.mjs
  */
 import { execFileSync } from 'node:child_process'
-import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join, relative } from 'node:path'
 
 const REPO_ROOT = join(import.meta.dirname, '..')
@@ -28,9 +28,23 @@ const AUTOMATION_IMPORT_MESSAGES = [
 const OUTRANK_ATTRIBUTION =
   /(?:Prepared with|Written with)\s+\[(?:Outrank (?:app|tool))\]\(https:\/\/outrank\.so\)/i
 
+const TRUSTED_GIT_BINARIES = ['/usr/bin/git', '/usr/local/bin/git']
+
+function resolveTrustedGitBinary() {
+  for (const gitPath of TRUSTED_GIT_BINARIES) {
+    if (existsSync(gitPath)) {
+      return gitPath
+    }
+  }
+
+  throw new Error(`No trusted git binary found. Expected one of: ${TRUSTED_GIT_BINARIES.join(', ')}`)
+}
+
+const GIT_BINARY = resolveTrustedGitBinary()
+
 function execGit(args) {
   try {
-    return execFileSync('git', args, {
+    return execFileSync(GIT_BINARY, args, {
       cwd: REPO_ROOT,
       encoding: 'utf8',
       maxBuffer: 16 * 1024 * 1024,

--- a/scripts/backfill-blog-origin.mjs
+++ b/scripts/backfill-blog-origin.mjs
@@ -9,7 +9,7 @@
  */
 import { execFileSync } from 'node:child_process'
 import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { join, relative } from 'node:path'
+import { isAbsolute, join, relative } from 'node:path'
 
 const REPO_ROOT = join(import.meta.dirname, '..')
 const BLOG_DIR = join(REPO_ROOT, 'apps/web/src/content/blog/en')
@@ -28,9 +28,17 @@ const AUTOMATION_IMPORT_MESSAGES = [
 const OUTRANK_ATTRIBUTION =
   /(?:Prepared with|Written with)\s+\[(?:Outrank (?:app|tool))\]\(https:\/\/outrank\.so\)/i
 
-const TRUSTED_GIT_BINARIES = ['/usr/bin/git', '/usr/local/bin/git']
+const TRUSTED_GIT_BINARIES = ['/usr/bin/git', '/usr/local/bin/git', '/opt/homebrew/bin/git']
 
 function resolveTrustedGitBinary() {
+  const override = process.env.GIT_BINARY_PATH
+  if (override) {
+    if (!isAbsolute(override) || !existsSync(override)) {
+      throw new Error(`GIT_BINARY_PATH must be an existing absolute path: ${override}`)
+    }
+    return override
+  }
+
   for (const gitPath of TRUSTED_GIT_BINARIES) {
     if (existsSync(gitPath)) {
       return gitPath

--- a/scripts/backfill-blog-origin.mjs
+++ b/scripts/backfill-blog-origin.mjs
@@ -35,8 +35,17 @@ function execGit(args) {
       encoding: 'utf8',
       maxBuffer: 16 * 1024 * 1024,
     }).trim()
-  } catch {
-    return ''
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`git ${args.join(' ')} failed: ${message}`, { cause: error })
+  }
+}
+
+function assertGitRepositoryReady() {
+  execGit(['rev-parse', '--git-dir'])
+
+  if (execGit(['rev-parse', '--is-shallow-repository']) === 'true') {
+    throw new Error('Shallow clone detected. Run `git fetch --unshallow` before backfilling origins.')
   }
 }
 
@@ -60,7 +69,7 @@ function parseGitLog(output) {
 }
 
 function getAddsForPath(path, { follow = false, all = false } = {}) {
-  const args = ['log', '--diff-filter=A', '--format=%H|%ai|%an|%ae|%s']
+  const args = ['log', '--diff-filter=A', '--format=%H|%aI|%an|%ae|%s']
   if (all) args.push('--all')
   if (follow) args.push('--follow')
   args.push('--', path)
@@ -187,6 +196,8 @@ function upsertOrigin(frontmatterBlock, origin) {
 
   return `${frontmatterBlock}\norigin: ${origin}`
 }
+
+assertGitRepositoryReady()
 
 const files = readdirSync(BLOG_DIR).filter((file) => file.endsWith('.md') || file.endsWith('.mdx'))
 const counts = { human: 0, ai: 0, updated: 0 }

--- a/scripts/backfill-blog-origin.mjs
+++ b/scripts/backfill-blog-origin.mjs
@@ -1,20 +1,166 @@
 #!/usr/bin/env bun
 /**
- * Backfill `origin: human | ai` on blog post frontmatter.
+ * Backfill `origin: human | ai` on EN blog post frontmatter from git history.
  *
- * - human: Capgo editorial team authors only (posts that show the 3-person byline)
- * - ai: everything else (listed under /articles)
+ * - human: first meaningful commit that added the article was by a person (not import automation)
+ * - ai: Outrank/Distrib/GitHub Action imports and other bot-authored adds (listed under /articles)
+ *
+ * Run: bun run scripts/backfill-blog-origin.mjs
  */
+import { execFileSync } from 'node:child_process'
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, relative } from 'node:path'
 
-const BLOG_DIR = join(import.meta.dirname, '../apps/web/src/content/blog/en')
+const REPO_ROOT = join(import.meta.dirname, '..')
+const BLOG_DIR = join(REPO_ROOT, 'apps/web/src/content/blog/en')
 
-const HUMAN_AUTHORS = new Set(['WcaleNieWolny', 'Michael (WcaleNieWolny)', 'Anik Dhabal Babu', 'Rupert Barrow'])
+const MECHANICAL_COMMIT_PATTERNS = [
+  /^chore: auto-bump updated_at dates for modified blog posts$/i,
+  /^feat\(blog\): separate human and AI article listings/i,
+]
 
-function classifyOrigin(frontmatter) {
-  const author = frontmatter.author ?? ''
-  return HUMAN_AUTHORS.has(author) ? 'human' : 'ai'
+const AUTOMATION_IMPORT_MESSAGES = [
+  /^chore: import outrank articles$/i,
+  /^chore: import distrib articles$/i,
+  /^chore: sync blog posts from seobot$/i,
+]
+
+const OUTRANK_ATTRIBUTION =
+  /(?:Prepared with|Written with)\s+\[(?:Outrank (?:app|tool))\]\(https:\/\/outrank\.so\)/i
+
+function execGit(args) {
+  try {
+    return execFileSync('git', args, {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+    }).trim()
+  } catch {
+    return ''
+  }
+}
+
+function parseGitLog(output) {
+  if (!output) return []
+
+  return output
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split('|')
+      const [hash, date, author, email, ...messageParts] = parts
+      return {
+        hash,
+        date,
+        author,
+        email,
+        message: messageParts.join('|'),
+      }
+    })
+}
+
+function getAddsForPath(path, { follow = false, all = false } = {}) {
+  const args = ['log', '--diff-filter=A', '--format=%H|%ai|%an|%ae|%s']
+  if (all) args.push('--all')
+  if (follow) args.push('--follow')
+  args.push('--', path)
+
+  return parseGitLog(execGit(args))
+}
+
+function legacyPathPatterns(slug) {
+  const names = [`${slug}.md`, `${slug}.mdx`]
+  const prefixes = [
+    'apps/web/src/content/blog/en',
+    'src/content/blog/en',
+    'src/content/blog',
+    'content/blog',
+    'src/content/article',
+    'content/article',
+  ]
+
+  const paths = new Set()
+  for (const prefix of prefixes) {
+    for (const name of names) {
+      paths.add(`${prefix}/${name}`)
+    }
+  }
+
+  return [...paths]
+}
+
+function isMechanicalCommit(message) {
+  return MECHANICAL_COMMIT_PATTERNS.some((pattern) => pattern.test(message.trim()))
+}
+
+function isAutomationAuthor({ author, email }) {
+  const authorLower = author.toLowerCase()
+  const emailLower = email.toLowerCase()
+
+  if (authorLower === 'github action') return true
+  if (authorLower === 'actions-user') return true
+  if (authorLower.includes('[bot]')) return true
+  if (emailLower === 'action@github.com') return true
+  if (authorLower.includes('cursor agent')) return true
+  if (authorLower.includes('devin ai')) return true
+  if (authorLower.endsWith('-bot')) return true
+
+  return false
+}
+
+function isAutomationImportMessage(message) {
+  return AUTOMATION_IMPORT_MESSAGES.some((pattern) => pattern.test(message.trim()))
+}
+
+function classifyCommit(commit) {
+  if (isAutomationAuthor(commit) || isAutomationImportMessage(commit.message)) {
+    return 'ai'
+  }
+
+  return 'human'
+}
+
+function findIntroducingCommit(slug, currentRelPath) {
+  const byHash = new Map()
+
+  const addCandidates = (commits) => {
+    for (const commit of commits) {
+      if (!byHash.has(commit.hash)) {
+        byHash.set(commit.hash, commit)
+      }
+    }
+  }
+
+  addCandidates(getAddsForPath(currentRelPath, { follow: true }))
+  for (const path of legacyPathPatterns(slug)) {
+    addCandidates(getAddsForPath(path, { all: true }))
+  }
+
+  const meaningful = [...byHash.values()]
+    .filter((commit) => !isMechanicalCommit(commit.message))
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+
+  return meaningful[0] ?? null
+}
+
+function classifyOrigin(slug, currentRelPath, body) {
+  const commit = findIntroducingCommit(slug, currentRelPath)
+
+  if (!commit) {
+    if (OUTRANK_ATTRIBUTION.test(body)) {
+      return { origin: 'ai', commit: null, reason: 'outrank-attribution' }
+    }
+
+    return { origin: 'ai', commit: null, reason: 'default-unclassified' }
+  }
+
+  const origin = classifyCommit(commit)
+
+  if (origin === 'human' && OUTRANK_ATTRIBUTION.test(body)) {
+    return { origin: 'ai', commit, reason: 'outrank-attribution-overrides-human-commit' }
+  }
+
+  return { origin, commit, reason: 'git-introducing-commit' }
 }
 
 function parseFrontmatter(content) {
@@ -44,6 +190,7 @@ function upsertOrigin(frontmatterBlock, origin) {
 
 const files = readdirSync(BLOG_DIR).filter((file) => file.endsWith('.md') || file.endsWith('.mdx'))
 const counts = { human: 0, ai: 0, updated: 0 }
+const examples = { human: [], ai: [] }
 
 for (const file of files) {
   const filePath = join(BLOG_DIR, file)
@@ -54,8 +201,18 @@ for (const file of files) {
     continue
   }
 
-  const origin = classifyOrigin(parsed.frontmatter)
+  const slug = parsed.frontmatter.slug || file.replace(/\.(md|mdx)$/, '')
+  const currentRelPath = relative(REPO_ROOT, filePath)
+  const { origin, commit } = classifyOrigin(slug, currentRelPath, parsed.body)
   counts[origin]++
+
+  if (examples[origin].length < 5) {
+    examples[origin].push({
+      slug,
+      author: commit?.author ?? 'n/a',
+      message: commit?.message ?? 'n/a',
+    })
+  }
 
   const nextFrontmatter = upsertOrigin(parsed.block.slice(4, -4), origin)
   const nextContent = `---\n${nextFrontmatter}\n---${parsed.body}`
@@ -69,3 +226,13 @@ for (const file of files) {
 console.log(`Backfilled ${files.length} EN posts (${counts.updated} files changed)`)
 console.log(`  human: ${counts.human}`)
 console.log(`  ai: ${counts.ai}`)
+console.log('')
+console.log('Example human slugs:')
+for (const example of examples.human) {
+  console.log(`  - ${example.slug} (${example.author}: ${example.message})`)
+}
+console.log('')
+console.log('Example ai slugs:')
+for (const example of examples.ai) {
+  console.log(`  - ${example.slug} (${example.author}: ${example.message})`)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Recut EN blog `origin: human | ai` from git history instead of the old frontmatter author-name allowlist (PR #988).

`scripts/backfill-blog-origin.mjs` now finds the earliest meaningful add commit for each post across legacy paths (`content/blog`, `src/content/blog`, `apps/web/...`), skips mechanical date/origin-only commits, and classifies automation imports (Outrank, Distrib, SEObot, GitHub Actions) as `ai`.

## Counts after backfill

| Origin | Count |
|--------|-------|
| `human` | 100 |
| `ai` | 303 |
| **Total EN posts** | **403** |

Previously (author allowlist): 12 human, ~380 ai.

## Example `human` posts (introducing commit)

| Slug | Author | Message |
|------|--------|---------|
| `how-capgo-is-born` | martindonadieu | fix: alternative to article and use old text to write backstory |
| `birth-of-capgo-revolutionizing-capacitor-app-updates` | Martin Donadieu | doc: first version of birth article |
| `introducing-capgo-cloud-build` | Martin Donadieu | feat: Add iOS Builds documentation and troubleshooting guide |
| `capgo-build-leaves-beta` | WcaleNieWolny | feat(blog): add "Capgo Build leaves beta" announcement post |
| `capgo-2025-year-in-review` | WcaleNieWolny | feat: Add a comprehensive blog post for 2025 Year in Review (#421) |

## Example `ai` posts (introducing commit)

| Slug | Author | Message |
|------|--------|---------|
| `yarn-clear-cache` | GitHub Action | chore: import Outrank articles |
| `what-is-network-latency` | GitHub Action | chore: import Outrank articles |
| `2-way-communication-in-capacitor-apps` | github-actions[bot] | chore: sync blog posts from SEObot |
| `5-common-ota-update-mistakes-to-avoid` | github-actions[bot] | chore: sync blog posts from SEObot |

## Re-run

```bash
bun run scripts/backfill-blog-origin.mjs
```

## Test plan

- [x] `how-capgo-is-born`, `birth-of-capgo-revolutionizing-capacitor-app-updates`, `introducing-capgo-cloud-build` are `origin: human`
- [x] Outrank/Distrib/SEObot imports are `origin: ai`
- [x] No Martin-first-add EN posts left as `ai`
- [ ] CI passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f4d7f4d-007a-483f-8faf-4ba8ed50e915?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f4d7f4d-007a-483f-8faf-4ba8ed50e915&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790377445&installation_model_id=430928&pr_number=992&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F992&signature=63562df76f49b53992a6ac5921e8eaf76ddb0548222d04a8b8d2f56c07bc32ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how article origins are categorized and displayed.
* **Content Updates**
  * Updated provenance labels across the blog to distinguish human-authored and imported articles.
  * Added origin labels to previously unclassified articles.
* **Chores**
  * Improved consistency and accuracy of article-origin classification.
  * Enhanced handling and reporting when publication history is unavailable.
  * Made content provenance easier to understand while browsing the article library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->