### PR TITLE
feat(web): teach staged rollout with scroll-triggered motion on homepage

### DIFF
--- a/apps/web/src/components/solutions/RolloutIllustration.astro
+++ b/apps/web/src/components/solutions/RolloutIllustration.astro
@@ -140,6 +140,10 @@ const { class: className, animated = false, ...props } = Astro.props
     fill: #22c55e;
   }
 
+  .rollout-illustration--animated.is-reduced .rollout-prod-label.fill-amber-500 {
+    fill: #22c55e;
+  }
+
   .rollout-illustration--animated.is-reduced .rollout-health,
   .rollout-illustration--animated.is-reduced .rollout-rollback,
   .rollout-illustration--animated.is-reduced .rollout-prod-icon-done {
@@ -217,7 +221,7 @@ const { class: className, animated = false, ...props } = Astro.props
   function finish(root: HTMLElement) {
     root.classList.add('is-complete')
     const label = root.querySelector<SVGElement>('.rollout-prod-label')
-    if (label) label.setAttribute('fill', '#22c55e')
+    if (label) label.classList.replace('fill-amber-500', 'fill-green-500')
 
     const bar = root.querySelector<SVGRectElement>('.rollout-prod-bar')
     if (bar) bar.classList.replace('fill-amber-500', 'fill-green-500')

--- a/apps/web/src/components/solutions/RolloutIllustration.astro
+++ b/apps/web/src/components/solutions/RolloutIllustration.astro
@@ -1,42 +1,286 @@
 ---
-const { class: className, ...props } = Astro.props
+interface Props {
+  class?: string
+  animated?: boolean
+}
+
+const { class: className, animated = false, ...props } = Astro.props
+const uid = `rollout-${Math.random().toString(36).slice(2, 9)}`
 ---
-<svg viewBox="0 0 600 400" fill="none" xmlns="http://www.w3.org/2000/svg" class:list={["w-full h-auto drop-shadow-2xl", className]} {...props}>
-  <!-- Main Container -->
-  <rect x="40" y="40" width="520" height="320" rx="12" class="fill-gray-900 stroke-gray-700" stroke-width="2"/>
 
-  <!-- Connection Line -->
-  <path d="M100 110 V290" stroke="currentColor" stroke-width="2" stroke-dasharray="8 8" class="text-gray-600 opacity-50"/>
+<div class:list={['rollout-illustration', animated && 'rollout-illustration--animated']} data-rollout-illustration={animated ? 'true' : undefined} data-rollout-uid={uid}>
+  <svg viewBox="0 0 600 400" fill="none" xmlns="http://www.w3.org/2000/svg" class:list={['h-auto w-full drop-shadow-2xl', className]} {...props} aria-hidden="true">
+    <rect x="40" y="40" width="520" height="320" rx="12" class="fill-gray-900 stroke-gray-700" stroke-width="2"></rect>
 
-  <!-- Stage 1: QA -->
-  <g transform="translate(80, 80)">
-    <circle cx="20" cy="20" r="20" class="fill-gray-800 stroke-green-500" stroke-width="2"/>
-    <path d="M12 20l6 6 12-12" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="text-green-500"/>
-    <text x="60" y="25" class="fill-gray-300 font-bold text-sm">Internal QA</text>
-    <rect x="250" y="15" width="100" height="8" rx="4" class="fill-gray-800"/>
-    <rect x="250" y="15" width="100" height="8" rx="4" class="fill-green-500"/>
-    <text x="370" y="24" class="fill-green-500 text-xs font-mono">100%</text>
-  </g>
+    <path d="M100 110 V290" stroke="currentColor" stroke-width="2" stroke-dasharray="8 8" class="text-gray-600 opacity-50"></path>
 
-  <!-- Stage 2: Beta -->
-  <g transform="translate(80, 170)">
-    <circle cx="20" cy="20" r="20" class="fill-gray-800 stroke-blue-500" stroke-width="2"/>
-    <path d="M12 20l6 6 12-12" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="text-blue-500"/>
-    <text x="60" y="25" class="fill-gray-300 font-bold text-sm">Beta Users</text>
-    <rect x="250" y="15" width="100" height="8" rx="4" class="fill-gray-800"/>
-    <rect x="250" y="15" width="100" height="8" rx="4" class="fill-blue-500"/>
-    <text x="370" y="24" class="fill-blue-500 text-xs font-mono">100%</text>
-  </g>
+    <!-- Stage 1: QA -->
+    <g transform="translate(80, 80)">
+      <circle cx="20" cy="20" r="20" class="fill-gray-800 stroke-green-500" stroke-width="2"></circle>
+      <path d="M12 20l6 6 12-12" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="text-green-500"></path>
+      <text x="60" y="25" class="fill-gray-300 text-sm font-bold">Internal QA</text>
+      <rect x="250" y="15" width="100" height="8" rx="4" class="fill-gray-800"></rect>
+      <rect x="250" y="15" width="100" height="8" rx="4" class="fill-green-500"></rect>
+      <text x="370" y="24" class="fill-green-500 font-mono text-xs">100%</text>
+    </g>
 
-  <!-- Stage 3: Production -->
-  <g transform="translate(80, 260)">
-    <circle cx="20" cy="20" r="20" class="fill-gray-800 stroke-amber-500" stroke-width="2"/>
-    <circle cx="20" cy="20" r="8" class="fill-amber-500 animate-pulse"/>
-    <text x="60" y="25" class="fill-white font-bold text-sm">Production</text>
-    <rect x="250" y="15" width="100" height="8" rx="4" class="fill-gray-800"/>
-    <rect x="250" y="15" width="25" height="8" rx="4" class="fill-amber-500"/>
-    <text x="370" y="24" class="fill-amber-500 text-xs font-mono">25%</text>
-  </g>
+    <!-- Stage 2: Beta -->
+    <g transform="translate(80, 170)">
+      <circle cx="20" cy="20" r="20" class="fill-gray-800 stroke-blue-500" stroke-width="2"></circle>
+      <path d="M12 20l6 6 12-12" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="text-blue-500"></path>
+      <text x="60" y="25" class="fill-gray-300 text-sm font-bold">Beta Users</text>
+      <rect x="250" y="15" width="100" height="8" rx="4" class="fill-gray-800"></rect>
+      <rect x="250" y="15" width="100" height="8" rx="4" class="fill-blue-500"></rect>
+      <text x="370" y="24" class="fill-blue-500 font-mono text-xs">100%</text>
+    </g>
 
-</svg>
+    <!-- Stage 3: Production -->
+    <g transform="translate(80, 260)">
+      <circle cx="20" cy="20" r="20" class="rollout-prod-icon-pending fill-gray-800 stroke-amber-500" stroke-width="2"></circle>
+      <circle cx="20" cy="20" r="8" class="rollout-prod-pulse fill-amber-500"></circle>
+      <g class="rollout-prod-icon-done" opacity="0">
+        <circle cx="20" cy="20" r="20" class="fill-gray-800 stroke-green-500" stroke-width="2"></circle>
+        <path d="M12 20l6 6 12-12" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="text-green-500"></path>
+      </g>
+      <text x="60" y="25" class="fill-white text-sm font-bold">Production</text>
+      <rect x="250" y="15" width="100" height="8" rx="4" class="fill-gray-800"></rect>
+      <rect x="250" y="15" height="8" rx="4" class="rollout-prod-bar fill-amber-500" style={animated ? 'width: 10px' : 'width: 25px'}></rect>
+      <text x="370" y="24" class="rollout-prod-label fill-amber-500 font-mono text-xs">{animated ? '10%' : '25%'}</text>
+    </g>
 
+    <!-- Device cohort grid -->
+    {
+      animated && (
+        <g class="rollout-device-grid" transform="translate(80, 318)">
+          {Array.from({ length: 40 }).map((_, index) => (
+            <circle
+              cx={(index % 10) * 14 + 6}
+              cy={Math.floor(index / 10) * 14 + 6}
+              r="4"
+              class="rollout-device-dot fill-gray-800 stroke-gray-700"
+              data-device-index={index}
+              stroke-width="1"
+            />
+          ))}
+        </g>
+      )
+    }
+
+    <!-- Health signal -->
+    {
+      animated && (
+        <g class="rollout-health" transform="translate(330, 318)" opacity="0">
+          <rect x="0" y="0" width="170" height="34" rx="8" class="fill-green-500/10 stroke-green-500/40" stroke-width="1" />
+          <circle cx="18" cy="17" r="8" class="fill-green-500/20" />
+          <path d="M14 17l3 3 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-green-400" />
+          <text x="34" y="21" class="fill-green-400 text-xs font-semibold">
+            Crash-free · ready to expand
+          </text>
+        </g>
+      )
+    }
+
+    <!-- Rollback ready badge -->
+    {
+      animated && (
+        <g class="rollout-rollback" transform="translate(430, 52)" opacity="0">
+          <rect x="0" y="0" width="118" height="28" rx="6" class="fill-blue-500/10 stroke-blue-400/30" stroke-width="1" />
+          <text x="12" y="18" class="fill-blue-300 text-xs font-semibold">
+            Rollback ready
+          </text>
+        </g>
+      )
+    }
+  </svg>
+</div>
+
+<style>
+  .rollout-illustration--animated .rollout-prod-bar {
+    transition: width 500ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .rollout-illustration--animated .rollout-health,
+  .rollout-illustration--animated .rollout-rollback,
+  .rollout-illustration--animated .rollout-prod-icon-done {
+    transition: opacity 350ms ease;
+  }
+
+  .rollout-illustration--animated .rollout-device-dot {
+    transition:
+      fill 300ms ease,
+      stroke 300ms ease;
+  }
+
+  .rollout-illustration--animated.is-complete .rollout-prod-pulse,
+  .rollout-illustration--animated.is-complete .rollout-prod-icon-pending {
+    opacity: 0;
+  }
+
+  .rollout-illustration--animated.is-complete .rollout-prod-icon-done {
+    opacity: 1;
+  }
+
+  .rollout-illustration--animated.is-reduced .rollout-prod-bar {
+    width: 100px !important;
+    transition: none;
+  }
+
+  .rollout-illustration--animated.is-reduced .rollout-prod-label {
+    fill: #22c55e;
+  }
+
+  .rollout-illustration--animated.is-reduced .rollout-health,
+  .rollout-illustration--animated.is-reduced .rollout-rollback,
+  .rollout-illustration--animated.is-reduced .rollout-prod-icon-done {
+    opacity: 1;
+  }
+
+  .rollout-illustration--animated.is-reduced .rollout-prod-pulse,
+  .rollout-illustration--animated.is-reduced .rollout-prod-icon-pending {
+    opacity: 0;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .rollout-illustration--animated .rollout-prod-bar,
+    .rollout-illustration--animated .rollout-health,
+    .rollout-illustration--animated .rollout-rollback,
+    .rollout-illustration--animated .rollout-prod-icon-done,
+    .rollout-illustration--animated .rollout-device-dot {
+      transition: none;
+    }
+  }
+</style>
+
+<script>
+  const BAR_MAX = 100
+
+  function setProductionState(root: HTMLElement, percent: number) {
+    const bar = root.querySelector<SVGRectElement>('.rollout-prod-bar')
+    const label = root.querySelector<SVGElement>('.rollout-prod-label')
+    const dots = root.querySelectorAll<SVGCircleElement>('.rollout-device-dot')
+
+    if (bar) bar.style.width = `${(percent / 100) * BAR_MAX}px`
+    if (label) label.textContent = `${percent}%`
+
+    const activeCount = Math.round((percent / 100) * dots.length)
+    dots.forEach((dot, index) => {
+      const active = index < activeCount
+      dot.setAttribute('fill', active ? '#f59e0b' : '#1f2937')
+      dot.setAttribute('stroke', active ? '#fbbf24' : '#374151')
+    })
+  }
+
+  function showHealth(root: HTMLElement) {
+    const health = root.querySelector<SVGElement>('.rollout-health')
+    if (health) health.setAttribute('opacity', '1')
+  }
+
+  function showRollback(root: HTMLElement) {
+    const badge = root.querySelector<SVGElement>('.rollout-rollback')
+    if (badge) badge.setAttribute('opacity', '1')
+  }
+
+  function highlightPlay(root: HTMLElement, index: number) {
+    const section = root.closest('[data-solution-app-examples]')
+    if (!section) return
+
+    section.querySelectorAll('[data-rollout-play]').forEach((item) => {
+      item.classList.remove('is-rollout-active')
+    })
+
+    const target = section.querySelector(`[data-rollout-play="${index}"]`)
+    target?.classList.add('is-rollout-active')
+  }
+
+  function finish(root: HTMLElement) {
+    root.classList.add('is-complete')
+    const label = root.querySelector<SVGElement>('.rollout-prod-label')
+    if (label) label.setAttribute('fill', '#22c55e')
+
+    const bar = root.querySelector<SVGRectElement>('.rollout-prod-bar')
+    if (bar) bar.classList.replace('fill-amber-500', 'fill-green-500')
+
+    root.querySelectorAll<SVGCircleElement>('.rollout-device-dot').forEach((dot) => {
+      dot.setAttribute('fill', '#22c55e')
+      dot.setAttribute('stroke', '#4ade80')
+    })
+
+    showRollback(root)
+    highlightPlay(root, 2)
+  }
+
+  function applyReducedState(root: HTMLElement) {
+    root.classList.add('is-reduced', 'is-complete')
+    setProductionState(root, 100)
+    showHealth(root)
+    showRollback(root)
+
+    const bar = root.querySelector<SVGRectElement>('.rollout-prod-bar')
+    if (bar) bar.classList.replace('fill-amber-500', 'fill-green-500')
+
+    root.querySelectorAll<SVGCircleElement>('.rollout-device-dot').forEach((dot) => {
+      dot.setAttribute('fill', '#22c55e')
+      dot.setAttribute('stroke', '#4ade80')
+    })
+
+    highlightPlay(root, 2)
+  }
+
+  function wait(ms: number) {
+    return new Promise((resolve) => window.setTimeout(resolve, ms))
+  }
+
+  async function playRollout(root: HTMLElement) {
+    if (root.dataset.rolloutPlayed === 'true') return
+    root.dataset.rolloutPlayed = 'true'
+
+    setProductionState(root, 10)
+    highlightPlay(root, 0)
+    await wait(900)
+
+    showHealth(root)
+    highlightPlay(root, 1)
+    await wait(1100)
+
+    setProductionState(root, 50)
+    await wait(700)
+
+    setProductionState(root, 100)
+    await wait(600)
+
+    finish(root)
+  }
+
+  function initRolloutIllustration(root: HTMLElement) {
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    if (reduceMotion) {
+      applyReducedState(root)
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return
+          observer.disconnect()
+          void playRollout(root)
+        })
+      },
+      { threshold: 0.45 },
+    )
+
+    observer.observe(root)
+  }
+
+  function bootRolloutIllustrations() {
+    document.querySelectorAll<HTMLElement>('[data-rollout-illustration="true"]').forEach((root) => {
+      if (root.dataset.rolloutInit === 'true') return
+      root.dataset.rolloutInit = 'true'
+      initRolloutIllustration(root)
+    })
+  }
+
+  bootRolloutIllustrations()
+  document.addEventListener('astro:page-load', bootRolloutIllustrations)
+</script>

