### PR TITLE
fix(translation-worker): enforce ±3 word count on short UI copy

### DIFF
--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -164,7 +164,42 @@ const supportContext = __translationWorkerTest.resolveTranslationContexts(['Supp
 assert(typeof supportContext === 'string' && supportContext.includes('support') && supportContext.includes('capwesome'), 'Duplicate Support text dropped one of its contexts')
 const emptySuffixContext = __translationWorkerTest.resolveTranslationContexts(['1 build hour'])[0]
 assert(typeof emptySuffixContext === 'string' && emptySuffixContext.includes('native_build_builder_build_hour'), 'Empty placeholder suffix did not resolve build-hour context')
-assert(__translationWorkerTest.TRANSLATION_CACHE_VERSION.includes('nav-guard-dedupe-batch-v1'), 'Cache version was not bumped for nav guard + batch dedupe support')
+assert(__translationWorkerTest.TRANSLATION_CACHE_VERSION.includes('word-count-constraint-v1'), 'Cache version was not bumped for word count constraint support')
+
+assert(__translationWorkerTest.translationWordCount('Ship mobile updates instantly') === 4, 'Word count did not count a short English headline')
+assert(__translationWorkerTest.translationWordCount('Évitez l\u2019attente de l\u2019App Store.') === 5, 'Word count did not count elided French words')
+assert(
+  __translationWorkerTest.translationWordCount(
+    'Deploy fixes and features without waiting for app store review delays while keeping your release pipeline fast and reliable for every user across all platforms.',
+  ) > 24,
+  'Word count fixture did not exceed the short-copy enforcement ceiling',
+)
+
+assert(
+  __translationWorkerTest.translationWordCountViolation('Ship mobile updates instantly', 'Déployez des mises à jour mobiles instantanément aux utilisateurs partout', 'French'),
+  'Word count guard did not reject an overlong French headline translation',
+)
+assert(
+  !__translationWorkerTest.translationWordCountViolation('Ship mobile updates instantly', 'Déployez des mises à jour mobiles', 'French'),
+  'Word count guard flagged a French headline within the ±3 word window',
+)
+assert(
+  !__translationWorkerTest.translationWordCountViolation(
+    'Deploy fixes and features without waiting for app store review delays while keeping your release pipeline fast and reliable for every user across all platforms.',
+    'Déployez des correctifs et des fonctionnalités sans attendre les délais de révision de l\u2019App Store tout en gardant votre pipeline de publication rapide et fiable pour chaque utilisateur sur toutes les plateformes.',
+    'French',
+  ),
+  'Word count guard should not apply to long body copy',
+)
+assert(
+  !__translationWorkerTest.translationWordCountViolation('Ship mobile updates instantly', '全デバイスへ安全に配信', 'Japanese'),
+  'Word count guard should not apply to compact CJK targets',
+)
+assert(
+  __translationWorkerTest.guardTranslationLength('Ship mobile updates instantly', 'Déployez des mises à jour mobiles instantanément aux utilisateurs partout', 'French') ===
+    'Ship mobile updates instantly',
+  'Translation guard did not fall back to source for word-count violations',
+)
 assert(
   __translationWorkerTest.applyFrenchArticleElision('Évitez la attente. Livrez la correction.') === 'Évitez l\u2019attente. Livrez la correction.',
   'French elision did not fix "la attente"',

--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -164,7 +164,7 @@ const supportContext = __translationWorkerTest.resolveTranslationContexts(['Supp
 assert(typeof supportContext === 'string' && supportContext.includes('support') && supportContext.includes('capwesome'), 'Duplicate Support text dropped one of its contexts')
 const emptySuffixContext = __translationWorkerTest.resolveTranslationContexts(['1 build hour'])[0]
 assert(typeof emptySuffixContext === 'string' && emptySuffixContext.includes('native_build_builder_build_hour'), 'Empty placeholder suffix did not resolve build-hour context')
-assert(__translationWorkerTest.TRANSLATION_CACHE_VERSION.includes('word-count-constraint-v1'), 'Cache version was not bumped for word count constraint support')
+assert(__translationWorkerTest.TRANSLATION_CACHE_VERSION.includes('word-count-retry-v1'), 'Cache version was not bumped for word count retry support')
 
 assert(__translationWorkerTest.translationWordCount('Ship mobile updates instantly') === 4, 'Word count did not count a short English headline')
 assert(__translationWorkerTest.translationWordCount('Évitez l\u2019attente de l\u2019App Store.') === 5, 'Word count did not count elided French words')
@@ -196,9 +196,21 @@ assert(
   'Word count guard should not apply to compact CJK targets',
 )
 assert(
+  __translationWorkerTest.guardTranslationLength('Ship mobile updates instantly', 'Déployez des mises à jour mobiles', 'French') === 'Déployez des mises à jour mobiles',
+  'Length guard keeps valid short headline translations instead of falling back to English',
+)
+assert(
   __translationWorkerTest.guardTranslationLength('Ship mobile updates instantly', 'Déployez des mises à jour mobiles instantanément aux utilisateurs partout', 'French') ===
     'Ship mobile updates instantly',
-  'Translation guard did not fall back to source for word-count violations',
+  'Length guard still falls back to English for character-length violations',
+)
+assert(
+  __translationWorkerTest.pickShortestWordCountCandidate('Ship mobile updates instantly', [
+    'Déployez des mises à jour mobiles instantanément aux utilisateurs partout',
+    'Déployez des mises à jour mobiles',
+    'Déployez des mises à jour mobiles instantanément',
+  ]) === 'Déployez des mises à jour mobiles',
+  'Shortest word-count candidate was not selected after retries',
 )
 assert(
   __translationWorkerTest.applyFrenchArticleElision('Évitez la attente. Livrez la correction.') === 'Évitez l\u2019attente. Livrez la correction.',

--- a/apps/translation-worker/scripts/verify-parser.ts
+++ b/apps/translation-worker/scripts/verify-parser.ts
@@ -186,7 +186,7 @@ assert(
 assert(
   !__translationWorkerTest.translationWordCountViolation(
     'Deploy fixes and features without waiting for app store review delays while keeping your release pipeline fast and reliable for every user across all platforms.',
-    'Déployez des correctifs et des fonctionnalités sans attendre les délais de révision de l\u2019App Store tout en gardant votre pipeline de publication rapide et fiable pour chaque utilisateur sur toutes les plateformes.',
+    'Déployez des correctifs et des fonctionnalités sans attendre les délais de révision de l\u2019App Store tout en gardant votre pipeline de publication rapide et fiable pour chaque utilisateur dans toutes les plateformes.',
     'French',
   ),
   'Word count guard should not apply to long body copy',

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -165,7 +165,7 @@ const TRANSLATION_SOURCE_CHECK_SECONDS = 5 * 60
 const TRANSLATION_PENDING_SECONDS = 10 * 60
 const TRANSLATION_RETRY_SECONDS = 5
 const TRANSLATION_COORDINATOR_PENDING_MS = 15 * 60 * 1000
-const TRANSLATION_CACHE_VERSION = '2026-09-01-word-count-constraint-v1'
+const TRANSLATION_CACHE_VERSION = '2026-09-01-word-count-retry-v1'
 const NAV_GUARD_PATHS = ['/pricing/', '/blog/', '/enterprise/'] as const
 const NAV_PATH_EXPECTED_SOURCES: Record<(typeof NAV_GUARD_PATHS)[number], ReadonlySet<string>> = {
   '/pricing/': new Set(['Pricing']),
@@ -176,6 +176,8 @@ const TRANSLATION_LENGTH_MAX_RATIO = 1.3
 const TRANSLATION_LENGTH_MIN_RATIO = 0.7
 const TRANSLATION_WORD_COUNT_MAX_DELTA = 3
 const TRANSLATION_WORD_COUNT_MAX_SOURCE_WORDS = 24
+const TRANSLATION_WORD_COUNT_RETRIES = 2
+const TRANSLATION_WORD_COUNT_ATTEMPTS = TRANSLATION_WORD_COUNT_RETRIES + 1
 const TRANSLATION_SOURCE_HASH_HEADER = 'X-Capgo-Translation-Source-Hash'
 const TRANSLATION_SCRIPTS_HEADER = 'X-Capgo-Translation-Scripts'
 const CLIENT_NO_STORE = 'no-store, max-age=0, must-revalidate'
@@ -1798,9 +1800,8 @@ function translationWordCountViolation(source: string, translated: string, targe
   return delta > TRANSLATION_WORD_COUNT_MAX_DELTA
 }
 
-function translationLengthViolation(source: string, translated: string, targetLanguage = ''): boolean {
+function translationCharacterLengthViolation(source: string, translated: string, targetLanguage = ''): boolean {
   if (!shouldEnforceTranslationLength(source)) return false
-  if (translationWordCountViolation(source, translated, targetLanguage)) return true
   const sourceLen = source.length
   const translatedLen = translated.length
   if (sourceLen < 12) return translatedLen > sourceLen + 8
@@ -1809,8 +1810,36 @@ function translationLengthViolation(source: string, translated: string, targetLa
   return translatedLen < sourceLen * TRANSLATION_LENGTH_MIN_RATIO
 }
 
+function translationLengthViolation(source: string, translated: string, targetLanguage = ''): boolean {
+  return translationCharacterLengthViolation(source, translated, targetLanguage)
+}
+
+function pickShortestWordCountCandidate(source: string, candidates: readonly string[]): string {
+  const unique = [...new Set(candidates.map((candidate) => candidate.trim()).filter(Boolean))]
+  if (unique.length === 0) return source
+
+  const sourceWords = translationWordCount(source)
+  return unique.sort((left, right) => {
+    const leftWords = translationWordCount(left)
+    const rightWords = translationWordCount(right)
+    if (leftWords !== rightWords) return leftWords - rightWords
+
+    const leftDelta = Math.abs(sourceWords - leftWords)
+    const rightDelta = Math.abs(sourceWords - rightWords)
+    if (leftDelta !== rightDelta) return leftDelta - rightDelta
+
+    return left.length - right.length
+  })[0]
+}
+
+function rememberWordCountCandidate(candidates: string[], source: string, translated: string, targetLanguage: string): boolean {
+  if (translationCharacterLengthViolation(source, translated, targetLanguage)) return false
+  candidates.push(translated)
+  return !translationWordCountViolation(source, translated, targetLanguage)
+}
+
 function guardTranslationLength(source: string, translated: string, targetLanguage = ''): string {
-  return translationLengthViolation(source, translated, targetLanguage) ? source : translated
+  return translationCharacterLengthViolation(source, translated, targetLanguage) ? source : translated
 }
 
 function guardTranslatedBatchLengths(batch: string[], translated: string[], targetLanguage = ''): string[] {
@@ -2034,19 +2063,11 @@ async function translateBatchWithJsonMode(env: Env, targetLanguage: string, batc
           return polishTranslatedText(targetLanguage, result.text)
         })
         assertTranslatedBatch(targetLanguage, uniqueBatch, restored)
-        const guarded = guardTranslatedBatchLengths(uniqueBatch, restored, targetLanguage).map((text, index) => {
-          if (text === uniqueBatch[index] && translationLengthViolation(uniqueBatch[index], restored[index], targetLanguage)) {
-            console.warn('Translation kept source after length bound violation', {
-              targetLanguage,
-              index,
-              sourceLength: uniqueBatch[index].length,
-              translatedLength: restored[index].length,
-              sourcePreview: aiPayloadPreview(uniqueBatch[index]),
-              outputPreview: aiPayloadPreview(restored[index]),
-            })
-          }
-          return text
-        })
+        const guarded = guardTranslatedBatchLengths(uniqueBatch, restored, targetLanguage)
+        for (let index = 0; index < guarded.length; index += 1) {
+          if (!shouldEnforceTranslationWordCount(uniqueBatch[index])) continue
+          guarded[index] = await translateSingleText(env, targetLanguage, uniqueBatch[index], pagePath, guarded[index])
+        }
         return expandDedupedBatchTranslations(guarded, expandIndexes)
       }
     } catch (error) {
@@ -2082,13 +2103,20 @@ async function translateBatch(env: Env, targetLanguage: string, batch: string[],
   return await translateBatchIndividually(env, targetLanguage, batch, pagePath)
 }
 
-async function translateSingleText(env: Env, targetLanguage: string, text: string, pagePath = ''): Promise<string> {
+async function translateSingleText(env: Env, targetLanguage: string, text: string, pagePath = '', seedCandidate?: string): Promise<string> {
   const model = env.TRANSLATION_MODEL || DEFAULT_MODEL
   let lastError: Error | null = null
   const protectedText = protectTranslationTokens(text)
   const context = resolveTranslationContexts([text])[0]
+  const enforceWordCount = shouldEnforceTranslationWordCount(text)
+  const maxAttempts = enforceWordCount ? TRANSLATION_WORD_COUNT_ATTEMPTS : TRANSLATION_SINGLE_TEXT_ATTEMPTS
+  const wordCountCandidates: string[] = []
 
-  for (let attempt = 1; attempt <= TRANSLATION_SINGLE_TEXT_ATTEMPTS; attempt += 1) {
+  if (seedCandidate && rememberWordCountCandidate(wordCountCandidates, text, seedCandidate, targetLanguage)) {
+    return seedCandidate
+  }
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     let payload: unknown = ''
     try {
       const result = await env.AI.run(model, {
@@ -2106,8 +2134,13 @@ async function translateSingleText(env: Env, targetLanguage: string, text: strin
               'Preserve brand names, product names, developer terms, URLs, code identifiers, file paths, package names, language codes, numbers, punctuation, and whitespace meaning.',
               'Do not translate or transliterate literal tokens such as Capgo, Capacitor, Live Update, code, API, SDK, CLI, npm, bun, GitHub, Cloudflare, package names, command names, and framework names.',
               'Source text may include placeholders like __CAPGO_KEEP_0__. Copy every placeholder exactly as written; placeholders are restored after translation.',
+              enforceWordCount && attempt > 1
+                ? 'Your previous translation used too many or too few words for this short UI string. Shorten or tighten the wording while keeping the same meaning.'
+                : '',
               'Return only the translated text. Do not return JSON, Markdown, labels, explanations, quotes around the whole answer, or extra lines.',
-            ].join(' '),
+            ]
+              .filter(Boolean)
+              .join(' '),
           },
           {
             role: 'user',
@@ -2126,14 +2159,27 @@ async function translateSingleText(env: Env, targetLanguage: string, text: strin
       const translated = plainTranslationFromUnknown(payload)
       if (translated) {
         const restored = polishTranslatedText(targetLanguage, protectedText.restore(translated))
-        if (translationLengthViolation(text, restored, targetLanguage)) {
+        if (translationCharacterLengthViolation(text, restored, targetLanguage)) {
+          lastError = new Error(`Translation length out of bounds for ${targetLanguage}: ${restored.length} chars vs source ${text.length}`)
+        } else if (rememberWordCountCandidate(wordCountCandidates, text, restored, targetLanguage)) {
+          return restored
+        } else if (enforceWordCount && attempt < maxAttempts) {
           const sourceWords = translationWordCount(text)
           const translatedWords = translationWordCount(restored)
-          lastError = translationWordCountViolation(text, restored, targetLanguage)
-            ? new Error(`Translation word count out of bounds for ${targetLanguage}: ${translatedWords} words vs source ${sourceWords}`)
-            : new Error(`Translation length out of bounds for ${targetLanguage}: ${restored.length} chars vs source ${text.length}`)
+          lastError = new Error(`Translation word count out of bounds for ${targetLanguage}: ${translatedWords} words vs source ${sourceWords}`)
+          console.warn('Word count out of bounds; retrying translation', {
+            targetLanguage,
+            attempt,
+            maxAttempts,
+            sourceWords,
+            translatedWords,
+            sourcePreview: aiPayloadPreview(text),
+            outputPreview: aiPayloadPreview(restored),
+          })
         } else {
-          return restored
+          const sourceWords = translationWordCount(text)
+          const translatedWords = translationWordCount(restored)
+          lastError = new Error(`Translation word count out of bounds for ${targetLanguage}: ${translatedWords} words vs source ${sourceWords}`)
         }
       } else {
         lastError = new Error(`Translation model returned empty text for ${targetLanguage}`)
@@ -2145,10 +2191,23 @@ async function translateSingleText(env: Env, targetLanguage: string, text: strin
     console.warn('Single-text translation response rejected', {
       targetLanguage,
       attempt,
-      maxAttempts: TRANSLATION_SINGLE_TEXT_ATTEMPTS,
+      maxAttempts,
       error: lastError.message,
       outputPreview: aiPayloadPreview(payload),
     })
+  }
+
+  if (enforceWordCount && wordCountCandidates.length > 0) {
+    const shortest = pickShortestWordCountCandidate(text, wordCountCandidates)
+    console.warn('Word count out of bounds after retries; using shortest candidate', {
+      targetLanguage,
+      sourceWords: translationWordCount(text),
+      candidateCount: wordCountCandidates.length,
+      selectedWords: translationWordCount(shortest),
+      sourcePreview: aiPayloadPreview(text),
+      selectedPreview: aiPayloadPreview(shortest),
+    })
+    return shortest
   }
 
   if (lastError?.message.startsWith('Translation dropped protected token: ')) {
@@ -2160,7 +2219,7 @@ async function translateSingleText(env: Env, targetLanguage: string, text: strin
     return text
   }
 
-  if (lastError?.message.includes('length out of bounds') || lastError?.message.includes('word count out of bounds')) {
+  if (lastError?.message.includes('length out of bounds')) {
     console.warn('Single-text translation kept source after length bound violation', {
       targetLanguage,
       error: lastError.message,
@@ -3484,6 +3543,7 @@ export const __translationWorkerTest = {
   translationLengthViolation,
   translationWordCount,
   translationWordCountViolation,
+  pickShortestWordCountCandidate,
 }
 
 export default {

--- a/apps/translation-worker/src/index.ts
+++ b/apps/translation-worker/src/index.ts
@@ -165,7 +165,7 @@ const TRANSLATION_SOURCE_CHECK_SECONDS = 5 * 60
 const TRANSLATION_PENDING_SECONDS = 10 * 60
 const TRANSLATION_RETRY_SECONDS = 5
 const TRANSLATION_COORDINATOR_PENDING_MS = 15 * 60 * 1000
-const TRANSLATION_CACHE_VERSION = '2026-08-31-nav-guard-dedupe-batch-v1'
+const TRANSLATION_CACHE_VERSION = '2026-09-01-word-count-constraint-v1'
 const NAV_GUARD_PATHS = ['/pricing/', '/blog/', '/enterprise/'] as const
 const NAV_PATH_EXPECTED_SOURCES: Record<(typeof NAV_GUARD_PATHS)[number], ReadonlySet<string>> = {
   '/pricing/': new Set(['Pricing']),
@@ -174,6 +174,8 @@ const NAV_PATH_EXPECTED_SOURCES: Record<(typeof NAV_GUARD_PATHS)[number], Readon
 }
 const TRANSLATION_LENGTH_MAX_RATIO = 1.3
 const TRANSLATION_LENGTH_MIN_RATIO = 0.7
+const TRANSLATION_WORD_COUNT_MAX_DELTA = 3
+const TRANSLATION_WORD_COUNT_MAX_SOURCE_WORDS = 24
 const TRANSLATION_SOURCE_HASH_HEADER = 'X-Capgo-Translation-Source-Hash'
 const TRANSLATION_SCRIPTS_HEADER = 'X-Capgo-Translation-Scripts'
 const CLIENT_NO_STORE = 'no-store, max-age=0, must-revalidate'
@@ -1776,8 +1778,29 @@ function shouldEnforceTranslationLength(source: string): boolean {
   return source.trim().length > 0
 }
 
+function translationWordCount(value: string): number {
+  const normalized = normalizedTranslationValue(value)
+  if (!normalized) return 0
+  const stripped = normalized.replace(/__CAPGO_KEEP_\d+__/g, ' ')
+  const tokens = stripped.match(/[\p{L}\p{N}][\p{L}\p{N}'\u2019-]*/gu) ?? []
+  return tokens.length
+}
+
+function shouldEnforceTranslationWordCount(source: string): boolean {
+  const count = translationWordCount(source)
+  return count >= 2 && count <= TRANSLATION_WORD_COUNT_MAX_SOURCE_WORDS
+}
+
+function translationWordCountViolation(source: string, translated: string, targetLanguage = ''): boolean {
+  if (!shouldEnforceTranslationWordCount(source)) return false
+  if (COMPACT_TRANSLATION_TARGETS.has(targetLanguage)) return false
+  const delta = Math.abs(translationWordCount(source) - translationWordCount(translated))
+  return delta > TRANSLATION_WORD_COUNT_MAX_DELTA
+}
+
 function translationLengthViolation(source: string, translated: string, targetLanguage = ''): boolean {
   if (!shouldEnforceTranslationLength(source)) return false
+  if (translationWordCountViolation(source, translated, targetLanguage)) return true
   const sourceLen = source.length
   const translatedLen = translated.length
   if (sourceLen < 12) return translatedLen > sourceLen + 8
@@ -1923,7 +1946,7 @@ function translationGrammarSystemHint(): string {
 }
 
 function translationLengthSystemHint(): string {
-  return 'Keep each translation about the same length as the source (similar character count, roughly within ±30%). Do not expand short UI labels, buttons, nav items, table headers, or headings into longer sentences. Over-long translations break Capgo page layouts and UI spacing.'
+  return 'Keep each translation about the same length as the source (similar character count, roughly within ±30%). For headings, titles, buttons, navigation labels, and other short UI copy (about 2–24 source words), keep the translated word count within ±3 words of the source. Do not expand short UI labels, buttons, nav items, table headers, or headings into longer sentences. Over-long translations break Capgo page layouts and UI spacing.'
 }
 
 /** Fix unelided French le/la before a vowel (e.g. "la attente" → "l’attente").
@@ -2104,7 +2127,11 @@ async function translateSingleText(env: Env, targetLanguage: string, text: strin
       if (translated) {
         const restored = polishTranslatedText(targetLanguage, protectedText.restore(translated))
         if (translationLengthViolation(text, restored, targetLanguage)) {
-          lastError = new Error(`Translation length out of bounds for ${targetLanguage}: ${restored.length} chars vs source ${text.length}`)
+          const sourceWords = translationWordCount(text)
+          const translatedWords = translationWordCount(restored)
+          lastError = translationWordCountViolation(text, restored, targetLanguage)
+            ? new Error(`Translation word count out of bounds for ${targetLanguage}: ${translatedWords} words vs source ${sourceWords}`)
+            : new Error(`Translation length out of bounds for ${targetLanguage}: ${restored.length} chars vs source ${text.length}`)
         } else {
           return restored
         }
@@ -2133,7 +2160,7 @@ async function translateSingleText(env: Env, targetLanguage: string, text: strin
     return text
   }
 
-  if (lastError?.message.includes('length out of bounds')) {
+  if (lastError?.message.includes('length out of bounds') || lastError?.message.includes('word count out of bounds')) {
     console.warn('Single-text translation kept source after length bound violation', {
       targetLanguage,
       error: lastError.message,
@@ -3455,6 +3482,8 @@ export const __translationWorkerTest = {
   resolveTranslationContexts,
   syncExecutableScriptsFromEnglish,
   translationLengthViolation,
+  translationWordCount,
+  translationWordCountViolation,
 }
 
 export default {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

French headlines and short UI copy often translate into many more words than English, breaking layout (nav, hero headings, buttons).

## Fix

Add a **±3 word count constraint** for short translatable copy (2–24 source words):

- `translationWordCount()` counts Unicode words (handles French elision/apostrophes)
- Over limit → **retry up to 2 times** with a tighten-wording prompt
- Still over limit after retries → **keep the shortest candidate** (fewest words, then closest to source count)
- Character-length violations still fall back to English source
- Long body copy (>24 words) is not word-count constrained
- CJK locales remain exempt
- Model prompt updated to preserve word count on headings and short UI labels
- Cache version bumped to retranslate affected pages

## Tests

`apps/translation-worker/scripts/verify-parser.ts`:

- Word counting (English headline, French elision)
- Rejects overlong French headline (+6 words)
- Accepts French headline within ±3
- Skips long body copy and Japanese
- Picks shortest candidate after retries
- Length guard keeps valid translations; still falls back on char-length only

```bash
cd apps/translation-worker && bun run check
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a059c9-50bc-7f87-add6-287a8f18086d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a059c9-50bc-7f87-add6-287a8f18086d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790847172&installation_model_id=430928&pr_number=998&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F998&signature=ecfe94f558a9c409b9fbfbed10498cec63ce009cb5f65975cba2b9c10454bca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation quality for short UI text by enforcing word-count limits.
  * Falls back to the original text when a translation exceeds acceptable limits.
  * Preserves flexibility for longer content and compact-script languages.
  * Updated translation caching to ensure revised validation rules are applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->