### PR TITLE
fix(web): let register page share the site header fade

### DIFF
--- a/apps/web/src/pages/register.astro
+++ b/apps/web/src/pages/register.astro
@@ -25,7 +25,16 @@ const content = {
     <section class="relative flex min-h-screen items-center justify-center overflow-hidden p-4">
       <div class="relative w-full max-w-4xl">
         <div class="absolute inset-0 -translate-x-4 transform">
-          <svg class="blur-3xl filter" style="filter: blur(64px)" width="100%" height="100%" viewBox="0 0 444 775" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <svg
+            class="blur-3xl filter"
+            style="filter: blur(64px)"
+            width="100%"
+            height="100%"
+            viewBox="0 0 444 775"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
             <path
               opacity="0.5"
               d="M48.1169 329.705C48.1169 139.089 -73.495 -1.98068e-05 69.9555 -7.266e-06C213.406 5.27484e-06 444 499.666 444 690.282C444 880.898 213.406 690.282 69.9554 690.282C-73.4951 690.282 48.1168 520.321 48.1169 329.705Z"
@@ -116,7 +125,7 @@ const content = {
               href="https://support.capgo.app"
               class="flex w-full items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-none"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" class="mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg xmlns="http://www.w3.org/2000/svg" class="mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                 <path
                   stroke-linecap="round"
                   stroke-linejoin="round"
@@ -145,8 +154,11 @@ const content = {
           </div>
         </div>
       </div>
-      <div class="pointer-events-none absolute inset-0 overflow-hidden">
-        <img class="h-full w-full transform object-cover object-top opacity-20" src="/background-pattern.webp" alt="" />
+      <div
+        class="pointer-events-none absolute inset-0 overflow-hidden opacity-20"
+        aria-hidden="true"
+        style="background-image: url('/background-pattern.webp'); background-size: cover; background-position: top;"
+      >
       </div>
     </section>
   </div>

--- a/apps/web/src/pages/register.astro
+++ b/apps/web/src/pages/register.astro
@@ -24,23 +24,6 @@ const content = {
   <div class="hero-wash">
     <section class="relative flex min-h-screen items-center justify-center overflow-hidden p-4">
       <div class="relative w-full max-w-4xl">
-        <div class="absolute inset-0 -translate-x-4 transform">
-          <svg
-            class="blur-3xl filter"
-            style="filter: blur(64px)"
-            width="100%"
-            height="100%"
-            viewBox="0 0 444 775"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden="true"
-          >
-            <path
-              opacity="0.5"
-              d="M48.1169 329.705C48.1169 139.089 -73.495 -1.98068e-05 69.9555 -7.266e-06C213.406 5.27484e-06 444 499.666 444 690.282C444 880.898 213.406 690.282 69.9554 690.282C-73.4951 690.282 48.1168 520.321 48.1169 329.705Z"
-              fill="rgba(59,130,246,0.35)"></path>
-          </svg>
-        </div>
         <div class="relative z-10 grid overflow-hidden rounded-lg bg-white shadow-xl md:grid-cols-2">
           <div class="space-y-6 p-6">
             <div>

--- a/apps/web/src/pages/register.astro
+++ b/apps/web/src/pages/register.astro
@@ -21,133 +21,135 @@ const content = {
 {enableCaptcha && <script is:inline src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer />}
 
 <Layout content={content}>
-  <section class="flex min-h-screen items-center justify-center overflow-hidden bg-slate-900 p-4">
-    <div class="relative w-full max-w-4xl">
-      <div class="absolute inset-0 -translate-x-4 transform">
-        <svg class="blur-3xl filter" style="filter: blur(64px)" width="100%" height="100%" viewBox="0 0 444 775" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path
-            opacity="0.5"
-            d="M48.1169 329.705C48.1169 139.089 -73.495 -1.98068e-05 69.9555 -7.266e-06C213.406 5.27484e-06 444 499.666 444 690.282C444 880.898 213.406 690.282 69.9554 690.282C-73.4951 690.282 48.1168 520.321 48.1169 329.705Z"
-            fill="rgba(59,130,246,0.35)"></path>
-        </svg>
-      </div>
-      <div class="relative z-10 grid overflow-hidden rounded-lg bg-white shadow-xl md:grid-cols-2">
-        <div class="space-y-6 p-6">
-          <div>
-            <h1 class="text-4xl font-bold text-gray-900">{m.register_title({}, { locale: Astro.locals.locale })}</h1>
-            <p class="text-sm text-gray-500">
-              {m.already_have_account({}, { locale: Astro.locals.locale })}
-              <a href="https://console.capgo.app/login/" target="_blank" class="text-gray-200 hover:underline">{m.sign_in({}, { locale: Astro.locals.locale })}</a>
-            </p>
-          </div>
-          <form id="registerForm" class="space-y-4 text-black">
+  <div class="hero-wash">
+    <section class="relative flex min-h-screen items-center justify-center overflow-hidden p-4">
+      <div class="relative w-full max-w-4xl">
+        <div class="absolute inset-0 -translate-x-4 transform">
+          <svg class="blur-3xl filter" style="filter: blur(64px)" width="100%" height="100%" viewBox="0 0 444 775" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+              opacity="0.5"
+              d="M48.1169 329.705C48.1169 139.089 -73.495 -1.98068e-05 69.9555 -7.266e-06C213.406 5.27484e-06 444 499.666 444 690.282C444 880.898 213.406 690.282 69.9554 690.282C-73.4951 690.282 48.1168 520.321 48.1169 329.705Z"
+              fill="rgba(59,130,246,0.35)"></path>
+          </svg>
+        </div>
+        <div class="relative z-10 grid overflow-hidden rounded-lg bg-white shadow-xl md:grid-cols-2">
+          <div class="space-y-6 p-6">
             <div>
-              <label for="email" class="block text-sm font-medium text-gray-700">{m.email_label({}, { locale: Astro.locals.locale })}</label>
-              <input
-                id="email"
-                name="email"
-                type="email"
-                required
-                class="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-gray-500 focus:outline-none"
-                placeholder={m.email_placeholder({}, { locale: Astro.locals.locale })}
-              />
+              <h1 class="text-4xl font-bold text-gray-900">{m.register_title({}, { locale: Astro.locals.locale })}</h1>
+              <p class="text-sm text-gray-500">
+                {m.already_have_account({}, { locale: Astro.locals.locale })}
+                <a href="https://console.capgo.app/login/" target="_blank" class="text-gray-200 hover:underline">{m.sign_in({}, { locale: Astro.locals.locale })}</a>
+              </p>
             </div>
-            <div class="grid grid-cols-2 gap-4">
+            <form id="registerForm" class="space-y-4 text-black">
               <div>
-                <label for="firstName" class="block text-sm font-medium text-gray-700">{m.first_name_label({}, { locale: Astro.locals.locale })}</label>
+                <label for="email" class="block text-sm font-medium text-gray-700">{m.email_label({}, { locale: Astro.locals.locale })}</label>
                 <input
-                  id="firstName"
-                  name="firstName"
-                  type="text"
+                  id="email"
+                  name="email"
+                  type="email"
                   required
                   class="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-gray-500 focus:outline-none"
-                  placeholder={m.first_name_placeholder({}, { locale: Astro.locals.locale })}
+                  placeholder={m.email_placeholder({}, { locale: Astro.locals.locale })}
                 />
               </div>
-              <div>
-                <label for="lastName" class="block text-sm font-medium text-gray-700">{m.last_name_label({}, { locale: Astro.locals.locale })}</label>
-                <input
-                  id="lastName"
-                  name="lastName"
-                  type="text"
-                  required
-                  class="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-gray-500 focus:outline-none"
-                  placeholder={m.last_name_placeholder({}, { locale: Astro.locals.locale })}
-                />
-              </div>
-            </div>
-            <div>
-              <label for="password" class="block text-sm font-medium text-gray-700">{m.password_label({}, { locale: Astro.locals.locale })}</label>
-              <input
-                id="password"
-                name="password"
-                type="password"
-                required
-                class="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-gray-500 focus:outline-none"
-                placeholder={m.password_placeholder({}, { locale: Astro.locals.locale })}
-              />
-            </div>
-            {
-              enableCaptcha && (
+              <div class="grid grid-cols-2 gap-4">
                 <div>
-                  <label class="block text-sm font-medium text-gray-700">Captcha</label>
-                  <div class="cf-turnstile" data-sitekey={CLOUDFLARE_TURNSTILE_SITE_KEY} data-size="flexible" />
+                  <label for="firstName" class="block text-sm font-medium text-gray-700">{m.first_name_label({}, { locale: Astro.locals.locale })}</label>
+                  <input
+                    id="firstName"
+                    name="firstName"
+                    type="text"
+                    required
+                    class="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-gray-500 focus:outline-none"
+                    placeholder={m.first_name_placeholder({}, { locale: Astro.locals.locale })}
+                  />
                 </div>
-              )
-            }
-            <button
-              type="submit"
-              class="flex w-full justify-center rounded-md border border-transparent bg-gray-900 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-none"
-            >
-              {m.sign_up_button({}, { locale: Astro.locals.locale })}
-            </button>
-            <p class="mt-2 text-center text-xs text-gray-400" set:html={m.register_tos_notice({}, { locale: Astro.locals.locale })} />
-          </form>
-          <div class="relative">
-            <div class="absolute inset-0 flex items-center">
-              <div class="w-full border-t border-gray-300"></div>
-            </div>
-            <div class="relative flex justify-center text-sm">
-              <span class="bg-white px-2 text-gray-500">{m.need_help({}, { locale: Astro.locals.locale })}</span>
-            </div>
-          </div>
-          <a
-            href="https://support.capgo.app"
-            class="flex w-full items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-none"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" class="mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z"
-              ></path>
-            </svg>
-            {m.open_support({}, { locale: Astro.locals.locale })}
-          </a>
-        </div>
-        <div class="flex items-center bg-slate-800 p-4">
-          <blockquote class="text-white">
-            <p class="mb-4 text-2xl font-bold">
-              {m.testimonial_title({}, { locale: Astro.locals.locale })}<br />
-              After update,
-              <span class="rounded-full bg-gray-900 px-2 py-1 text-white">{m.testimonial_highlight({}, { locale: Astro.locals.locale })}</span>
-            </p>
-            <div class="mb-4 flex items-center">
-              <img src="/avatar-male-2.webp" alt="Jermaine, a Capgo customer" class="mr-4 h-12 w-12 rounded-full" />
+                <div>
+                  <label for="lastName" class="block text-sm font-medium text-gray-700">{m.last_name_label({}, { locale: Astro.locals.locale })}</label>
+                  <input
+                    id="lastName"
+                    name="lastName"
+                    type="text"
+                    required
+                    class="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-gray-500 focus:outline-none"
+                    placeholder={m.last_name_placeholder({}, { locale: Astro.locals.locale })}
+                  />
+                </div>
+              </div>
               <div>
-                <cite class="font-bold text-white">Jermaine</cite>
-                <p class="text-gray-400">{m.testimonial_description({}, { locale: Astro.locals.locale })}</p>
+                <label for="password" class="block text-sm font-medium text-gray-700">{m.password_label({}, { locale: Astro.locals.locale })}</label>
+                <input
+                  id="password"
+                  name="password"
+                  type="password"
+                  required
+                  class="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-gray-500 focus:outline-none"
+                  placeholder={m.password_placeholder({}, { locale: Astro.locals.locale })}
+                />
+              </div>
+              {
+                enableCaptcha && (
+                  <div>
+                    <label class="block text-sm font-medium text-gray-700">Captcha</label>
+                    <div class="cf-turnstile" data-sitekey={CLOUDFLARE_TURNSTILE_SITE_KEY} data-size="flexible" />
+                  </div>
+                )
+              }
+              <button
+                type="submit"
+                class="flex w-full justify-center rounded-md border border-transparent bg-gray-900 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-none"
+              >
+                {m.sign_up_button({}, { locale: Astro.locals.locale })}
+              </button>
+              <p class="mt-2 text-center text-xs text-gray-400" set:html={m.register_tos_notice({}, { locale: Astro.locals.locale })} />
+            </form>
+            <div class="relative">
+              <div class="absolute inset-0 flex items-center">
+                <div class="w-full border-t border-gray-300"></div>
+              </div>
+              <div class="relative flex justify-center text-sm">
+                <span class="bg-white px-2 text-gray-500">{m.need_help({}, { locale: Astro.locals.locale })}</span>
               </div>
             </div>
-          </blockquote>
+            <a
+              href="https://support.capgo.app"
+              class="flex w-full items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-none"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z"
+                ></path>
+              </svg>
+              {m.open_support({}, { locale: Astro.locals.locale })}
+            </a>
+          </div>
+          <div class="flex items-center bg-slate-800 p-4">
+            <blockquote class="text-white">
+              <p class="mb-4 text-2xl font-bold">
+                {m.testimonial_title({}, { locale: Astro.locals.locale })}<br />
+                After update,
+                <span class="rounded-full bg-gray-900 px-2 py-1 text-white">{m.testimonial_highlight({}, { locale: Astro.locals.locale })}</span>
+              </p>
+              <div class="mb-4 flex items-center">
+                <img src="/avatar-male-2.webp" alt="Jermaine, a Capgo customer" class="mr-4 h-12 w-12 rounded-full" />
+                <div>
+                  <cite class="font-bold text-white">Jermaine</cite>
+                  <p class="text-gray-400">{m.testimonial_description({}, { locale: Astro.locals.locale })}</p>
+                </div>
+              </div>
+            </blockquote>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="pointer-events-none absolute inset-0 overflow-hidden">
-      <img class="h-full w-full transform object-cover object-top opacity-20" src="/background-pattern.webp" alt="" />
-    </div>
-  </section>
+      <div class="pointer-events-none absolute inset-0 overflow-hidden">
+        <img class="h-full w-full transform object-cover object-top opacity-20" src="/background-pattern.webp" alt="" />
+      </div>
+    </section>
+  </div>
 </Layout>
 
 <script>

--- a/apps/web/src/styles/product-surface.css
+++ b/apps/web/src/styles/product-surface.css
@@ -350,7 +350,7 @@ main.data-page .data-section-muted {
 }
 
 /* Dark bands outside .product-hero still used unique slate/navy fills.
-   Exact classes only: skip /50 washes and full-page canvases such as /register/.
+   Exact classes only: skip /50 washes and leftover full-page canvases.
    Keep `section` and `main > div` as separate rules so :is() does not inflate
    section specificity past `.product-hero > section:first-of-type`. */
 section:is(.bg-gray-800, .bg-gray-900, .bg-gray-950, .bg-slate-700, .bg-slate-800, .bg-slate-900, .bg-slate-950):not([class*='min-h-screen']) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The register page still used a full-page `bg-slate-900` canvas, so the site-wide blue-to-charcoal fade stopped at the header and left a hard color break under the Capgo nav.

This wraps `/register/` in the same `hero-wash` used by other marketing pages and drops the solid section fill so the body wash continues behind the form.

## Changes
- Remove the full-page slate background from the register section
- Use `hero-wash` so the first section stays transparent against the shared body fade
- Keep the white signup card and testimonial panel as-is
- Hide decorative SVGs from assistive tech and render the pattern as a CSS background

## Visual
Header and page canvas now share the same body wash. The signup card stays solid so the form stays readable.

Desktop after:

![Register page desktop after removing the solid canvas](https://cursor.com/artifacts/c/art-86c9cf05-c75a-4395-bda2-580996bce10f)

Mobile after:

![Register page mobile after removing the solid canvas](https://cursor.com/artifacts/c/art-0929bc66-fc6e-4415-9cf9-4f0f5ab9636b)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33037b7d-7d88-492a-8668-8207a6a9e9bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33037b7d-7d88-492a-8668-8207a6a9e9bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/1004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790956332&installation_model_id=430928&pr_number=1004&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F1004&signature=f28c5d795df7563f66e4c19991adfc4a18beb7299ea44420b377e43f5e812086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/1004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Refreshed the registration page with a lighter hero background treatment and a centered, responsive card layout.
  - Improved spacing and positioning for a more balanced presentation across screen sizes.
  - Preserved the split registration card design, including the form and testimonial panels.
  - Retained the background pattern and existing registration functionality, including CAPTCHA, support links, and localization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->