--- a/apps/web/src/components/solutions/RolloutIllustration.astro
+++ b/apps/web/src/components/solutions/RolloutIllustration.astro
@@ -5,14 +5,21 @@ interface Props {
 }
 
 const { class: className, animated = false, ...props } = Astro.props
-const uid = `rollout-${Math.random().toString(36).slice(2, 9)}`
 ---
 
-<div class:list={['rollout-illustration', animated && 'rollout-illustration--animated']} data-rollout-illustration={animated ? 'true' : undefined} data-rollout-uid={uid}>
-  <svg viewBox="0 0 600 400" fill="none" xmlns="http://www.w3.org/2000/svg" class:list={['h-auto w-full drop-shadow-2xl', className]} {...props} aria-hidden="true">
-    <rect x="40" y="40" width="520" height="320" rx="12" class="fill-gray-900 stroke-gray-700" stroke-width="2"></rect>
+<div class:list={['rollout-illustration', animated && 'rollout-illustration--animated']} data-rollout-illustration={animated ? 'true' : undefined}>
+  {
+    animated && (
+      <p class="sr-only" aria-live="polite" aria-atomic="true" data-rollout-status>
+        Progressive rollout illustration ready.
+      </p>
+    )
+  }
 
-    <path d="M100 110 V290" stroke="currentColor" stroke-width="2" stroke-dasharray="8 8" class="text-gray-600 opacity-50"></path>
+  <svg viewBox="0 0 600 440" fill="none" xmlns="http://www.w3.org/2000/svg" class:list={['h-auto w-full drop-shadow-2xl', className]} {...props} aria-hidden="true">
+    <rect x="40" y="40" width="520" height="360" rx="12" class="fill-gray-900 stroke-gray-700" stroke-width="2"></rect>
+
+    <path d="M100 110 V300" stroke="currentColor" stroke-width="2" stroke-dasharray="8 8" class="text-gray-600 opacity-50"></path>
 
     <!-- Stage 1: QA -->
     <g transform="translate(80, 80)">
