### PR TITLE
fix(web): stop most-popular pill from squeezing plan descriptions

### DIFF
--- a/apps/web/src/components/pricing/Plans.astro
+++ b/apps/web/src/components/pricing/Plans.astro
@@ -69,14 +69,14 @@ function buildTimeDisplay(buildTimeSeconds: number) {
           ]}
           data-plan={plan.name}
         >
-          <div class="flex min-h-24 items-start justify-between gap-3">
-            <div>
+          <div class="min-h-24">
+            <div class="flex flex-wrap items-center gap-2">
               <h3 class="text-2xl font-semibold tracking-tight text-gray-950">{plan.name}</h3>
-              <p class="mt-3 text-sm leading-6 text-gray-600">{planDescriptionToText(plan.description, Astro.locals.locale)}</p>
+              {plan.name === 'Maker' && (
+                <span class="rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-700">{m.most_popular({}, { locale: Astro.locals.locale })}</span>
+              )}
             </div>
-            {plan.name === 'Maker' && (
-              <span class="shrink-0 rounded-full bg-blue-100 px-3 py-1 text-xs font-semibold text-blue-700">{m.most_popular({}, { locale: Astro.locals.locale })}</span>
-            )}
+            <p class="mt-3 text-sm leading-6 text-gray-600">{planDescriptionToText(plan.description, Astro.locals.locale)}</p>
           </div>
 
           <div class="mt-6 lg:mt-8">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What happened

On `/pricing/`, the Maker (“most popular”) card description wrapped to a narrow column instead of using the full card width. The title and description lived in a flex child next to the pill, so the copy shrank to leftover space beside “Most popular”.

## Fix

Keep the pill on the title row. Put the description in its own full-width block under that row.

Measured on the built page: description width matches the card content box (259px of 316px card, the rest is padding). French Maker copy wraps to 2 lines instead of 4.

## Test plan

- [x] Maker description uses the full card width (EN and FR overlay)
- [x] “Most popular” / “Le plus populaire” still sits next to the title
- [x] Other plan cards unchanged

## Before / after

Before (description squeezed beside the pill):

![Maker plan description wrapping too narrow next to the most popular pill](https://cursor.com/artifacts/c/art-b4ff46d0-9c73-4fb1-b4a2-9b139a503093)

After (description uses the full card width):

![Pricing plan cards with Maker description using the full column width](https://cursor.com/artifacts/c/art-4f0b8301-c7a0-4284-9b92-55859105494d)

![Maker card with Le plus populaire next to the title and full-width description](https://cursor.com/artifacts/c/art-d45a9876-b5d0-4893-9a6d-344eb1167a99)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47778992-f357-4a4e-ad8e-d8b359aaa5d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47778992-f357-4a4e-ad8e-d8b359aaa5d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/1000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790851733&installation_model_id=430928&pr_number=1000&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F1000&signature=b50165b5b598f114ddcaac9a2c6300fa75e42ed7e2b45d85501a726e66ed577a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/1000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved pricing plan header layout.
  * The “Most popular” badge now wraps neatly below the plan name when space is limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->