### PR TITLE
docs(builder): document build cache keys for multi-environment builds

### DIFF
--- a/apps/docs/src/content/docs/docs/builder/configuration.mdx
+++ b/apps/docs/src/content/docs/docs/builder/configuration.mdx
@@ -154,8 +154,10 @@ Capgo saves compiled native artifacts (CocoaPods, Gradle, and related build outp
 
 | CLI Flag | API field | Default | Description |
 |----------|-----------|---------|-------------|
-| `--no-cache` | `cache_enabled: false` | cache on | Skip cache restore **and** do not save a new cache entry for this build |
-| `--cache-key <value>` | `cache_key` | *(empty)* | Separate cache buckets by environment, branch, or Android flavor. Omit for one shared default cache per app |
+| `--no-cache` | `cache_enabled: false` | cache on | Disable cache for this build: skip restore **and** do not save a new entry |
+| `--cache-key <value>` | `cache_key` | *(omit)* | Partition the cache (for example `prod`, `staging`). Omit for one shared general cache per app |
+
+CLI equivalents: [`build request`](/docs/cli/reference/build/#build-request) accepts `--no-cache` and `--cache-key`.
 
 <Aside type="tip">
 Use different `--cache-key` values when RC and production builds share the same app ID but must not reuse each other's compiled output — for example `--cache-key=prod` and `--cache-key=staging`.
@@ -188,7 +190,7 @@ bunx @capgo/cli@latest build request com.example.app --platform ios --no-cache
 }
 ```
 
-Set `"cache_enabled": false` to disable cache for a single request (same as `--no-cache`).
+Omit `cache_key` for the shared general cache. Set `cache_key` to partition by environment. Set `"cache_enabled": false` to disable cache for a single request (same as `--no-cache`).
 
 If a build looks successful but the artifact is wrong — or an Android AAB is missing after switching RC vs production — try a dedicated cache key or a one-off `--no-cache` build. See [Troubleshooting: wrong cache restore](/docs/builder/troubleshooting/#build-succeeded-but-artifact-is-wrong-after-an-environment-switch).
 

--- a/apps/docs/src/content/docs/docs/builder/configuration.mdx
+++ b/apps/docs/src/content/docs/docs/builder/configuration.mdx
@@ -148,6 +148,50 @@ When `--skip-build-number-bump` is set, the build uses whatever version is alrea
 
 **Retention format:** Use human-readable durations like `1h`, `6h`, `2d`, `7d`. Minimum is 1 hour, maximum is 7 days. When set via env var, use seconds (e.g., `3600` for 1 hour).
 
+### Build cache
+
+Capgo saves compiled native artifacts (CocoaPods, Gradle, and related build outputs) **per app** so repeat builds start faster. **Build cache is enabled by default** for each app.
+
+| CLI Flag | API field | Default | Description |
+|----------|-----------|---------|-------------|
+| `--no-cache` | `cache_enabled: false` | cache on | Skip cache restore **and** do not save a new cache entry for this build |
+| `--cache-key <value>` | `cache_key` | *(empty)* | Separate cache buckets by environment, branch, or Android flavor. Omit for one shared default cache per app |
+
+<Aside type="tip">
+Use different `--cache-key` values when RC and production builds share the same app ID but must not reuse each other's compiled output — for example `--cache-key=prod` and `--cache-key=staging`.
+</Aside>
+
+**CLI examples:**
+
+```bash
+# Default: restore/save the shared per-app cache
+bunx @capgo/cli@latest build request com.example.app --platform android
+
+# Separate caches per environment
+bunx @capgo/cli@latest build request com.example.app --platform android \
+  --cache-key=prod
+
+bunx @capgo/cli@latest build request com.example.app --platform android \
+  --cache-key=staging \
+  --android-flavor staging
+
+# One-off clean build (no restore, no save)
+bunx @capgo/cli@latest build request com.example.app --platform ios --no-cache
+```
+
+**API / webhook payload** (when your integration calls Capgo Build directly):
+
+```json
+{
+  "platform": "android",
+  "cache_key": "prod"
+}
+```
+
+Set `"cache_enabled": false` to disable cache for a single request (same as `--no-cache`).
+
+If a build looks successful but the artifact is wrong — or an Android AAB is missing after switching RC vs production — try a dedicated cache key or a one-off `--no-cache` build. See [Troubleshooting: wrong cache restore](/docs/builder/troubleshooting/#build-succeeded-but-artifact-is-wrong-after-an-environment-switch).
+
 ### Authentication
 
 | CLI Flag | Env Variable | Default | Description |

--- a/apps/docs/src/content/docs/docs/builder/github-actions.mdx
+++ b/apps/docs/src/content/docs/docs/builder/github-actions.mdx
@@ -427,6 +427,10 @@ By default each release build increments the build number. To pin it to a value 
 
 ### Cache dependencies
 
+<Aside type="note">
+This section is about **GitHub Actions** caching on the CI runner (local `Pods/` and `.gradle` before upload). Capgo also keeps a **cloud build cache** per app on the build runner — use [`--cache-key`](/docs/builder/configuration/#build-cache) when RC and production must not share the same restore bucket. See [Troubleshooting: wrong cache restore](/docs/builder/troubleshooting/#build-succeeded-but-artifact-is-wrong-after-an-environment-switch).
+</Aside>
+
 `bun install` is already fast enough that a JS-deps cache rarely pays off, but Capacitor's native dependencies (CocoaPods, Gradle) are worth caching for larger projects:
 
 ```yaml

--- a/apps/docs/src/content/docs/docs/builder/github-actions.mdx
+++ b/apps/docs/src/content/docs/docs/builder/github-actions.mdx
@@ -428,7 +428,7 @@ By default each release build increments the build number. To pin it to a value 
 ### Cache dependencies
 
 <Aside type="note">
-This section is about **GitHub Actions** caching on the CI runner (local `Pods/` and `.gradle` before upload). Capgo also keeps a **cloud build cache** per app on the build runner — use [`--cache-key`](/docs/builder/configuration/#build-cache) when RC and production must not share the same restore bucket. See [Troubleshooting: wrong cache restore](/docs/builder/troubleshooting/#build-succeeded-but-artifact-is-wrong-after-an-environment-switch).
+This section is about **GitHub Actions** caching on the CI runner (local `Pods/` and `.gradle` before upload). Capgo also keeps a **cloud build cache** per app on the build runner (enabled by default; omit `cache_key` for the shared general cache). Pass [`--cache-key`](/docs/builder/configuration/#build-cache) to partition RC and production, or `--no-cache` to disable restore and save. See [Troubleshooting: wrong cache restore](/docs/builder/troubleshooting/#build-succeeded-but-artifact-is-wrong-after-an-environment-switch).
 </Aside>
 
 `bun install` is already fast enough that a JS-deps cache rarely pays off, but Capacitor's native dependencies (CocoaPods, Gradle) are worth caching for larger projects:

--- a/apps/docs/src/content/docs/docs/builder/index.mdx
+++ b/apps/docs/src/content/docs/docs/builder/index.mdx
@@ -100,7 +100,7 @@ Capgo offers two complementary features for updating your app. Here's when to us
 When you run the build command:
 
 1. **Upload** - The CLI zips only what's needed (native platform folder + native dependencies) and uploads to secure cloud storage
-2. **Build** - Your app compiles on dedicated infrastructure using Fastlane. Repeat builds restore a per-app compilation cache by default; use [`--cache-key`](/docs/builder/configuration/#build-cache) to keep RC and production caches separate
+2. **Build** - Your app compiles on dedicated infrastructure using Fastlane. Repeat builds restore a per-app compilation cache by default (omit `cache_key` for the shared general cache); set [`--cache-key`](/docs/builder/configuration/#build-cache) to partition RC and production, or pass `--no-cache` to disable restore and save
 3. **Sign** - Certificates and keystores are applied (they exist only in memory during the build)
 4. **Submit** - Signed apps are uploaded directly to App Store Connect or Google Play
 5. **Cleanup** - All build artifacts and credentials are automatically deleted

--- a/apps/docs/src/content/docs/docs/builder/index.mdx
+++ b/apps/docs/src/content/docs/docs/builder/index.mdx
@@ -100,7 +100,7 @@ Capgo offers two complementary features for updating your app. Here's when to us
 When you run the build command:
 
 1. **Upload** - The CLI zips only what's needed (native platform folder + native dependencies) and uploads to secure cloud storage
-2. **Build** - Your app compiles on dedicated infrastructure using Fastlane
+2. **Build** - Your app compiles on dedicated infrastructure using Fastlane. Repeat builds restore a per-app compilation cache by default; use [`--cache-key`](/docs/builder/configuration/#build-cache) to keep RC and production caches separate
 3. **Sign** - Certificates and keystores are applied (they exist only in memory during the build)
 4. **Submit** - Signed apps are uploaded directly to App Store Connect or Google Play
 5. **Cleanup** - All build artifacts and credentials are automatically deleted

--- a/apps/docs/src/content/docs/docs/builder/troubleshooting.mdx
+++ b/apps/docs/src/content/docs/docs/builder/troubleshooting.mdx
@@ -432,7 +432,7 @@ Very large projects may hit the build-time limit (see [Known Limitations](#known
 - Android AAB missing or wrong after switching RC vs production credentials or `--android-flavor`
 - Build finishes suspiciously fast right after changing signing config or product flavor
 
-**Cause:** Capgo restores the **per-app build cache** by default. If RC and production share the same app ID, a restore can reuse compiled output from the previous environment.
+**Cause:** Capgo restores the **per-app build cache** by default (omit `cache_key` for the shared general cache). If RC and production share the same app ID without separate keys, a restore can reuse compiled output from the previous environment.
 
 **Solutions:**
 

--- a/apps/docs/src/content/docs/docs/builder/troubleshooting.mdx
+++ b/apps/docs/src/content/docs/docs/builder/troubleshooting.mdx
@@ -425,6 +425,41 @@ Very large projects may hit the build-time limit (see [Known Limitations](#known
    - Check Play Console → Testing → Internal testing
    - Processing may take a few minutes
 
+### Build succeeded but artifact is wrong after an environment switch
+
+**Symptoms:**
+- Build status is `success` but the IPA/AAB/APK does not match the branch or flavor you just built
+- Android AAB missing or wrong after switching RC vs production credentials or `--android-flavor`
+- Build finishes suspiciously fast right after changing signing config or product flavor
+
+**Cause:** Capgo restores the **per-app build cache** by default. If RC and production share the same app ID, a restore can reuse compiled output from the previous environment.
+
+**Solutions:**
+
+1. **Use a cache key per environment** (recommended for ongoing RC/PROD pipelines):
+
+   ```bash
+   # Production
+   bunx @capgo/cli@latest build request com.example.app --platform android \
+     --cache-key=prod \
+     --android-flavor production
+
+   # Staging / RC
+   bunx @capgo/cli@latest build request com.example.app --platform android \
+     --cache-key=staging \
+     --android-flavor staging
+   ```
+
+2. **Force one clean build** when debugging:
+
+   ```bash
+   bunx @capgo/cli@latest build request com.example.app --platform android --no-cache
+   ```
+
+3. **In API or webhook integrations**, pass `cache_key` (for example `"prod"`) or set `cache_enabled: false` for a single clean run.
+
+See [Build cache](/docs/builder/configuration/#build-cache) for the full option reference.
+
 ## CI/CD Specific Issues
 
 ### GitHub Actions: "Command not found"
@@ -527,6 +562,7 @@ See the full catalog: [Prescan checks](/docs/builder/prescan/).
 ## Additional Resources
 
 - [Getting Started](/docs/builder/getting-started/) - Initial setup guide
+- [Configuration Options](/docs/builder/configuration/) - CLI flags including [`--cache-key`](/docs/builder/configuration/#build-cache) and `--no-cache`
 - [iOS Builds](/docs/builder/ios/) - iOS-specific configuration
 - [Android Builds](/docs/builder/android/) - Android-specific configuration
 - [Prescan checks](/docs/builder/prescan/) - Full list of pre-build checks and ignore flags

--- a/apps/docs/src/content/docs/docs/cli/reference/build.mdx
+++ b/apps/docs/src/content/docs/docs/cli/reference/build.mdx
@@ -135,6 +135,8 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--no-output-upload** | <code>boolean</code> | Override output upload behavior for this build only (disable). Precedence: CLI > env > saved credentials |
 | **--output-retention** | <code>string</code> | Override output link TTL for this build only (1h to 7d). Examples: 1h, 6h, 2d. Precedence: CLI > env > saved credentials |
 | **--output-record** | <code>string</code> | After a successful build, write a JSON record (jobId, status, outputUrl, qrCodeAscii, qrCodePngPath, finishedAt) to a path. A PNG QR code is also written next to that path with the `.qr.png` suffix. Read fields back with `build last-output`. |
+| **--no-cache** | <code>boolean</code> | Skip build cache restore **and** do not save a new cache entry for this build. Build cache is enabled by default per app. |
+| **--cache-key** | <code>string</code> | Partition the build cache by environment, branch, or Android flavor (for example `prod`, `staging`). Omit for one shared default cache per app. |
 | **--no-skip-build-number-bump** | <code>boolean</code> | Override saved credentials to re-enable automatic build number incrementing for this build only. |
 | **--skip-marketing-version-bump** | <code>boolean</code> | Skip automatic marketing version (CFBundleShortVersionString / versionName) bump when the app is already released. |
 | **--sync-ios-version** | <code>boolean</code> | iOS: sync Xcode MARKETING_VERSION from package.json before uploading the project. |
@@ -150,6 +152,8 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--supa-host** | <code>string</code> | Custom Supabase host URL (for self-hosting or Capgo development) |
 | **--supa-anon** | <code>string</code> | Custom Supabase anon key (for self-hosting) |
 | **--verbose** | <code>boolean</code> | Enable verbose output with detailed logging |
+
+**Build cache:** Capgo restores and saves compiled native artifacts (CocoaPods, Gradle, and related outputs) per app by default. Use `--cache-key` to keep RC and production caches separate; use `--no-cache` for a one-off clean build. API integrations can pass `cache_key` or `cache_enabled: false` in the build request payload. See [Build cache](/docs/builder/configuration/#build-cache) and [Troubleshooting: wrong cache restore](/docs/builder/troubleshooting/#build-succeeded-but-artifact-is-wrong-after-an-environment-switch).
 
 ### <a id="build-sync-ios-version"></a> 🔹 **Sync-ios-version**
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents Capgo Builder compilation cache behavior for teams that push RC and production from the same app ID and hit wrong cache restores.

## Changes

- **`configuration.mdx`** — New **Build cache** section: default per-app cache, `--no-cache`, `--cache-key` / API `cache_key`, `cache_enabled`, and copy-paste CLI/API examples.
- **`troubleshooting.mdx`** — New section for success-with-wrong-artifact / missing AAB after environment switches; links to configuration.
- **`index.mdx`** — Brief mention in **How It Works** with link to build cache options.
- **`github-actions.mdx`** — Aside under **Cache dependencies** distinguishing GitHub Actions runner cache vs Capgo cloud build cache.

## Docs-only

No API surface beyond existing `cache_key`, `--cache-key`, `--no-cache`, and `cache_enabled`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebc1ea8f-04a1-5226-b656-bd43b07c03b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebc1ea8f-04a1-5226-b656-bd43b07c03b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/website/pr/1019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791546662&installation_model_id=430928&pr_number=1019&repository=Cap-go%2Fwebsite&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fwebsite%2Fpull%2F1019&signature=40c7b7c3639a42ae5dcf7fc56f7cfeedfe436553925e0e9720f97e7723d39191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/website/pull/1019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documented default per-app caching for compiled native build artifacts.
  - Added guidance for controlling cache behavior with `--cache-key` and `--no-cache`, including API and webhook configuration.
  - Clarified the difference between GitHub Actions dependency caching and cloud build caching.
  - Added troubleshooting guidance for incorrect artifacts after environment switches.
  - Added examples for CLI and API build requests and linked related configuration and troubleshooting resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->