@@ -21,21 +28,21 @@ const uid = `rollout-${Math.random().toString(36).slice(2, 9)}`
       <text x="60" y="25" class="fill-gray-300 text-sm font-bold">Internal QA</text>
       <rect x="250" y="15" width="100" height="8" rx="4" class="fill-gray-800"></rect>
       <rect x="250" y="15" width="100" height="8" rx="4" class="fill-green-500"></rect>
-      <text x="370" y="24" class="fill-green-500 font-mono text-xs">100%</text>
+      <text x="360" y="24" class="fill-green-500 font-mono text-xs">100%</text>
     </g>
 
     <!-- Stage 2: Beta -->
-    <g transform="translate(80, 170)">
+    <g transform="translate(80, 165)">
       <circle cx="20" cy="20" r="20" class="fill-gray-800 stroke-blue-500" stroke-width="2"></circle>
       <path d="M12 20l6 6 12-12" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="text-blue-500"></path>
       <text x="60" y="25" class="fill-gray-300 text-sm font-bold">Beta Users</text>
       <rect x="250" y="15" width="100" height="8" rx="4" class="fill-gray-800"></rect>
       <rect x="250" y="15" width="100" height="8" rx="4" class="fill-blue-500"></rect>
-      <text x="370" y="24" class="fill-blue-500 font-mono text-xs">100%</text>
+      <text x="360" y="24" class="fill-blue-500 font-mono text-xs">100%</text>
     </g>
 
     <!-- Stage 3: Production -->
