### PR TITLE
docs(notifications): remove private-preview npm access copy

### DIFF
--- a/apps/docs/src/content/docs/docs/plugins/notifications/debugging.mdx
+++ b/apps/docs/src/content/docs/docs/plugins/notifications/debugging.mdx
@@ -96,7 +96,7 @@ Run the setup command from the folder that contains `capacitor.config.*`:
 npx @capgo/cli@latest notifications setup com.example.app
 ```
 
-If the command cannot infer your app ID, pass it explicitly as shown above. If package installation fails, confirm Capgo has enabled private-preview package access for your npm account, then rerun the command.
+If the command cannot infer your app ID, pass it explicitly as shown above. If package installation fails, confirm the package name is `@capgo/capacitor-notifications`, verify your npm registry is `https://registry.npmjs.org`, check network access, then rerun the command.
 
 ### Device Does Not Appear In Recipient Lookup
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the last website copy that implied `@capgo/capacitor-notifications` requires Capgo to enable private-preview npm package access.

## Change
- `apps/docs/src/content/docs/docs/plugins/notifications/debugging.mdx`: replace gated npm access troubleshooting with standard install checks (package name, registry, network).

## Scope
- Private-preview / enable-package-access messaging only.
- No changes to Notifications beta badges, banners, or product-beta wording.
- No console (`capgo.app`) changes.

## Verification
Repo grep finds zero matches for `private preview`, `private-preview`, `enable package access`, or `currently in private`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afb79a00-3494-4e76-863f-49bdafb4061c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afb79a00-3494-4e76-863f-49bdafb4061c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/1012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791372695&installation_model_id=430928&pr_number=1012&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F1012&signature=87d01b2bb8cb7777a3a2206581443b7fb9261382e5a4d7e013e6075c2752b44c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/1012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI setup troubleshooting guidance to check npm registry access, package naming, and network connectivity before rerunning setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->