### PR TITLE
feat: internal links from home/pricing to 2026 live-updates blog

### DIFF
--- a/apps/web/src/components/AppflowShutdown.astro
+++ b/apps/web/src/components/AppflowShutdown.astro
@@ -218,6 +218,12 @@ import HumanSupport from '@/components/HumanSupport.astro'
           >
             {m.migration_guide({}, { locale: Astro.locals.locale })}
           </a>
+          <a
+            href={getRelativeLocaleUrl(Astro.locals.locale, 'blog/mobile-app-best-practices-2026-live-updates')}
+            class="inline-flex items-center justify-center rounded-xl border-2 border-transparent bg-transparent px-8 py-4 text-base font-semibold text-blue-700 underline-offset-4 transition-all duration-200 hover:underline focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
+          >
+            Read 2026 mobile best practices
+          </a>
         </div>
       </div>
     </div>

--- a/apps/web/src/pages/pricing.astro
+++ b/apps/web/src/pages/pricing.astro
@@ -383,7 +383,7 @@ if (plans.length > 0) {
         >Capgo Notifications</a
       > for native push and update checks, <a href={getRelativeLocaleUrl(Astro.locals.locale, 'observe')}>Capgo Observe</a> for release health, <a href="/native-build/">Capgo Native Builds</a> for signed binaries, <a href="/plugins/">Capgo Plugin Directory</a> for native features, <a
         href="/enterprise/">Capgo Enterprise</a
-      > for larger teams, and <a href="/premium-support/">Premium Support</a> for production help.
+      > for larger teams, <a href="/premium-support/">Premium Support</a> for production help, and <a href={getRelativeLocaleUrl(Astro.locals.locale, 'blog/mobile-app-best-practices-2026-live-updates')}>2026 mobile best practices</a> for why live updates beat store review queues.
     </p>
   </section>
   </div>


### PR DESCRIPTION
## Summary
- Homepage Appflow shutdown CTA: add tertiary link to `/blog/mobile-app-best-practices-2026-live-updates/`
- Pricing “Keep going” footer: add the same blog for why live updates beat store review queues

TOF ask from Charly (via Sandra): amplify the new post from high-traffic `/` and `/pricing/`. Primary register/migration CTAs unchanged.

## Review
- @ site ops: Paul
- Jose gates merge-ready

## Test plan
- [ ] `/` Appflow section shows “Read 2026 mobile best practices” and opens the blog
- [ ] `/pricing/` Keep going paragraph includes the blog link
- [ ] Existing migration/register CTAs still work

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/1016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791524236&installation_model_id=430928&pr_number=1016&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F1016&signature=244b108610dca4461433eb1225f90b677285068d4472dfb57b8945cf6bf0770f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/1016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added links to the “2026 mobile best practices” article in the Appflow shutdown notice and pricing page footer.
  - Updated the pricing page footer copy to include the new resource alongside existing support options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->