-    <g transform="translate(80, 260)">
+    <g transform="translate(80, 250)">
       <circle cx="20" cy="20" r="20" class="rollout-prod-icon-pending fill-gray-800 stroke-amber-500" stroke-width="2"></circle>
       <circle cx="20" cy="20" r="8" class="rollout-prod-pulse fill-amber-500"></circle>
       <g class="rollout-prod-icon-done" opacity="0">
@@ -45,19 +52,20 @@ const uid = `rollout-${Math.random().toString(36).slice(2, 9)}`
       <text x="60" y="25" class="fill-white text-sm font-bold">Production</text>
       <rect x="250" y="15" width="100" height="8" rx="4" class="fill-gray-800"></rect>
       <rect x="250" y="15" height="8" rx="4" class="rollout-prod-bar fill-amber-500" style={animated ? 'width: 10px' : 'width: 25px'}></rect>
-      <text x="370" y="24" class="rollout-prod-label fill-amber-500 font-mono text-xs">{animated ? '10%' : '25%'}</text>
+      <text x="360" y="24" class="rollout-prod-label fill-amber-500 font-mono text-xs">{animated ? '10%' : '25%'}</text>
     </g>
 
     <!-- Device cohort grid -->
     {
       animated && (
-        <g class="rollout-device-grid" transform="translate(80, 318)">
-          {Array.from({ length: 40 }).map((_, index) => (
+        <g class="rollout-device-grid" transform="translate(80, 332)">
+          {Array.from({ length: 32 }).map((_, index) => (
             <circle
-              cx={(index % 10) * 14 + 6}
-              cy={Math.floor(index / 10) * 14 + 6}
+              cx={(index % 8) * 14 + 6}
+              cy={Math.floor(index / 8) * 14 + 6}
               r="4"
-              class="rollout-device-dot fill-gray-800 stroke-gray-700"
+              class="rollout-device-dot"
+              style="fill:#1f2937;stroke:#374151"
               data-device-index={index}
               stroke-width="1"
             />
@@ -69,12 +77,15 @@ const uid = `rollout-${Math.random().toString(36).slice(2, 9)}`
     <!-- Health signal -->
     {
       animated && (
-        <g class="rollout-health" transform="translate(330, 318)" opacity="0">
-          <rect x="0" y="0" width="170" height="34" rx="8" class="fill-green-500/10 stroke-green-500/40" stroke-width="1" />
-          <circle cx="18" cy="17" r="8" class="fill-green-500/20" />
-          <path d="M14 17l3 3 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-green-400" />
-          <text x="34" y="21" class="fill-green-400 text-xs font-semibold">
-            Crash-free · ready to expand
+        <g class="rollout-health" transform="translate(248, 328)" opacity="0">
+          <rect x="0" y="0" width="132" height="40" rx="8" class="fill-green-500/10 stroke-green-500/40" stroke-width="1" />
+          <circle cx="16" cy="20" r="8" class="fill-green-500/20" />
+          <path d="M12 20l3 3 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-green-400" />
+          <text x="32" y="18" class="fill-green-400 text-[10px] font-semibold">
+            Crash-free
+          </text>
+          <text x="32" y="31" class="fill-green-400/90 text-[10px]">
+            Ready to expand
           </text>
         </g>
       )
@@ -83,9 +94,9 @@ const uid = `rollout-${Math.random().toString(36).slice(2, 9)}`
     <!-- Rollback ready badge -->
     {
       animated && (
-        <g class="rollout-rollback" transform="translate(430, 52)" opacity="0">
-          <rect x="0" y="0" width="118" height="28" rx="6" class="fill-blue-500/10 stroke-blue-400/30" stroke-width="1" />
-          <text x="12" y="18" class="fill-blue-300 text-xs font-semibold">
+        <g class="rollout-rollback" transform="translate(408, 56)" opacity="0">
+          <rect x="0" y="0" width="108" height="26" rx="6" class="fill-blue-500/10 stroke-blue-400/30" stroke-width="1" />
+          <text x="10" y="17" class="fill-blue-300 text-[10px] font-semibold">
             Rollback ready
           </text>
         </g>
@@ -153,6 +164,19 @@ const uid = `rollout-${Math.random().toString(36).slice(2, 9)}`
 
 <script>
   const BAR_MAX = 100
+  const DOT_INACTIVE = { fill: '#1f2937', stroke: '#374151' }
+  const DOT_ACTIVE = { fill: '#f59e0b', stroke: '#fbbf24' }
+  const DOT_COMPLETE = { fill: '#22c55e', stroke: '#4ade80' }
+
+  function setDotColors(dot: SVGCircleElement, colors: { fill: string; stroke: string }) {
+    dot.style.fill = colors.fill
+    dot.style.stroke = colors.stroke
+  }
+
+  function announceStatus(root: HTMLElement, message: string) {
+    const status = root.querySelector<HTMLElement>('[data-rollout-status]')
+    if (status) status.textContent = message
+  }
 
   function setProductionState(root: HTMLElement, percent: number) {
     const bar = root.querySelector<SVGRectElement>('.rollout-prod-bar')
@@ -164,9 +188,7 @@ const uid = `rollout-${Math.random().toString(36).slice(2, 9)}`
 
     const activeCount = Math.round((percent / 100) * dots.length)
     dots.forEach((dot, index) => {
-      const active = index < activeCount
-      dot.setAttribute('fill', active ? '#f59e0b' : '#1f2937')
-      dot.setAttribute('stroke', active ? '#fbbf24' : '#374151')
+      setDotColors(dot, index < activeCount ? DOT_ACTIVE : DOT_INACTIVE)
     })
   }
 
@@ -201,12 +223,12 @@ const uid = `rollout-${Math.random().toString(36).slice(2, 9)}`
     if (bar) bar.classList.replace('fill-amber-500', 'fill-green-500')
 
     root.querySelectorAll<SVGCircleElement>('.rollout-device-dot').forEach((dot) => {
-      dot.setAttribute('fill', '#22c55e')
-      dot.setAttribute('stroke', '#4ade80')
+      setDotColors(dot, DOT_COMPLETE)
     })
 
     showRollback(root)
     highlightPlay(root, 2)
+    announceStatus(root, 'Production rollout complete at 100 percent. Rollback remains ready.')
   }
 
   function applyReducedState(root: HTMLElement) {
@@ -219,11 +241,11 @@ const uid = `rollout-${Math.random().toString(36).slice(2, 9)}`
     if (bar) bar.classList.replace('fill-amber-500', 'fill-green-500')
 
     root.querySelectorAll<SVGCircleElement>('.rollout-device-dot').forEach((dot) => {
-      dot.setAttribute('fill', '#22c55e')
-      dot.setAttribute('stroke', '#4ade80')
+      setDotColors(dot, DOT_COMPLETE)
     })
 
     highlightPlay(root, 2)
+    announceStatus(root, 'Production rollout complete at 100 percent. Crash-free and rollback ready.')
   }
 
   function wait(ms: number) {
@@ -236,16 +258,20 @@ const uid = `rollout-${Math.random().toString(36).slice(2, 9)}`
 
     setProductionState(root, 10)
     highlightPlay(root, 0)
+    announceStatus(root, 'Production rollout started at 10 percent of devices.')
     await wait(900)
 
     showHealth(root)
     highlightPlay(root, 1)
+    announceStatus(root, 'Crash-free health check passed. Ready to expand rollout.')
     await wait(1100)
 
     setProductionState(root, 50)
+    announceStatus(root, 'Production rollout expanded to 50 percent of devices.')
     await wait(700)
 
     setProductionState(root, 100)
+    announceStatus(root, 'Production rollout expanded to 100 percent of devices.')
     await wait(600)
 
     finish(root)

--- a/apps/web/src/components/solutions/RolloutIllustration.astro
+++ b/apps/web/src/components/solutions/RolloutIllustration.astro
@@ -5,6 +5,13 @@ interface Props {
 }
 
 const { class: className, animated = false, ...props } = Astro.props
+
+const viewBox = animated ? '0 0 600 440' : '0 0 600 400'
+const cardHeight = animated ? 360 : 320
+const connectorEndY = animated ? 300 : 290
+const qaY = 80
+const betaY = animated ? 165 : 170
+const productionY = animated ? 250 : 260
 ---
 
 <div class:list={['rollout-illustration', animated && 'rollout-illustration--animated']} data-rollout-illustration={animated ? 'true' : undefined}>
@@ -16,13 +23,13 @@ const { class: className, animated = false, ...props } = Astro.props
     )
   }
 
-  <svg viewBox="0 0 600 440" fill="none" xmlns="http://www.w3.org/2000/svg" class:list={['h-auto w-full drop-shadow-2xl', className]} {...props} aria-hidden="true">
-    <rect x="40" y="40" width="520" height="360" rx="12" class="fill-gray-900 stroke-gray-700" stroke-width="2"></rect>
+  <svg viewBox={viewBox} fill="none" xmlns="http://www.w3.org/2000/svg" class:list={['h-auto w-full drop-shadow-2xl', className]} {...props} aria-hidden="true">
+    <rect x="40" y="40" width="520" height={cardHeight} rx="12" class="fill-gray-900 stroke-gray-700" stroke-width="2"></rect>
 
-    <path d="M100 110 V300" stroke="currentColor" stroke-width="2" stroke-dasharray="8 8" class="text-gray-600 opacity-50"></path>
+    <path d={`M100 110 V${connectorEndY}`} stroke="currentColor" stroke-width="2" stroke-dasharray="8 8" class="text-gray-600 opacity-50"></path>
 
     <!-- Stage 1: QA -->
-    <g transform="translate(80, 80)">
+    <g transform={`translate(80, ${qaY})`}>
       <circle cx="20" cy="20" r="20" class="fill-gray-800 stroke-green-500" stroke-width="2"></circle>
       <path d="M12 20l6 6 12-12" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="text-green-500"></path>
       <text x="60" y="25" class="fill-gray-300 text-sm font-bold">Internal QA</text>
@@ -32,7 +39,7 @@ const { class: className, animated = false, ...props } = Astro.props
     </g>
 
     <!-- Stage 2: Beta -->
-    <g transform="translate(80, 165)">
+    <g transform={`translate(80, ${betaY})`}>
       <circle cx="20" cy="20" r="20" class="fill-gray-800 stroke-blue-500" stroke-width="2"></circle>
       <path d="M12 20l6 6 12-12" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="text-blue-500"></path>
       <text x="60" y="25" class="fill-gray-300 text-sm font-bold">Beta Users</text>
@@ -42,7 +49,7 @@ const { class: className, animated = false, ...props } = Astro.props
     </g>
 
     <!-- Stage 3: Production -->
-    <g transform="translate(80, 250)">
+    <g transform={`translate(80, ${productionY})`}>
       <circle cx="20" cy="20" r="20" class="rollout-prod-icon-pending fill-gray-800 stroke-amber-500" stroke-width="2"></circle>
       <circle cx="20" cy="20" r="8" class="rollout-prod-pulse fill-amber-500"></circle>
       <g class="rollout-prod-icon-done" opacity="0">

--- a/apps/web/src/components/solutions/RolloutIllustration.astro
+++ b/apps/web/src/components/solutions/RolloutIllustration.astro
@@ -248,6 +248,9 @@ const productionY = animated ? 250 : 260
     showHealth(root)
     showRollback(root)
 
+    const label = root.querySelector<SVGElement>('.rollout-prod-label')
+    if (label) label.classList.replace('fill-amber-500', 'fill-green-500')
+
     const bar = root.querySelector<SVGRectElement>('.rollout-prod-bar')
     if (bar) bar.classList.replace('fill-amber-500', 'fill-green-500')
 

--- a/apps/web/src/components/solutions/SolutionAppExample.astro
+++ b/apps/web/src/components/solutions/SolutionAppExample.astro
@@ -11,9 +11,10 @@ import RolloutIllustration from '@/components/solutions/RolloutIllustration.astr
 interface Props {
   solution: SolutionAppExampleKey
   randomize?: boolean
+  animateRollout?: boolean
 }
 
-const { solution, randomize = false } = Astro.props
+const { solution, randomize = false, animateRollout = false } = Astro.props
 const locale = Astro.locals.locale
 const example = solutionAppExamples[solution]
 const copy = (key: MessageKey, values?: MessageValues) => m[key](values, { locale })
@@ -27,7 +28,6 @@ const categories = [...new Set(appExamples.map(({ app }) => renameCat(app.catego
 const registerUrl = getRelativeLocaleUrl(locale, 'register')
 const talkToTeamUrl = 'https://book.capgo.app/enterprise-inquiry/'
 const showExampleCtas = solution === 'enterprise'
-const showRolloutIllustration = solution === 'production-updates'
 ---
 
 {
@@ -148,8 +148,8 @@ const showRolloutIllustration = solution === 'production-updates'
               <h3 class="mt-3 text-2xl leading-8 font-semibold tracking-tight text-balance text-white">{copy('solution_app_examples_cta_title')}</h3>
               <p class="mt-4 text-base leading-7 text-pretty text-gray-400">{copy('solution_app_examples_cta_text')}</p>
 
-              {showRolloutIllustration && (
-                <div class="solution-app-examples-rollout mt-6 overflow-hidden rounded-lg border border-white/10 bg-[#111]/80 p-3">
+              {animateRollout && (
+                <div class="solution-app-examples-rollout mt-6 overflow-hidden rounded-lg border border-white/10 bg-[#111]/80 p-2 sm:p-3">
                   <RolloutIllustration animated class="text-amber-500" />
                 </div>
               )}
@@ -157,8 +157,8 @@ const showRolloutIllustration = solution === 'production-updates'
               <div class="solution-app-examples-plays mt-6 space-y-3 border-y border-white/10 py-5">
                 {plays.map((play, index) => (
                   <div
-                    class="solution-app-examples-play grid grid-cols-[auto_1fr] gap-3 rounded-md text-sm leading-6 text-gray-300 transition-colors duration-300"
-                    data-rollout-play={showRolloutIllustration ? index : undefined}
+                    class="solution-app-examples-play grid grid-cols-[auto_minmax(0,1fr)] gap-3 rounded-md px-1 text-sm leading-6 text-gray-300 transition-colors duration-300"
+                    data-rollout-play={animateRollout ? index : undefined}
                   >
                     <span class="mt-1 flex h-5 w-5 items-center justify-center rounded-full bg-blue-500/15 text-blue-300 ring-1 ring-blue-400/25">
                       <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -169,7 +169,7 @@ const showRolloutIllustration = solution === 'production-updates'
                         />
                       </svg>
                     </span>
-                    <span>{play}</span>
+                    <span class="min-w-0 text-pretty break-words">{play}</span>
                   </div>
                 ))}
               </div>

--- a/apps/web/src/components/solutions/SolutionAppExample.astro
+++ b/apps/web/src/components/solutions/SolutionAppExample.astro
@@ -6,6 +6,7 @@ import { renameCat, shortNumber } from '@/services/misc'
 import { getRelativeLocaleUrl } from '@/services/links'
 import TeamAvatars from '@/components/TeamAvatars.astro'
 import HumanSupport from '@/components/HumanSupport.astro'
+import RolloutIllustration from '@/components/solutions/RolloutIllustration.astro'
 
 interface Props {
   solution: SolutionAppExampleKey
@@ -26,6 +27,7 @@ const categories = [...new Set(appExamples.map(({ app }) => renameCat(app.catego
 const registerUrl = getRelativeLocaleUrl(locale, 'register')
 const talkToTeamUrl = 'https://book.capgo.app/enterprise-inquiry/'
 const showExampleCtas = solution === 'enterprise'
+const showRolloutIllustration = solution === 'production-updates'
 ---
 
 {
@@ -146,9 +148,18 @@ const showExampleCtas = solution === 'enterprise'
               <h3 class="mt-3 text-2xl leading-8 font-semibold tracking-tight text-balance text-white">{copy('solution_app_examples_cta_title')}</h3>
               <p class="mt-4 text-base leading-7 text-pretty text-gray-400">{copy('solution_app_examples_cta_text')}</p>
 
+              {showRolloutIllustration && (
+                <div class="solution-app-examples-rollout mt-6 overflow-hidden rounded-lg border border-white/10 bg-[#111]/80 p-3">
+                  <RolloutIllustration animated class="text-amber-500" />
+                </div>
+              )}
+
               <div class="solution-app-examples-plays mt-6 space-y-3 border-y border-white/10 py-5">
-                {plays.map((play) => (
-                  <div class="grid grid-cols-[auto_1fr] gap-3 text-sm leading-6 text-gray-300">
+                {plays.map((play, index) => (
+                  <div
+                    class="solution-app-examples-play grid grid-cols-[auto_1fr] gap-3 rounded-md text-sm leading-6 text-gray-300 transition-colors duration-300"
+                    data-rollout-play={showRolloutIllustration ? index : undefined}
+                  >
                     <span class="mt-1 flex h-5 w-5 items-center justify-center rounded-full bg-blue-500/15 text-blue-300 ring-1 ring-blue-400/25">
                       <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                         <path
@@ -197,3 +208,22 @@ const showExampleCtas = solution === 'enterprise'
     list.removeAttribute('aria-busy')
   }
 </script>
+
+<style>
+  .solution-app-examples-play.is-rollout-active {
+    background: rgb(59 130 246 / 0.08);
+    color: rgb(226 232 240);
+  }
+
+  .solution-app-examples-play.is-rollout-active span:first-child {
+    background: rgb(59 130 246 / 0.28);
+    color: rgb(191 219 254);
+    box-shadow: 0 0 0 1px rgb(96 165 250 / 0.45);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .solution-app-examples-play {
+      transition: none;
+    }
+  }
+</style>

--- a/apps/web/src/components/solutions/SolutionAppExample.astro
+++ b/apps/web/src/components/solutions/SolutionAppExample.astro
@@ -28,6 +28,7 @@ const categories = [...new Set(appExamples.map(({ app }) => renameCat(app.catego
 const registerUrl = getRelativeLocaleUrl(locale, 'register')
 const talkToTeamUrl = 'https://book.capgo.app/enterprise-inquiry/'
 const showExampleCtas = solution === 'enterprise'
+const showRolloutIllustration = animateRollout || solution === 'production-updates'
 ---
 
 {
@@ -148,9 +149,9 @@ const showExampleCtas = solution === 'enterprise'
               <h3 class="mt-3 text-2xl leading-8 font-semibold tracking-tight text-balance text-white">{copy('solution_app_examples_cta_title')}</h3>
               <p class="mt-4 text-base leading-7 text-pretty text-gray-400">{copy('solution_app_examples_cta_text')}</p>
 
-              {animateRollout && (
+              {showRolloutIllustration && (
                 <div class="solution-app-examples-rollout mt-6 overflow-hidden rounded-lg border border-white/10 bg-[#111]/80 p-2 sm:p-3">
-                  <RolloutIllustration animated class="text-amber-500" />
+                  <RolloutIllustration animated={animateRollout} class="text-amber-500" />
                 </div>
               )}
 

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -95,7 +95,7 @@ const content = {
     <!-- <CompaniesLogo /> -->
     <ProblemSolution />
     <HowItWorks />
-    <SolutionAppExample solution="production-updates" randomize />
+    <SolutionAppExample solution="production-updates" randomize animateRollout />
     <MonitoringFeatures />
     <ReleaseIntelligence />
     <DeviceLogs />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds instructional motion to the homepage **Next release lane** panel (`SolutionAppExample` / production-updates). The animation uses the existing `RolloutIllustration` artwork and plays once when scrolled into view.

**What the motion teaches:** OTA does not blast to everyone. Capgo progressive rollout starts with a small production cohort (10%), verifies crash-free health, then expands the percentage while keeping rollback ready.

## Motion sequence

1. **10% cohort** — production bar + device grid light up a small slice; play step 1 highlights
2. **Health check** — "Crash-free / Ready to expand" appears; play step 2 highlights
3. **Expansion** — bar grows 10% → 50% → 100%; cohort grid fills; rollback badge appears; play step 3 highlights

`prefers-reduced-motion` shows the final static end state (100%, health + rollback visible) with no replay controls. Screen readers receive stage updates via a visually hidden `aria-live="polite"` region.

## Before / after

**Before** (live main — text-only CTA aside):

![Before: Next release lane panel without rollout illustration](https://cursor.com/artifacts/c/art-792ff43d-71a6-4fa4-bf28-5c02b60b37c1)

**After** (complete rollout state, all elements inside card bounds):

![After: animated rollout illustration at 100% with rollback ready](https://cursor.com/artifacts/c/art-16dcc46b-e8da-45ea-b80c-c6339ecf5adb)

## Recording

![Staged rollout animation: 10% → health check → expand to 100%](https://cursor.com/artifacts/c/art-fae76dad-bc3b-49dd-aae5-ba67175475f6)

## Files changed

- `apps/web/src/components/solutions/RolloutIllustration.astro` — optional `animated` prop, scroll-triggered play-once sequence, aria-live status
- `apps/web/src/components/solutions/SolutionAppExample.astro` — `animateRollout` prop (homepage only); play-step overflow fix
- `apps/web/src/pages/index.astro` — passes `animateRollout` from homepage

## Notes

- Does not touch PR #993 (How It Works card 3)
- `/solutions/production-updates` stays static (no illustration) — animation gated by `animateRollout`
- No GSAP dependency; uses IntersectionObserver + CSS transitions
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1289024a-7c22-4bd8-a0e1-5e420bdc47d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1289024a-7c22-4bd8-a0e1-5e420bdc47d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/1007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791127539&installation_model_id=430928&pr_number=1007&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F1007&signature=ed9147eb50aa2295927188b8de3d67e6a431803cfabe8713b9917d6d754c97a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/1007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional animated rollout visualization with production progress, device cohorts, system health, rollback status, and accessibility announcements.
  * Added synchronized highlighting and staged, viewport-triggered updates for rollout controls in the production updates example.
  * Added responsive presentation and sizing for rollout details across screen sizes.
  * Added support for reduced-motion preferences while preserving rollout completion states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->