### PR TITLE
feat(web): internal links home + pricing → best practices 2026 blog

### DIFF
--- a/apps/web/src/components/AppflowShutdown.astro
+++ b/apps/web/src/components/AppflowShutdown.astro
@@ -218,6 +218,12 @@ import HumanSupport from '@/components/HumanSupport.astro'
           >
             {m.migration_guide({}, { locale: Astro.locals.locale })}
           </a>
+          <a
+            href={getRelativeLocaleUrl(Astro.locals.locale, 'blog/mobile-app-best-practices-2026-live-updates')}
+            class="inline-flex items-center justify-center rounded-xl border-2 border-transparent bg-transparent px-8 py-4 text-base font-semibold text-blue-700 underline-offset-4 transition-all duration-200 hover:underline focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
+          >
+            Read 2026 mobile best practices
+          </a>
         </div>
       </div>
     </div>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -19,6 +19,7 @@ import { createLdJsonGraph, createServiceLdJson, createSoftwareApplicationLdJson
 import AppflowShutdown from '@/components/AppflowShutdown.astro'
 import UpdateTypesSection from '@/components/landing/UpdateTypesSection.astro'
 import SolutionAppExample from '@/components/solutions/SolutionAppExample.astro'
+import { getRelativeLocaleUrl } from '@/services/links'
 
 const config = Astro.locals.runtimeConfig
 
@@ -111,7 +112,7 @@ const content = {
     <section class="mx-auto max-w-5xl px-6 py-10 text-sm leading-6 text-gray-600 lg:px-8">
       <h2 class="text-2xl font-semibold text-gray-950">Keep shipping in 2026</h2>
       <p class="mt-4 [&_a]:text-blue-600 [&_a]:underline [&_a]:decoration-1 [&_a]:underline-offset-2 hover:[&_a]:text-blue-500">
-        Store review queues are less predictable this year. Read <a href="/blog/mobile-app-best-practices-2026-live-updates/">Mobile App Best Practices in 2026: Why Live Updates Win</a> — then <a href="/register/">register</a> and ship web-layer fixes without waiting on every binary review.
+        Store review queues are less predictable this year. Read <a href={getRelativeLocaleUrl(Astro.locals.locale, 'blog/mobile-app-best-practices-2026-live-updates')}>Mobile App Best Practices in 2026: Why Live Updates Win</a> — then <a href={getRelativeLocaleUrl(Astro.locals.locale, 'register')}>register</a> and ship web-layer fixes without waiting on every binary review.
       </p>
     </section>
   </div>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -108,6 +108,12 @@ const content = {
     <Manifesto />
     <Orgs />
     <AppflowShutdown />
+    <section class="mx-auto max-w-5xl px-6 py-10 text-sm leading-6 text-gray-600 lg:px-8">
+      <h2 class="text-2xl font-semibold text-gray-950">Keep shipping in 2026</h2>
+      <p class="mt-4 [&_a]:text-blue-600 [&_a]:underline [&_a]:decoration-1 [&_a]:underline-offset-2 hover:[&_a]:text-blue-500">
+        Store review queues are less predictable this year. Read <a href="/blog/mobile-app-best-practices-2026-live-updates/">Mobile App Best Practices in 2026: Why Live Updates Win</a> — then <a href="/register/">register</a> and ship web-layer fixes without waiting on every binary review.
+      </p>
+    </section>
   </div>
 
   <style is:global>

--- a/apps/web/src/pages/pricing.astro
+++ b/apps/web/src/pages/pricing.astro
@@ -383,7 +383,7 @@ if (plans.length > 0) {
         >Capgo Notifications</a
       > for native push and update checks, <a href={getRelativeLocaleUrl(Astro.locals.locale, 'observe')}>Capgo Observe</a> for release health, <a href="/native-build/">Capgo Native Builds</a> for signed binaries, <a href="/plugins/">Capgo Plugin Directory</a> for native features, <a
         href="/enterprise/">Capgo Enterprise</a
-      > for larger teams, and <a href="/premium-support/">Premium Support</a> for production help.
+      > for larger teams, and <a href="/premium-support/">Premium Support</a> for production help. For the 2026 shipping playbook, read <a href="/blog/mobile-app-best-practices-2026-live-updates/">Mobile App Best Practices in 2026: Why Live Updates Win</a>.
     </p>
   </section>
   </div>


### PR DESCRIPTION
## Summary

Adds natural internal links from `/` and `/pricing/` to `/blog/mobile-app-best-practices-2026-live-updates/` (Mobile App Best Practices in 2026: Why Live Updates Win).

TOF goal: arrivals → educate → register. Primary register/pricing CTAs unchanged.

## Changes

- **Home (`index.astro`)**: short “Keep shipping in 2026” callout after AppflowShutdown with blog + register links.
- **Pricing (`pricing.astro`)**: extend existing “Keep going from Capgo Pricing” paragraph with the same blog link.

Relative paths only. No dependency changes.

## Test plan

- [ ] Homepage shows the callout; blog + register links resolve
- [ ] Pricing keep-going paragraph includes the blog link; plan CTAs untouched
- [ ] CI: Web Build + SEO + Contrast / typos green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/1017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791524249&installation_model_id=430928&pr_number=1017&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F1017&signature=f2d42216696e661efbc45844111aed09fd7df0817d8ea81404e17c13e3a8a0c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/1017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

